### PR TITLE
Document the enhancement proposal process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,86 @@
 # Enhancement Proposals
 
-This repository is for proposing enhancements to the Open Sovereign AI Cloud project. It is modeled after the [OpenShift Enhancement Proposals] repository.
+This repository is for proposing enhancements to the Open Sovereign AI Cloud (O-SAC) project. It is modeled after the [OpenShift Enhancement Proposals] repository. It provides a rally point to discuss, debate, and reach consensus for how O-SAC enhancements are introduced. The O-SAC solution is built on top of multiple projects, including both existing third party projects and code produced de novo for O-SAC. Given the breadth of the projects and repositories, it is useful to have a centralized place to describe enhancements via an actionable design proposal.
+
+Enhancements may take multiple releases to ultimately complete and thus provide the basis of a roadmap. Enhancements may be filed from anyone in the community, but require consensus from domain specific project maintainers in order to implement and accept into the release.
 
 [openshift enhancement proposals]: https://github.com/openshift/enhancements
 
+## Is my proposed change an enhancement?
+
+A rough heuristic for an enhancement is anything that:
+
+- includes addition or removal of significant capabilities
+- impacts upgrade/downgrade
+- needs significant effort to complete
+- requires consensus/code across multiple domains/repositories
+- proposes adding a new user-facing component
+- has phases of maturity (Dev Preview, Tech Preview, GA)
+- demands formal documentation to utilize
+
+It is unlikely to require an enhancement if it:
+
+- fixes a bug
+- adds more testing
+- internally refactors a code or component only visible to that components domain
+- minimal impact to distribution as a whole
+
+If you are not sure if the proposed work requires an enhancement, file an issue and ask!
+
+## How do I create an enhancement proposal?
+
+To create an enhancement proposal:
+
+1. Create a new directory inside the `enhancements` directory:
+
+    ```sh
+    mkdir enhancements/my-nifty-feature
+    ```
+
+2. Copy `guidelines/enhancement_template.md` to `README.md` in your new directory:
+
+    ```sh
+    cp guidelines/enhancement_template.md enhancements/my-nitfy-feature/README.md
+    ```
+
+3. Edit `enhancements/my-nitfy-feature/README.md`, following the embedded instructions. If a section does not apply to your proposal, mark it `N/A` rather than removing it.
+
+4. If your proposal requires additional assets -- images, sample configuration files, etc -- include them in the same directory as the `README.md`.
+
+5. Create a pull request with your changes against the main branch of the [enhancement proposals] repository.
+
+6. Select at least three reviewers for your pull request.
+
+## How are enhancement proposals reviewed and approved?
+
+The author of an enhancement is responsible for managing it through the review and approval process, including soliciting feedback on the pull request and in meetings, if necessary.
+
+The set of reviewers for an enhancement proposal can be anyone that has an interest in this work or the expertise to provide a useful input/assessment. At a minimum, the reviewers must include a representative of any team that will need to do work for this proposal, or whose team will own/support the resulting implementation. Be mindful of the workload of reviewers, however, and the challenge of finding consensus as the group of reviewers grows larger. Clearly indicating what aspect of the proposal you expect each reviewer to be concerned with will allow them to focus their reviews.
+
+An enhancement proposal is formally accepted when reviewers have reach consensus on the proposal and it has been merged into the main branch of the repository.
+
+Approval of an enhancement proposal does not guarantee implementation. Developers have existing commitments that may take priority over some (or all) enhancement proposals.
+
+## How Can an Author Help Speed Up the Review Process?
+
+Enhancements should have agreement from all stakeholders prior to being approved and merged. Reviews are not time-boxed. If it is not possible to attract the attention of enough of the right maintainers to act as reviewers, that is a signal that the project's rate of change is maxed out. With that said, there are a few things that authors can do to help keep the conversation moving along:
+
+1. Respond to comments quickly, so that a reviewer can tell you are engaged.
+
+2. Push update patches, rather than force-pushing a replacement, to make it easier for reviewers to see what you have changed. Use descriptive commit messages on those updates, or plan to squash the commits when the pull request merges.
+
+3. If the conversation otherwise seems stuck, pinging reviewers on Slack can be used to remind them to look at updates. It's generally appropriate to give people at least a business day or two to respond in the GitHub thread first, before reaching out to them directly on Slack, so that they can manage their work queue and disruptions.
+
+## What is the lifecycle of an enhancement proposal?
+
+An enhancement begins life as a pull request against the O-SAC [enhancement proposals] repository.
+
+[enhancement proposals]: https://github.com/innabox/enhancement-proposals/
+
+The pull request is reviewed by the core development team and other interested members of the community.
+
+An enhancement proposal is accepted when the pull request has been merged into the main branch of the enhancement proposals repository. Ideally pull requests with enhancement proposals will be merged before significant coding work begins, since this avoids having to rework the implementation if the design changes as well as arguing in favor of accepting a design simply because it is already implemented.
+
+After an enhancement proposal has been accepted and the implementation work is substantially complete, it may be necessary to update the design document in the O-SAC [docs] repository.
+
+[docs]: https://github.com/innabox/docs/

--- a/guidelines/enhancement_template.md
+++ b/guidelines/enhancement_template.md
@@ -2,28 +2,22 @@
 title: neat-enhancement-idea
 authors:
   - TBD
-reviewers: # Include a comment about what domain expertise a reviewer is expected to bring and what area of the enhancement you expect them to focus on. For example: - "@networkguru, for networking aspects, please look at IP bootstrapping aspect"
-  - TBD
-approvers: # A single approver is preferred, the role of the approver is to raise important questions, help ensure the enhancement receives reviews from all applicable areas/SMEs, and determine when consensus is achieved such that the EP can move forward to implementation.  Having multiple approvers makes it difficult to determine who is responsible for the actual approval.
-  - TBD
-api-approvers: # In case of new or modified APIs or API extensions (CRDs, aggregated apiservers, webhooks, finalizers). If there is no API change, use "None"
-  - TBD
 creation-date: yyyy-mm-dd
 last-updated: yyyy-mm-dd
-tracking-link: # link to the tracking ticket (for example: Jira Feature or Epic ticket) that corresponds to this enhancement
+tracking-link: # link to the tracking ticket (for example: Github issue) that corresponds to this enhancement
   - TBD
 see-also:
-  - "/enhancements/this-other-neat-thing.md"
+  - "/enhancements/this-other-neat-thing"
 replaces:
-  - "/enhancements/that-less-than-great-idea.md"
+  - "/enhancements/that-less-than-great-idea"
 superseded-by:
-  - "/enhancements/our-past-effort.md"
+  - "/enhancements/our-past-effort"
 ---
 
 To get started with this template:
-1. **Pick a domain.** Find the appropriate domain to discuss your enhancement.
+1. **Create a directory.** Create the directory for your enhancement proposal.
 1. **Make a copy of this template.** Copy this template into the directory for
-   the domain.
+   the proposal as `README.md`.
 1. **Fill out the metadata at the top.** The embedded YAML document is
    checked by the linter.
 1. **Fill out the "overview" sections.** This includes the Summary and
@@ -205,33 +199,6 @@ and finalizers, i.e. those mechanisms that change the OCP API surface and behavi
 Fill in the operational impact of these API Extensions in the "Operational Aspects
 of API Extensions" section.
 
-### Topology Considerations
-
-#### Hypershift / Hosted Control Planes
-
-Are there any unique considerations for making this change work with
-Hypershift?
-
-See https://github.com/openshift/enhancements/blob/e044f84e9b2bafa600e6c24e35d226463c2308a5/enhancements/multi-arch/heterogeneous-architecture-clusters.md?plain=1#L282
-
-How does it affect any of the components running in the
-management cluster? How does it affect any components running split
-between the management cluster and guest cluster?
-
-#### Standalone Clusters
-
-Is the change relevant for standalone clusters?
-
-#### Single-node Deployments or MicroShift
-
-How does this proposal affect the resource consumption of a
-single-node OpenShift deployment (SNO), CPU and memory?
-
-How does this proposal affect MicroShift? For example, if the proposal
-adds configuration options through API resources, should any of those
-behaviors also be exposed to MicroShift admins through the
-configuration file for MicroShift?
-
 ### Implementation Details/Notes/Constraints
 
 What are some important details that didn't come across above in the
@@ -327,28 +294,6 @@ please be sure to include in the graduation criteria.**
 **Examples**: These are generalized examples to consider, in addition
 to the aforementioned [maturity levels][maturity-levels].
 
-### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-- Enumerate service level indicators (SLIs), expose SLIs as metrics
-- Write symptoms-based alerts for the component(s)
-
-### Tech Preview -> GA
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-- Backhaul SLI telemetry
-- Document SLOs for the component
-- Conduct load testing
-- User facing documentation created in [openshift-docs](https://github.com/openshift/openshift-docs/)
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
-
 ### Removing a deprecated feature
 
 - Announce deprecation and support policy of the existing feature
@@ -408,42 +353,6 @@ enhancement:
   when this feature is used?
 - Will any other components on the node change? For example, changes to CSI, CRI
   or CNI may require updating that component before the kubelet.
-
-## Operational Aspects of API Extensions
-
-Describe the impact of API extensions (mentioned in the proposal section, i.e. CRDs,
-admission and conversion webhooks, aggregated API servers, finalizers) here in detail,
-especially how they impact the OCP system architecture and operational aspects.
-
-- For conversion/admission webhooks and aggregated apiservers: what are the SLIs (Service Level
-  Indicators) an administrator or support can use to determine the health of the API extensions
-
-  Examples (metrics, alerts, operator conditions)
-  - authentication-operator condition `APIServerDegraded=False`
-  - authentication-operator condition `APIServerAvailable=True`
-  - openshift-authentication/oauth-apiserver deployment and pods health
-
-- What impact do these API extensions have on existing SLIs (e.g. scalability, API throughput,
-  API availability)
-
-  Examples:
-  - Adds 1s to every pod update in the system, slowing down pod scheduling by 5s on average.
-  - Fails creation of ConfigMap in the system when the webhook is not available.
-  - Adds a dependency on the SDN service network for all resources, risking API availability in case
-    of SDN issues.
-  - Expected use-cases require less than 1000 instances of the CRD, not impacting
-    general API throughput.
-
-- How is the impact on existing SLIs to be measured and when (e.g. every release by QE, or
-  automatically in CI) and by whom (e.g. perf team; name the responsible person and let them review
-  this enhancement)
-
-- Describe the possible failure modes of the API extensions.
-- Describe how a failure or behaviour of the extension will impact the overall cluster health
-  (e.g. which kube-controller-manager functionality will stop working), especially regarding
-  stability, availability, performance and security.
-- Describe which OCP teams are likely to be called upon in case of escalation with one of the failure modes
-  and add them as reviewers to this enhancement.
 
 ## Support Procedures
 


### PR DESCRIPTION
Update the top-level README with information about the enhancement proposal
process and add some additional supporting documentation. Much of this is
copied from the OpenShift enhancements repository [1], but has been
simplified somewhat for our use.

[1]: https://github.com/openshift/enhancements
