### PR TITLE
MGMT-22638: ComputeInstance Phase and Condition Updates

### DIFF
--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -62,78 +62,42 @@ This change enables users to understand VM power state (running, stopped, paused
 
 ## Motivation
 
-This section is for explicitly listing the motivation, goals and non-goals of
-this proposal. Describe why the change is important and the benefits to users.
+As VMaaS matures to support full VM lifecycle operations, users need clear visibility into VM power state and operational status. The current phase model does not distinguish between a running VM and a stopped VM, and conditions overlap with phases rather than providing independent health information. This enhancement addresses these gaps to provide the operational visibility expected from a modern cloud platform.
 
 ### User Stories
 
-Detail the things that people will be able to do if this is implemented and
-what goal that allows them to achieve. In each story, explain who the actor
-is based on their role, explain what they want to do with the system,
-and explain the underlying goal they have, what it is they are going to
-achieve with this new feature.
+**For Tenants:**
 
-Use the standard three part formula:
+* As a tenant, I want to see if my VM is running, stopped, or paused, so that I understand its current power state
+* As a tenant, I want to see when my VM is starting or stopping, so that I know an operation is in progress
+* As a tenant, I want to see clear health indicators for my VM, so that I can identify issues without interpreting phase values
+* As a tenant, I want to see when my VM is being deleted, so that I can track the deletion progress
 
-> "As a _role_, I want to _take some action_ so that I can _accomplish a
-goal_."
+**For Cloud Providers:**
 
-Make the change feel real for users, without getting bogged down in
-implementation details.
+* As a cloud provider, I want to see clear VM power states for tenant VMs, so that I can provide effective support and troubleshooting
+* As a cloud provider, I want VM phases that align with industry standards, so that I can build monitoring dashboards with familiar terminology
 
-Here are some example user stories to show what they might look like:
+**For Developers:**
 
-* As an OpenShift engineer, I want to write an enhancement, so that I
-  can get feedback on my design and build consensus about the approach
-  to take before starting the implementation.
-* As an OpenShift engineer, I want to understand the rationale behind
-  a particular feature's design and alternatives considered, so I can
-  work on a new enhancement in that problem space knowing the history
-  of the current design better.
-* As a product manager, I want to review this enhancement proposal, so
-  that I can make sure the customer requirements are met by the
-  design.
-* As an administrator, I want a one-click OpenShift installer, so that
-  I can easily set up a new cluster without having to follow a long
-  set of operations.
-
-In each example, the persona's goal is clear, and the goal is clearly provided
-by the capability being described.
-The engineer wants feedback on their enhancement from their peers, and writing
-an enhancement allows for that feedback.
-The product manager wants to make sure that their customer requirements are fulfilled,
-reviewing the enhancement allows them to check that.
-The administrator wants to set up his OpenShift cluster as easily as possible, and
-reducing the install to a single click simplifies that process.
-
-Here are some real examples from previous enhancements:
-* [As a member of OpenShift concerned with the release process (TRT, dev, staff engineer, maybe even PM),
-I want to opt in to pre-release features so that I can run periodic testing in CI and obtain a signal of
-feature quality.](https://github.com/openshift/enhancements/blob/master/enhancements/installer/feature-sets.md#user-stories)
-* [As a cloud-provider affiliated engineer / platform integrator / RH partner
-I want to have a mechanism to signal OpenShift's built-in operators about additional
-cloud-provider specific components so that I can inject my own platform-specific controllers into OpenShift
-to improve the integration between OpenShift and my cloud provider.](https://github.com/openshift/enhancements/blob/master/enhancements/cloud-integration/infrastructure-external-platform-type.md#user-stories)
-* [As an OpenShift cluster administrator, I want to add worker nodes to my
-existing single control-plane node cluster, so that it'll be able to meet
-growing computation demands.](https://github.com/openshift/enhancements/blob/master/enhancements/single-node/single-node-openshift-with-workers.md#user-stories)
-
-Include a story on how this proposal will be operationalized:
-life-cycled, monitored and remediated at scale.
+* As a developer integrating with the OSAC API, I want consistent terminology (RESTART vs REBOOT), so that I don't have to handle inconsistencies between public and private APIs
+* As a developer, I want a phase/condition model where conditions are orthogonal to phases, so that new conditions can be added in future releases without breaking my existing integrations
+* As a developer, I want a well-defined phase model that can accommodate future VM operations (e.g., live migration), so that the API can evolve to support new capabilities
 
 ### Goals
 
-Summarize the specific goals of the proposal. How will we know that
-this has succeeded?  A good goal describes something a user wants from
-their perspective, and does not include the implementation details
-from the proposal.
+* Represent VM power state clearly - Users can see if a VM is Running, Stopped, or Paused
+* Expose transitional states - Users can see when operations are in progress (Starting, Stopping, Pausing, Deleting)
+* Align with industry standards - Phase values match what users expect from AWS, GCE, and KubeVirt
+* Make conditions orthogonal to phases - Conditions represent health/status attributes, not lifecycle state
+* Fix API inconsistencies - Unify RESTART/REBOOT terminology between public and private APIs
+* Expose DELETING in API - The K8s operator's Deleting phase should be visible in the public API
 
 ### Non-Goals
 
-What is out of scope for this proposal? Listing non-goals helps to
-focus discussion and make progress. Highlight anything that is being
-deferred to a later phase of implementation that may call for its own
-enhancement.
+* Additional conditions - Conditions such as NetworkReady and RestartRequired will be addressed in future enhancements as their dependencies (networking design, configuration change detection) are not yet finalized
+* New VM operations - This enhancement is about status representation, not adding pause/resume/stop operations themselves
+* Hibernate (suspend to disk) - Only in-memory pause is supported by KubeVirt; hibernate is out of scope
 
 ## Proposal
 

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -36,7 +36,7 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 
 * As a tenant, I want to see if my VM is running, stopped, or paused, so that I understand its current power state
 * As a tenant, I want to see when my VM is starting or stopping, so that I know an operation is in progress
-* As a tenant, I want to see clear health indicators for my VM, so that I can identify issues without interpreting phase values
+* As a tenant, I want to see status conditions for my VM, so that I can understand its readiness and configuration state
 * As a tenant, I want to see when my VM is being deleted, so that I can track deletion progress and identify if resource removal fails
 * As a tenant, I want to know when my VM requires a restart for configuration changes to take effect, so that I can initiate a reboot when convenient
 
@@ -218,14 +218,24 @@ The controller determines the ComputeInstance phase based on the KubeVirt `Virtu
 
 **Available Condition Logic**
 
-The `Available` condition has a simple rule: it is `True` only when the VM is in the `Running` phase.
+The `Available` condition is set to `True` when `VirtualMachine.Status.Ready = true`. The `VirtualMachine.Status.Ready` field ([VirtualMachineStatus Ready](https://github.com/kubevirt/api/blob/fe5ef708bb5c1ed6ef155c4ad9ec1e7cfcb99500/core/v1/types.go#L2074-L2075)) is derived from the `VirtualMachineInstance.Conditions[Ready]` condition ([VirtualMachineInstanceConditionType Ready](https://github.com/kubevirt/api/blob/fe5ef708bb5c1ed6ef155c4ad9ec1e7cfcb99500/core/v1/types.go#L698-L700)). KubeVirt's virt-controller syncs VMI conditions to the VM object ([see vm.go](https://github.com/kubevirt/kubevirt/pull/6575)), and the VMI Ready condition is synced from the virt-launcher pod's Ready condition.
 
-| Phase | Available |
-|-------|-----------|
-| `Running` | True |
-| All other phases | False |
+| VirtualMachine.Status.Ready | Available |
+|----------------------------|-----------|
+| `true` | True |
+| `false` | False |
 
-This straightforward logic reflects that a VM is only "available for use" when it is actively running.
+**Timeline:** `VirtualMachine.Status.Ready` becomes `true` when `VirtualMachineInstance.Conditions[Ready] = True`, which is synced from the virt-launcher pod's Ready condition. The complete flow is:
+
+1. **QEMU process starts** → `VirtualMachineInstance.Phase` = `Running` ([VirtualMachineInstancePhase Running](https://github.com/kubevirt/api/blob/fe5ef708bb5c1ed6ef155c4ad9ec1e7cfcb99500/core/v1/types.go#L1104-L1105))
+2. **virt-launcher pod becomes ready** → Pod `Ready` condition = `True`
+3. **Pod Ready condition syncs to VMI** → `VirtualMachineInstance.Conditions[Ready]` = `True` ([VirtualMachineInstanceConditionType Ready](https://github.com/kubevirt/api/blob/fe5ef708bb5c1ed6ef155c4ad9ec1e7cfcb99500/core/v1/types.go#L698-L700)) - [synced by virt-handler](https://github.com/kubevirt/kubevirt/pull/1921)
+4. **VMI Ready condition syncs to VM** → `VirtualMachine.Status.Ready` = `true` ([VirtualMachineStatus Ready](https://github.com/kubevirt/api/blob/fe5ef708bb5c1ed6ef155c4ad9ec1e7cfcb99500/core/v1/types.go#L2074-L2075)) - [synced by virt-controller](https://github.com/kubevirt/kubevirt/pull/6575)
+5. **ComputeInstance controller observes VM Ready** → `ComputeInstance.Conditions[Available]` = `True`
+
+This means `Available = True` indicates that the VM infrastructure (virt-launcher pod ready, QEMU process running) is operational, but does not verify guest OS boot status.
+
+> **Note:** `Available = True` indicates VM infrastructure readiness but does not guarantee that the guest OS has fully booted or that applications inside the VM are ready to serve traffic.
 
 **RestartRequired Condition Logic**
 
@@ -293,6 +303,10 @@ We could add a `Pausing` phase to mirror the `Stopping` transitional phase.
 ## 5. Open Questions
 
 - **Should we add a Degraded condition?** The existing `DEGRADED` enum value in the API is never set. What signals from KubeVirt would indicate a VM is "degraded" (running but with issues) vs "failed" (not running)? The KubeVirt signals considered (CrashLoopBackOff, ErrorUnschedulable, etc.) mostly indicate failure rather than degradation.
+
+- **Should the Available condition capture whether the guest OS is ready and accessible (e.g., user can SSH into it)?** Currently, `Available = True` when `VirtualMachine.Status.Ready = true`, which indicates VM infrastructure (virt-launcher pod, QEMU process) is ready. This does not verify that the guest OS has booted or that SSH/applications are accessible. Should we redefine `Available` to represent guest-level readiness, or is infrastructure-level readiness the correct semantic?
+
+- **If Available should capture guest OS readiness, which mechanism should we use?** KubeVirt supports readiness probes (TCP socket for SSH access, or guest agent ping for OS responsiveness) that can verify guest-level readiness. The choice impacts operational complexity (VM image requirements) and the accuracy of readiness detection.
 
 ## 6. Test Plan
 

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -1,0 +1,407 @@
+---
+title: neat-enhancement-idea
+authors:
+  - TBD
+creation-date: yyyy-mm-dd
+last-updated: yyyy-mm-dd
+tracking-link: # link to the tracking ticket (for example: Github issue) that corresponds to this enhancement
+  - TBD
+see-also:
+  - "/enhancements/this-other-neat-thing"
+replaces:
+  - "/enhancements/that-less-than-great-idea"
+superseded-by:
+  - "/enhancements/our-past-effort"
+---
+
+To get started with this template:``
+1. **Create a directory.** Create the directory for your enhancement proposal.
+1. **Make a copy of this template.** Copy this template into the directory for
+   the proposal as `README.md`.
+1. **Fill out the metadata at the top.** The embedded YAML document is
+   checked by the linter.
+1. **Fill out the "overview" sections.** This includes the Summary and
+   Motivation sections. These should be easy and explain why the community
+   should desire this enhancement.
+1. **Create a PR.** Assign it to folks with expertise in that domain to help
+   sponsor the process.
+1. **Merge after reaching consensus.** Merge when there is consensus
+   that the design is complete and all reviewer questions have been
+   answered so that work can begin.  Come back and update the document
+   if important details (API field names, workflow, etc.) change
+   during code review.
+1. **Keep all required headers.** If a section does not apply to an
+   enhancement, explain why but do not remove the section. This part
+   of the process is enforced by the linter CI job.
+
+See ../README.md for background behind these instructions.
+
+Start by filling out the header with the metadata for this enhancement.
+
+# Neat Enhancement Idea
+
+This is the title of the enhancement. Keep it simple and descriptive. A good
+title can help communicate what the enhancement is and should be considered as
+part of any review.
+
+The YAML `title` should be lowercased and spaces/punctuation should be
+replaced with `-`.
+
+The `Metadata` section above is intended to support the creation of tooling
+around the enhancement process.
+
+## Summary
+
+The `Summary` section is important for producing high quality
+user-focused documentation such as release notes or a development roadmap. It
+should be possible to collect this information before implementation begins in
+order to avoid requiring implementors to split their attention between writing
+release notes and implementing the feature itself.
+
+Your summary should be one paragraph long. More detail
+should go into the following sections.
+
+## Motivation
+
+This section is for explicitly listing the motivation, goals and non-goals of
+this proposal. Describe why the change is important and the benefits to users.
+
+### User Stories
+
+Detail the things that people will be able to do if this is implemented and
+what goal that allows them to achieve. In each story, explain who the actor
+is based on their role, explain what they want to do with the system,
+and explain the underlying goal they have, what it is they are going to
+achieve with this new feature.
+
+Use the standard three part formula:
+
+> "As a _role_, I want to _take some action_ so that I can _accomplish a
+goal_."
+
+Make the change feel real for users, without getting bogged down in
+implementation details.
+
+Here are some example user stories to show what they might look like:
+
+* As an OpenShift engineer, I want to write an enhancement, so that I
+  can get feedback on my design and build consensus about the approach
+  to take before starting the implementation.
+* As an OpenShift engineer, I want to understand the rationale behind
+  a particular feature's design and alternatives considered, so I can
+  work on a new enhancement in that problem space knowing the history
+  of the current design better.
+* As a product manager, I want to review this enhancement proposal, so
+  that I can make sure the customer requirements are met by the
+  design.
+* As an administrator, I want a one-click OpenShift installer, so that
+  I can easily set up a new cluster without having to follow a long
+  set of operations.
+
+In each example, the persona's goal is clear, and the goal is clearly provided
+by the capability being described.
+The engineer wants feedback on their enhancement from their peers, and writing
+an enhancement allows for that feedback.
+The product manager wants to make sure that their customer requirements are fulfilled,
+reviewing the enhancement allows them to check that.
+The administrator wants to set up his OpenShift cluster as easily as possible, and
+reducing the install to a single click simplifies that process.
+
+Here are some real examples from previous enhancements:
+* [As a member of OpenShift concerned with the release process (TRT, dev, staff engineer, maybe even PM),
+I want to opt in to pre-release features so that I can run periodic testing in CI and obtain a signal of
+feature quality.](https://github.com/openshift/enhancements/blob/master/enhancements/installer/feature-sets.md#user-stories)
+* [As a cloud-provider affiliated engineer / platform integrator / RH partner
+I want to have a mechanism to signal OpenShift's built-in operators about additional
+cloud-provider specific components so that I can inject my own platform-specific controllers into OpenShift
+to improve the integration between OpenShift and my cloud provider.](https://github.com/openshift/enhancements/blob/master/enhancements/cloud-integration/infrastructure-external-platform-type.md#user-stories)
+* [As an OpenShift cluster administrator, I want to add worker nodes to my
+existing single control-plane node cluster, so that it'll be able to meet
+growing computation demands.](https://github.com/openshift/enhancements/blob/master/enhancements/single-node/single-node-openshift-with-workers.md#user-stories)
+
+Include a story on how this proposal will be operationalized:
+life-cycled, monitored and remediated at scale.
+
+### Goals
+
+Summarize the specific goals of the proposal. How will we know that
+this has succeeded?  A good goal describes something a user wants from
+their perspective, and does not include the implementation details
+from the proposal.
+
+### Non-Goals
+
+What is out of scope for this proposal? Listing non-goals helps to
+focus discussion and make progress. Highlight anything that is being
+deferred to a later phase of implementation that may call for its own
+enhancement.
+
+## Proposal
+
+This section should explain what the proposal actually is. Enumerate
+*all* of the proposed changes at a *high level*, including all of the
+components that need to be modified and how they will be
+different. Include the reason for each choice in the design and
+implementation that is proposed here.
+
+To keep this section succinct, document the details like API field
+changes, new images, and other implementation details in the
+**Implementation Details** section and record the reasons for not
+choosing alternatives in the **Alternatives** section at the end of
+the document.
+
+### Workflow Description
+
+Explain how the user will use the feature. Be detailed and explicit.
+Describe all of the actors, their roles, and the APIs or interfaces
+involved. Define a starting state and then list the steps that the
+user would need to go through to trigger the feature described in the
+enhancement. Optionally add a
+[mermaid](https://github.com/mermaid-js/mermaid#readme) sequence
+diagram.
+
+Use sub-sections to explain variations, such as for error handling,
+failure recovery, or alternative outcomes.
+
+For example:
+
+**cluster creator** is a human user responsible for deploying a
+cluster.
+
+**application administrator** is a human user responsible for
+deploying an application in a cluster.
+
+1. The cluster creator sits down at their keyboard...
+2. ...
+3. The cluster creator sees that their cluster is ready to receive
+   applications, and gives the application administrator their
+   credentials.
+
+See
+https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/management-workload-partitioning.md#high-level-end-to-end-workflow
+and https://github.com/openshift/enhancements/blob/master/enhancements/agent-installer/automated-workflow-for-agent-based-installer.md for more detailed examples.
+
+### API Extensions
+
+API Extensions are CRDs, admission and conversion webhooks, aggregated API servers,
+and finalizers, i.e. those mechanisms that change the OCP API surface and behaviour.
+
+- Name the API extensions this enhancement adds or modifies.
+- Does this enhancement modify the behaviour of existing resources, especially those owned
+  by other parties than the authoring team (including upstream resources), and, if yes, how?
+  Please add those other parties as reviewers to the enhancement.
+
+  Examples:
+  - Adds a finalizer to namespaces. Namespace cannot be deleted without our controller running.
+  - Restricts the label format for objects to X.
+  - Defaults field Y on object kind Z.
+
+Fill in the operational impact of these API Extensions in the "Operational Aspects
+of API Extensions" section.
+
+### Implementation Details/Notes/Constraints
+
+What are some important details that didn't come across above in the
+**Proposal**? Go in to as much detail as necessary here. This might be
+a good place to talk about core concepts and how they relate. While it is useful
+to go into the details of the code changes required, it is not necessary to show
+how the code will be rewritten in the enhancement.
+
+### Risks and Mitigations
+
+What are the risks of this proposal and how do we mitigate. Think broadly. For
+example, consider both security and how this will impact the larger OKD
+ecosystem.
+
+How will security be reviewed and by whom?
+
+How will UX be reviewed and by whom?
+
+Consider including folks that also work outside your immediate sub-project.
+
+### Drawbacks
+
+The idea is to find the best form of an argument why this enhancement should
+_not_ be implemented.
+
+What trade-offs (technical/efficiency cost, user experience, flexibility,
+supportability, etc) must be made in order to implement this? What are the reasons
+we might not want to undertake this proposal, and how do we overcome them?
+
+Does this proposal implement a behavior that's new/unique/novel? Is it poorly
+aligned with existing user expectations?  Will it be a significant maintenance
+burden?  Is it likely to be superceded by something else in the near future?
+
+## Alternatives (Not Implemented)
+
+Similar to the `Drawbacks` section the `Alternatives` section is used
+to highlight and record other possible approaches to delivering the
+value proposed by an enhancement, including especially information
+about why the alternative was not selected.
+
+## Open Questions [optional]
+
+This is where to call out areas of the design that require closure before deciding
+to implement the design.  For instance,
+ > 1. This requires exposing previously private resources which contain sensitive
+  information.  Can we do this?
+
+## Test Plan
+
+**Note:** *Section not required until targeted at a release.*
+
+Consider the following in developing a test plan for this enhancement:
+- Will there be e2e and integration tests, in addition to unit tests?
+- How will it be tested in isolation vs with other components?
+- What additional testing is necessary to support managed OpenShift service-based offerings?
+
+No need to outline all of the test cases, just the general strategy. Anything
+that would count as tricky in the implementation and anything particularly
+challenging to test should be called out.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations).
+
+## Graduation Criteria
+
+**Note:** *Section not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, or as something else. Initial proposal
+should keep this high-level with a focus on what signals will be looked at to
+determine graduation.
+
+Consider the following in developing the graduation criteria for this
+enhancement:
+
+- Maturity levels
+  - [`alpha`, `beta`, `stable` in upstream Kubernetes][maturity-levels]
+  - `Dev Preview`, `Tech Preview`, `GA` in OpenShift
+- [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning),
+or by redefining what graduation means.
+
+In general, we try to use the same stages (alpha, beta, GA), regardless how the functionality is accessed.
+
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+**If this is a user facing change requiring new or updated documentation in [openshift-docs](https://github.com/openshift/openshift-docs/),
+please be sure to include in the graduation criteria.**
+
+**Examples**: These are generalized examples to consider, in addition
+to the aforementioned [maturity levels][maturity-levels].
+
+### Removing a deprecated feature
+
+- Announce deprecation and support policy of the existing feature
+- Deprecate the feature
+
+## Upgrade / Downgrade Strategy
+
+If applicable, how will the component be upgraded and downgraded? Make sure this
+is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade in order to keep previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade in order to make use of the enhancement?
+
+Upgrade expectations:
+- Each component should remain available for user requests and
+  workloads during upgrades. Ensure the components leverage best practices in handling [voluntary
+  disruption](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/). Any exception to
+  this should be identified and discussed here.
+- Micro version upgrades - users should be able to skip forward versions within a
+  minor release stream without being required to pass through intermediate
+  versions - i.e. `x.y.N->x.y.N+2` should work without requiring `x.y.N->x.y.N+1`
+  as an intermediate step.
+- Minor version upgrades - you only need to support `x.N->x.N+1` upgrade
+  steps. So, for example, it is acceptable to require a user running 4.3 to
+  upgrade to 4.5 with a `4.3->4.4` step followed by a `4.4->4.5` step.
+- While an upgrade is in progress, new component versions should
+  continue to operate correctly in concert with older component
+  versions (aka "version skew"). For example, if a node is down, and
+  an operator is rolling out a daemonset, the old and new daemonset
+  pods must continue to work correctly even while the cluster remains
+  in this partially upgraded state for some time.
+
+Downgrade expectations:
+- If an `N->N+1` upgrade fails mid-way through, or if the `N+1` cluster is
+  misbehaving, it should be possible for the user to rollback to `N`. It is
+  acceptable to require some documented manual steps in order to fully restore
+  the downgraded cluster to its previous state. Examples of acceptable steps
+  include:
+  - Deleting any CVO-managed resources added by the new version. The
+    CVO does not currently delete resources that no longer exist in
+    the target version.
+
+## Version Skew Strategy
+
+How will the component handle version skew with other components?
+What are the guarantees? Make sure this is in the test plan.
+
+Consider the following in developing a version skew strategy for this
+enhancement:
+- During an upgrade, we will always have skew among components, how will this impact your work?
+- Does this enhancement involve coordinating behavior in the control plane and
+  in the kubelet? How does an n-2 kubelet without this feature available behave
+  when this feature is used?
+- Will any other components on the node change? For example, changes to CSI, CRI
+  or CNI may require updating that component before the kubelet.
+
+## Support Procedures
+
+Describe how to
+- detect the failure modes in a support situation, describe possible symptoms (events, metrics,
+  alerts, which log output in which component)
+
+  Examples:
+  - If the webhook is not running, kube-apiserver logs will show errors like "failed to call admission webhook xyz".
+  - Operator X will degrade with message "Failed to launch webhook server" and reason "WehhookServerFailed".
+  - The metric `webhook_admission_duration_seconds("openpolicyagent-admission", "mutating", "put", "false")`
+    will show >1s latency and alert `WebhookAdmissionLatencyHigh` will fire.
+
+- disable the API extension (e.g. remove MutatingWebhookConfiguration `xyz`, remove APIService `foo`)
+
+  - What consequences does it have on the cluster health?
+
+    Examples:
+    - Garbage collection in kube-controller-manager will stop working.
+    - Quota will be wrongly computed.
+    - Disabling/removing the CRD is not possible without removing the CR instances. Customer will lose data.
+      Disabling the conversion webhook will break garbage collection.
+
+  - What consequences does it have on existing, running workloads?
+
+    Examples:
+    - New namespaces won't get the finalizer "xyz" and hence might leak resource X
+      when deleted.
+    - SDN pod-to-pod routing will stop updating, potentially breaking pod-to-pod
+      communication after some minutes.
+
+  - What consequences does it have for newly created workloads?
+
+    Examples:
+    - New pods in namespace with Istio support will not get sidecars injected, breaking
+      their networking.
+
+- Does functionality fail gracefully and will work resume when re-enabled without risking
+  consistency?
+
+  Examples:
+  - The mutating admission webhook "xyz" has FailPolicy=Ignore and hence
+    will not block the creation or updates on objects when it fails. When the
+    webhook comes back online, there is a controller reconciling all objects, applying
+    labels that were not applied during admission webhook downtime.
+  - Namespaces deletion will not delete all objects in etcd, leading to zombie
+    objects when another namespace with the same name is created.
+
+## Infrastructure Needed [optional]
+
+Use this section if you need things from the project. Examples include a new
+subproject, repos requested, github details, and/or testing infrastructure.

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -52,14 +52,13 @@ around the enhancement process.
 
 ## Summary
 
-The `Summary` section is important for producing high quality
-user-focused documentation such as release notes or a development roadmap. It
-should be possible to collect this information before implementation begins in
-order to avoid requiring implementors to split their attention between writing
-release notes and implementing the feature itself.
+This enhancement proposes a cleanup and expansion of the `ComputeInstancePhaseType` and `ComputeInstanceConditionType` values for the OSAC VMaaS offering.
 
-Your summary should be one paragraph long. More detail
-should go into the following sections.
+The current 4-phase model (`Progressing`, `Ready`, `Failed`, `Deleting`) was designed for initial provisioning workflows. As VMaaS matures to support full lifecycle operations (stop, start, pause, resume), the phase model needs to expand to represent these power states. Additionally, the current conditions overlap with phases rather than providing orthogonal health information, and there are inconsistencies between the public and private APIs that need to be addressed.
+
+The redesign expands from 4 phases to 9 phases to properly represent the full VM lifecycle, aligning with industry standards from AWS, GCE, and KubeVirt. Conditions are redesigned to be orthogonal health indicators that complement, rather than duplicate, the lifecycle phase.
+
+This change enables users to understand VM power state (running, stopped, paused), see transitional progress (starting, stopping), and receive clear health signals through conditions - providing the operational visibility expected from a modern cloud platform.
 
 ## Motivation
 

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -276,28 +276,27 @@ Since the product is in development with no external clients, old enum values (`
 
 ### Risks and Mitigations
 
-What are the risks of this proposal and how do we mitigate. Think broadly. For
-example, consider both security and how this will impact the larger OKD
-ecosystem.
-
-How will security be reviewed and by whom?
-
-How will UX be reviewed and by whom?
-
-Consider including folks that also work outside your immediate sub-project.
+| Risk | Mitigation |
+|------|------------|
+| **Breaking changes for internal consumers** - UI components, scripts, or any code tied to current phase/condition values will break when values change | Coordinate with internal teams before rollout; update all consumers in the same release |
+| **Developer scripts tied to old values** - Developers may have local scripts or automation that check for `Progressing`, `Ready`, or `Failed` conditions | Communicate changes clearly in release notes; provide migration guidance |
+| **Incorrect phase mapping from KubeVirt** - Controller could incorrectly map KubeVirt states, showing wrong phase values | Comprehensive unit tests for phase determination logic; manual testing with real VMs in dev environment |
+| **Edge cases in KubeVirt state transitions** - KubeVirt may have transitional states or error conditions not fully mapped | Review KubeVirt documentation; manual testing with various VM scenarios (create, stop, start, pause, resume, delete, error conditions) |
+| **Condition logic complexity** - Determining when `Available` and `Degraded` should be True/False adds controller complexity | Document condition semantics clearly; use table-driven logic in controller for maintainability |
 
 ### Drawbacks
 
-The idea is to find the best form of an argument why this enhancement should
-_not_ be implemented.
+**Migration effort for internal consumers**
 
-What trade-offs (technical/efficiency cost, user experience, flexibility,
-supportability, etc) must be made in order to implement this? What are the reasons
-we might not want to undertake this proposal, and how do we overcome them?
+Any UI components, scripts, or automation that reference current phase/condition values will need to be updated. Since the product is in development with no external clients, this is a one-time internal effort.
 
-Does this proposal implement a behavior that's new/unique/novel? Is it poorly
-aligned with existing user expectations?  Will it be a significant maintenance
-burden?  Is it likely to be superceded by something else in the near future?
+**Increased state complexity**
+
+Expanding from 4 phases to 8 phases means more states to reason about in controllers, tests, and documentation. However, the additional granularity aligns with industry standards and provides the operational visibility users expect.
+
+**No transitional Pausing phase**
+
+Unlike Stopping, we cannot show a "Pausing" transitional phase because KubeVirt does not expose this state - pause is instantaneous. GCE is the only major cloud provider that exposes a `SUSPENDING` transitional state; AWS and KubeVirt transition directly to the paused/stopped state. This minor inconsistency reflects the underlying platform behavior accurately.
 
 ## Alternatives (Not Implemented)
 

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -104,19 +104,19 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 This enhancement modifies the `ComputeInstance` status model across three layers:
 
 **1. OSAC Operator (Kubernetes CRD)**
-- Expand `ComputeInstancePhaseType` from 4 phases to 9 phases
-- Redesign `ComputeInstanceConditionType` to be orthogonal to phases
+- Expand `ComputeInstancePhaseType` from 4 phases to 8 phases
+- Refactor `ComputeInstanceConditionType` to be orthogonal to phases
 
 **2. Fulfillment API (Public protobuf)**
 - Add corresponding `ComputeInstanceState` enum values
 - Update `ComputeInstanceConditionType` enum to match the orthogonal design
-- Deprecate old values (`PROGRESSING`, `READY`) while maintaining backward compatibility
+- Remove old values (`PROGRESSING`, `READY`) since there are no external clients
 
 **3. Fulfillment Service (Private protobuf)**
 - Mirror public API changes
 - Fix RESTART/REBOOT terminology inconsistency
 
-**Proposed Phases (9):**
+**Proposed Phases (8):**
 
 | Phase | Description |
 |-------|-------------|
@@ -125,7 +125,6 @@ This enhancement modifies the `ComputeInstance` status model across three layers
 | `Running` | VM is running and operational |
 | `Stopping` | VM is powering off, guest OS shutting down |
 | `Stopped` | VM is powered off, resources retained |
-| `Pausing` | VM memory state is being saved |
 | `Paused` | VM is paused, memory preserved, no CPU allocated |
 | `Deleting` | VM is being permanently deleted |
 | `Failed` | VM encountered an error |
@@ -154,7 +153,7 @@ A tenant creates a ComputeInstance and observes its lifecycle through phases:
 3. **Boot completes**: VM is operational → Phase: `Running`
 4. **Stop requested**: Tenant stops the VM → Phase: `Stopping` → `Stopped`
 5. **Start requested**: Tenant starts the VM → Phase: `Starting` → `Running`
-6. **Pause requested**: Tenant pauses the VM → Phase: `Pausing` → `Paused`
+6. **Pause requested**: Tenant pauses the VM → Phase: `Paused`
 7. **Resume requested**: Tenant resumes the VM → Phase: `Running`
 8. **Delete requested**: Tenant deletes the VM → Phase: `Deleting` → (resource removed)
 
@@ -169,47 +168,111 @@ Restart is not a separate phase. When a tenant restarts a VM:
 **State Transition Diagram**
 
 ```
-[Create] → Pending → Starting → Running
-                                  │
-                ┌─────────────────┼─────────────────┐
-                ↓                 ↓                 ↓
-            Stopping          Pausing           Deleting
-                ↓                 ↓                 ↓
-            Stopped            Paused          (removed)
-                │                 │
-                └──→ Starting ←───┘
-                        ↓
-                     Running
+                              ┌─────────────────────────────────────────┐
+                              │                (start)                  │
+                              ▼                                         │
+[Create] ──► Pending ──► Starting ──► Running ──► Stopping ──► Stopped ─┘
+                                          │
+                                          │ (pause)
+                                          ▼
+                                       Paused
+                                          │
+                                          │ (resume)
+                                          ▼
+                                       Running
 
-[Any state] → Failed (on error)
-[Any state] → Deleting → (removed)
+[Any state] ──► Failed (on error)
+[Any state] ──► Deleting ──► (removed)
 ```
 
 ### API Extensions
 
-API Extensions are CRDs, admission and conversion webhooks, aggregated API servers,
-and finalizers, i.e. those mechanisms that change the OCP API surface and behaviour.
+This enhancement modifies existing API types rather than adding new CRDs or webhooks.
 
-- Name the API extensions this enhancement adds or modifies.
-- Does this enhancement modify the behaviour of existing resources, especially those owned
-  by other parties than the authoring team (including upstream resources), and, if yes, how?
-  Please add those other parties as reviewers to the enhancement.
+**Modified Resources:**
 
-  Examples:
-  - Adds a finalizer to namespaces. Namespace cannot be deleted without our controller running.
-  - Restricts the label format for objects to X.
-  - Defaults field Y on object kind Z.
+| Layer | Resource | Change |
+|-------|----------|--------|
+| OSAC Operator | `ComputeInstance` CRD | Expand `status.phase` values, refactor `status.conditions` |
+| Fulfillment API | `ComputeInstanceState` enum | Replace 4 values with 8 new phase values |
+| Fulfillment API | `ComputeInstanceConditionType` enum | Keep 3 conditions, remove 3, add 3 new |
+| Fulfillment Service | `ComputeInstanceState` enum | Mirror public API changes |
+| Fulfillment Service | `ComputeInstanceConditionType` enum | Mirror public API, rename REBOOT_* to RESTART_* |
 
-Fill in the operational impact of these API Extensions in the "Operational Aspects
-of API Extensions" section.
+**Condition Changes:**
+
+| Condition | Action | Notes |
+|-----------|--------|-------|
+| `DEGRADED` | Keep | No changes |
+| `RESTART_IN_PROGRESS` | Keep | Private API: rename from REBOOT_IN_PROGRESS |
+| `RESTART_FAILED` | Keep | Private API: rename from REBOOT_FAILED |
+| `PROGRESSING` | Remove | Phase now represents this |
+| `READY` | Remove | Replaced by `Available` |
+| `FAILED` | Remove | Phase now represents this |
+| `Provisioned` | New | Infrastructure resources are allocated |
+| `Available` | New | VM is ready for user workloads |
+| `ConfigurationApplied` | New | Desired configuration matches actual |
+
+**Behavioral Changes:**
+
+- `ComputeInstance.status.phase` will reflect VM power state (Running, Stopped, Paused) rather than reconciliation status
+- Conditions are orthogonal to phases - a condition like `Available` can be True or False independent of the phase
 
 ### Implementation Details/Notes/Constraints
 
-What are some important details that didn't come across above in the
-**Proposal**? Go in to as much detail as necessary here. This might be
-a good place to talk about core concepts and how they relate. While it is useful
-to go into the details of the code changes required, it is not necessary to show
-how the code will be rewritten in the enhancement.
+**Phase Determination Logic**
+
+The controller determines the ComputeInstance phase based on the KubeVirt `VirtualMachine.Status.PrintableStatus` and the `ComputeInstance.DeletionTimestamp`:
+
+| Condition | ComputeInstance Phase |
+|-----------|----------------------|
+| `DeletionTimestamp` is set | `Deleting` |
+| KubeVirt VM does not exist | `Pending` |
+| PrintableStatus = `Starting` | `Starting` |
+| PrintableStatus = `Running` AND VMI `Paused` condition = True | `Paused` |
+| PrintableStatus = `Running` | `Running` |
+| PrintableStatus = `Stopping` | `Stopping` |
+| PrintableStatus = `Stopped` | `Stopped` |
+| PrintableStatus = `ErrorUnschedulable` | `Failed` |
+
+> **Note:** KubeVirt does not have a transitional "Pausing" state. When a VM is paused, `PrintableStatus` remains "Running" but the VMI has a `Paused` condition set to `True`. The controller checks this condition to determine the `Paused` phase.
+
+**Condition Semantics by Phase**
+
+The following table shows the expected values of `Available` and `Degraded` conditions for each phase. These conditions are orthogonal to the phase - they represent the health and usability of the VM independent of its lifecycle state.
+
+| Phase | Available | Degraded | Description |
+|-------|-----------|----------|-------------|
+| `Pending` | False | False | VM is being provisioned, not yet usable |
+| `Starting` | False | False | VM is booting, not yet usable |
+| `Running` | True | False | VM is healthy and operational |
+| `Running` | True | True | VM is usable but has issues (e.g., performance degraded) |
+| `Running` | False | True | VM has issues preventing normal use |
+| `Stopping` | False | False | VM is shutting down |
+| `Stopped` | False | False | VM is powered off |
+| `Paused` | False | False | VM is paused, not usable until resumed |
+| `Deleting` | False | False | VM is being deleted |
+| `Failed` | False | False | VM encountered an unrecoverable error |
+
+**Key observations:**
+- `Available = True` only when phase is `Running` and the VM is usable
+- `Degraded = True` indicates issues, but the VM may still be usable (`Available = True`) or not (`Available = False`)
+- During transitional phases (`Starting`, `Stopping`, `Deleting`), both conditions are `False`
+- In terminal states (`Stopped`, `Paused`, `Failed`), both conditions are `False`
+
+**Files to Modify**
+
+| Repository | File | Changes |
+|------------|------|---------|
+| osac-operator | `api/v1alpha1/computeinstance_types.go` | Add new phase and condition constants |
+| osac-operator | `internal/controller/computeinstance_controller.go` | Update phase determination logic |
+| osac-operator | `internal/controller/computeinstance_feedback_controller.go` | Update phase-to-state mapping |
+| fulfillment-api | `proto/fulfillment/v1/compute_instance_type.proto` | Replace enum values |
+| fulfillment-service | `proto/private/v1/compute_instance_type.proto` | Replace enum values, rename REBOOT to RESTART |
+
+**Migration Approach**
+
+Since the product is in development with no external clients, old enum values (`PROGRESSING`, `READY`, `FAILED` for conditions) will be removed rather than deprecated. The controller will emit only the new phase and condition values.
 
 ### Risks and Mitigations
 

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -14,7 +14,7 @@ superseded-by:
 
 # ComputeInstance Phase and Condition Expansion
 
-## Summary
+## 1. Summary
 
 This enhancement proposes a cleanup and expansion of the `ComputeInstancePhaseType` and `ComputeInstanceConditionType` values for the OSAC VMaaS offering.
 
@@ -26,11 +26,11 @@ The redesign expands from 4 phases to 8 phases to properly represent the full VM
 
 This change enables users to understand VM power state (running, stopped, paused), see transitional progress (starting, stopping), and receive clear health signals through conditions - providing the operational visibility expected from a modern cloud platform.
 
-## Motivation
+## 2. Motivation
 
 As VMaaS matures to support full VM lifecycle operations, users need clear visibility into VM power state and operational status. The current phase model does not distinguish between a running VM and a stopped VM, and conditions overlap with phases rather than providing independent health information. This enhancement addresses these gaps to provide the operational visibility expected from a modern cloud platform.
 
-### User Stories
+### 2.1 User Stories
 
 **For Tenants:**
 
@@ -49,7 +49,7 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 * As a developer, I want a phase/condition model where conditions are orthogonal to phases, so that new conditions can be added in future releases without breaking my existing integrations
 * As a developer, I want a well-defined phase model that can accommodate future VM operations (e.g., live migration), so that the API can evolve to support new capabilities
 
-### Goals
+### 2.2 Goals
 
 * Represent VM power state clearly - Users can see if a VM is Running, Stopped, or Paused
 * Expose transitional states - Users can see when operations are in progress (Starting, Stopping, Deleting)
@@ -57,13 +57,13 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 * Make conditions orthogonal to phases - Conditions represent health/status attributes, not lifecycle state
 * Expose DELETING in API - The K8s operator's Deleting phase should be visible in the public API
 
-### Non-Goals
+### 2.3 Non-Goals
 
 * Additional conditions - Conditions such as NetworkReady and RestartRequired will be addressed in future enhancements as their dependencies (networking design, configuration change detection) are not yet finalized
 * New VM operations - This enhancement is about status representation, not adding pause/resume/stop operations themselves
 * Hibernate (suspend to disk) - Only in-memory pause is supported by KubeVirt; hibernate is out of scope
 
-## Proposal
+## 3. Proposal
 
 This enhancement modifies the `ComputeInstance` status model across three layers:
 
@@ -107,7 +107,7 @@ This enhancement modifies the `ComputeInstance` status model across three layers
 
 The phase values are derived from the underlying KubeVirt `VirtualMachine.Status.PrintableStatus`, ensuring accurate representation of VM power state.
 
-### Workflow Description
+### 3.1 Workflow Description
 
 **Phase Transitions**
 
@@ -150,7 +150,7 @@ Restart is not a separate phase. When a tenant restarts a VM:
 [Any state] ──► Deleting ──► (removed)
 ```
 
-### API Extensions
+### 3.2 API Extensions
 
 This enhancement modifies existing API types rather than adding new CRDs or webhooks.
 
@@ -197,7 +197,7 @@ This enhancement modifies existing API types rather than adding new CRDs or webh
 - `ComputeInstance.status.phase` will reflect VM power state (`Running`, `Stopped`, `Paused`) rather than reconciliation status
 - Conditions are orthogonal to phases - a condition like `Available` can be True or False independent of the phase
 
-### Implementation Details/Notes/Constraints
+### 3.3 Implementation Details/Notes/Constraints
 
 **Phase Determination Logic**
 
@@ -253,7 +253,7 @@ The following table shows the expected values of `Available` and `Degraded` cond
 
 Since the product is in development with no external clients, old enum values (`PROGRESSING`, `READY`, `FAILED` for conditions) will be removed rather than deprecated. The controller will emit only the new phase and condition values.
 
-### Risks and Mitigations
+### 3.4 Risks and Mitigations
 
 | Risk | Mitigation |
 |------|------------|
@@ -263,7 +263,7 @@ Since the product is in development with no external clients, old enum values (`
 | **Edge cases in KubeVirt state transitions** - KubeVirt may have transitional states or error conditions not fully mapped | Review KubeVirt documentation; manual testing with various VM scenarios (create, stop, start, pause, resume, delete, error conditions) |
 | **Condition logic complexity** - Determining when `Available` and `Degraded` should be True/False adds controller complexity | Document condition semantics clearly; use table-driven logic in controller for maintainability |
 
-### Drawbacks
+### 3.5 Drawbacks
 
 **Migration effort for internal consumers**
 
@@ -277,7 +277,7 @@ Expanding from 4 phases to 8 phases means more states to reason about in control
 
 Unlike Stopping, we cannot show a "Pausing" transitional phase because KubeVirt does not expose this state - pause is instantaneous. GCE is the only major cloud provider that exposes a `SUSPENDING` transitional state; AWS and KubeVirt transition directly to the paused/stopped state. This minor inconsistency reflects the underlying platform behavior accurately.
 
-## Alternatives (Not Implemented)
+## 4. Alternatives (Not Implemented)
 
 **1. Deprecate old values instead of removing them**
 
@@ -291,12 +291,12 @@ We could add a `Pausing` phase to mirror the `Stopping` transitional phase.
 
 *Why not selected:* KubeVirt does not expose a transitional "pausing" state - pause is instantaneous. Adding a phase we cannot accurately populate would be misleading.
 
-## Open Questions [optional]
+## 5. Open Questions
 
 - **NetworkReady condition** - Requires networking design to be finalized before this condition can be defined
 - **RestartRequired condition** - Requires configuration change detection logic to be designed
 
-## Test Plan
+## 6. Test Plan
 
 - **Unit tests**: Phase determination logic in `computeinstance_controller.go` - test each KubeVirt `PrintableStatus` → ComputeInstance phase mapping
 - **Unit tests**: Condition setting logic - test `Available` and `Degraded` conditions for each phase
@@ -304,22 +304,22 @@ We could add a `Pausing` phase to mirror the `Stopping` transitional phase.
 - **Manual testing**: Create VMs in dev environment and verify phase transitions through lifecycle operations (create, stop, start, pause, resume, delete)
 - **Manual testing**: Verify error scenarios produce `Failed` phase
 
-## Graduation Criteria
+## 7. Graduation Criteria
 
 TBD
 
-## Upgrade / Downgrade Strategy
+## 8. Upgrade / Downgrade Strategy
 
 TBD
 
-## Version Skew Strategy
+## 9. Version Skew Strategy
 
 N/A
 
-## Support Procedures
+## 10. Support Procedures
 
 TBD
 
-## Infrastructure Needed [optional]
+## 11. Infrastructure Needed
 
 N/A

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -239,7 +239,7 @@ This means `Available = True` indicates that the VM infrastructure (virt-launche
 
 **RestartRequired Condition Logic**
 
-The `RestartRequired` condition is derived from KubeVirt's `VirtualMachine.Status.Conditions` where `type = RestartRequired`. This condition is set by KubeVirt when configuration changes (such as adding or removing resources like CPUs, memory, or devices) have been applied to the VM spec but require a restart to take effect since they can't be live-propagated to the VMI. 
+The `RestartRequired` condition is derived from KubeVirt's `VirtualMachine.Status.Conditions` where `type = RestartRequired`. This condition is set by KubeVirt when configuration changes (such as adding or removing resources like CPUs, memory, or devices) have been applied to the VM spec but require a restart to take effect since they can't be live-propagated to the VMI.
 
 | KubeVirt VM Condition | RestartRequired |
 |-----------------------|-----------------|

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -98,7 +98,7 @@ This enhancement modifies the `ComputeInstance` status model across three layers
 | Condition (CRD) | Condition (Protobuf) | Layer | Description |
 |-----------------|---------------------|-------|-------------|
 | `Provisioned` | `PROVISIONED` | CRD + API | Infrastructure resources (compute, storage) are allocated |
-| `Available` | `AVAILABLE` | CRD + API | VM is ready for user workloads |
+| `Available` | `AVAILABLE` | CRD + API | VM infrastructure is running and ready (does not indicate guest OS readiness) |
 | `ConfigurationApplied` | `CONFIGURATION_APPLIED` | CRD + API | Desired configuration matches actual |
 | `RestartRequired` | `RESTART_REQUIRED` | CRD + API | VM needs a restart for configuration changes to take effect |
 | — | `RESTART_IN_PROGRESS` | API only | Restart operation is in progress |

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -3,7 +3,7 @@ title: computeinstance-phase-condition-expansion
 authors:
   - Akshay Nadkarni
 creation-date: 2026-01-29
-last-updated: 2026-01-29
+last-updated: 2026-02-03
 tracking-link:
   - TBD
 see-also:
@@ -20,7 +20,7 @@ This enhancement proposes a cleanup and expansion of the `ComputeInstancePhaseTy
 
 The current 4-phase model (`Progressing`, `Ready`, `Failed`, `Deleting`) was designed for initial provisioning workflows. As VMaaS matures to support full lifecycle operations (start, stop, pause, resume), the phase model needs to expand to represent these power states. Additionally, the current conditions overlap with phases rather than providing orthogonal health information.
 
-The redesign expands from 4 phases to 8 phases to properly represent the full VM lifecycle, aligning with industry standards from AWS, GCE, and KubeVirt. Conditions are redesigned to be orthogonal health indicators that complement, rather than duplicate, the lifecycle phase.
+The redesign expands from 4 phases to 7 phases to properly represent the full VM lifecycle, aligning with industry standards from AWS, GCE, and KubeVirt. Conditions are redesigned to be orthogonal health indicators that complement, rather than duplicate, the lifecycle phase.
 
 > **Note:** You can find more details on industry standards [here](https://docs.google.com/document/d/1wgqAblnT7OHlT5bvaI4bi842kyeR3u4VfC_TAJXbGcI/edit?tab=t.oocbc3frwt7c).
 
@@ -37,12 +37,13 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 * As a tenant, I want to see if my VM is running, stopped, or paused, so that I understand its current power state
 * As a tenant, I want to see when my VM is starting or stopping, so that I know an operation is in progress
 * As a tenant, I want to see clear health indicators for my VM, so that I can identify issues without interpreting phase values
-* As a tenant, I want to see when my VM is being deleted, so that I can track the deletion progress
+* As a tenant, I want to see when my VM is being deleted, so that I can track deletion progress and identify if resource removal fails
 
 **For Cloud Providers:**
 
 * As a cloud provider, I want to see clear VM power states for tenant VMs, so that I can provide effective support and troubleshooting
 * As a cloud provider, I want VM phases that align with industry standards, so that I can build monitoring dashboards with familiar terminology
+* As a cloud provider, I want visibility into VM deletion status, so that I can troubleshoot stuck deletions and ensure resources are properly cleaned up
 
 **For Developers:**
 
@@ -55,11 +56,11 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 * Expose transitional states - Users can see when operations are in progress (Starting, Stopping, Deleting)
 * Align with industry standards - Phase values match what users expect from AWS, GCE, and KubeVirt
 * Make conditions orthogonal to phases - Conditions represent health/status attributes, not lifecycle state
-* Expose DELETING in API - The K8s operator's Deleting phase should be visible in the public API
+* Give tenants and cloud providers visibility into the deletion phase - Track deletion progress and identify issues if resource removal fails
 
 ### 2.3 Non-Goals
 
-* Additional conditions - Conditions such as NetworkReady and RestartRequired will be addressed in future enhancements as their dependencies (networking design, configuration change detection) are not yet finalized
+* Additional conditions - Conditions such as Degraded and RestartRequired are deferred pending further discussion (see Open Questions)
 * New VM operations - This enhancement is about status representation, not adding pause/resume/stop operations themselves
 * Hibernate (suspend to disk) - Only in-memory pause is supported by KubeVirt; hibernate is out of scope
 
@@ -68,7 +69,7 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 This enhancement modifies the `ComputeInstance` status model across three layers:
 
 **1. OSAC Operator (Kubernetes CRD)**
-- Expand `ComputeInstancePhaseType` from 4 phases to 8 phases
+- Expand `ComputeInstancePhaseType` from 4 phases to 7 phases
 - Refactor `ComputeInstanceConditionType` to be orthogonal to phases
 
 **2. Fulfillment API (Public protobuf)**
@@ -79,17 +80,16 @@ This enhancement modifies the `ComputeInstance` status model across three layers
 **3. Fulfillment Service (Private protobuf)**
 - Mirror public API changes
 
-**Proposed Phases (8):**
+**Proposed Phases (7):**
 
 | Phase | Description |
 |-------|-------------|
-| `Pending` | VM is being provisioned, infrastructure resources allocating |
-| `Starting` | VM is powering on, guest OS booting |
-| `Running` | VM is running and operational |
-| `Stopping` | VM is powering off, guest OS shutting down |
-| `Stopped` | VM is powered off, resources retained |
-| `Paused` | VM is paused, memory preserved, no CPU allocated |
-| `Deleting` | VM is being permanently deleted |
+| `Starting` | Cluster resources associated with the VM are being provisioned and prepared, or VM is being prepared for running |
+| `Running` | VM is running |
+| `Stopping` | VM is in the process of being stopped |
+| `Stopped` | VM is stopped |
+| `Paused` | VM is paused |
+| `Deleting` | VM is in the process of deletion, as well as its associated resources |
 | `Failed` | VM encountered an error |
 
 **Proposed Conditions (orthogonal to phases):**
@@ -98,7 +98,6 @@ This enhancement modifies the `ComputeInstance` status model across three layers
 |-----------------|---------------------|-------|-------------|
 | `Provisioned` | `PROVISIONED` | CRD + API | Infrastructure resources (compute, storage) are allocated |
 | `Available` | `AVAILABLE` | CRD + API | VM is ready for user workloads |
-| `Degraded` | `DEGRADED` | CRD + API | VM is running but with reduced capability |
 | `ConfigurationApplied` | `CONFIGURATION_APPLIED` | CRD + API | Desired configuration matches actual |
 | — | `RESTART_IN_PROGRESS` | API only | Restart operation is in progress |
 | — | `RESTART_FAILED` | API only | Restart operation failed |
@@ -113,14 +112,13 @@ The phase values are derived from the underlying KubeVirt `VirtualMachine.Status
 
 A tenant creates a ComputeInstance and observes its lifecycle through phases:
 
-1. **Create**: Tenant requests a new VM → Phase: `Pending`
-2. **Provisioning completes**: KubeVirt VM is created, booting → Phase: `Starting`
-3. **Boot completes**: VM is operational → Phase: `Running`
-4. **Stop requested**: Tenant stops the VM → Phase: `Stopping` → `Stopped`
-5. **Start requested**: Tenant starts the VM → Phase: `Starting` → `Running`
-6. **Pause requested**: Tenant pauses the VM → Phase: `Paused`
-7. **Resume requested**: Tenant resumes the VM → Phase: `Running`
-8. **Delete requested**: Tenant deletes the VM → Phase: `Deleting` → (resource removed)
+1. **Create**: Tenant requests a new VM → Phase: `Starting`
+2. **Boot completes**: VM is running → Phase: `Running`
+3. **Stop requested**: Tenant stops the VM → Phase: `Stopping` → `Stopped`
+4. **Start requested**: Tenant starts the VM → Phase: `Starting` → `Running`
+5. **Pause requested**: Tenant pauses the VM → Phase: `Paused`
+6. **Resume requested**: Tenant resumes the VM → Phase: `Running`
+7. **Delete requested**: Tenant deletes the VM → Phase: `Deleting` → (resource removed)
 
 **Restart Handling**
 
@@ -133,18 +131,18 @@ Restart is not a separate phase. When a tenant restarts a VM:
 **State Transition Diagram**
 
 ```
-                              ┌─────────────────────────────────────────┐
-                              │                (start)                  │
-                              ▼                                         │
-[Create] ──► Pending ──► Starting ──► Running ──► Stopping ──► Stopped ─┘
-                                          │
-                                          │ (pause)
-                                          ▼
-                                       Paused
-                                          │
-                                          │ (resume)
-                                          ▼
-                                       Running
+                    ┌──────────────────────────────────────┐
+                    │              (start)                 │
+                    ▼                                      │
+[Create] ──► Starting ──► Running ──► Stopping ──► Stopped ─┘
+                            │
+                            │ (pause)
+                            ▼
+                         Paused
+                            │
+                            │ (resume)
+                            ▼
+                         Running
 
 [Any state] ──► Failed (on error)
 [Any state] ──► Deleting ──► (removed)
@@ -159,8 +157,8 @@ This enhancement modifies existing API types rather than adding new CRDs or webh
 | Layer | Resource | Change |
 |-------|----------|--------|
 | OSAC Operator | `ComputeInstance` CRD | Expand `status.phase` values, refactor `status.conditions` |
-| Fulfillment API | `ComputeInstanceState` enum | Replace 4 values with 8 new phase values |
-| Fulfillment API | `ComputeInstanceConditionType` enum | Keep 3 conditions, remove 3, add 3 new |
+| Fulfillment API | `ComputeInstanceState` enum | Replace 4 values with 7 new phase values |
+| Fulfillment API | `ComputeInstanceConditionType` enum | Keep 3 conditions, remove 4, add 2 new |
 | Fulfillment Service | `ComputeInstanceState` enum | Mirror public API changes |
 | Fulfillment Service | `ComputeInstanceConditionType` enum | Mirror public API changes |
 
@@ -168,8 +166,7 @@ This enhancement modifies existing API types rather than adding new CRDs or webh
 
 | Current (CRD) | Current (Protobuf) | Proposed (CRD) | Proposed (Protobuf) |
 |---------------|-------------------|----------------|---------------------|
-| `Progressing` | `PROGRESSING` | `Pending` | `PENDING` |
-| — | — | `Starting` | `STARTING` |
+| `Progressing` | `PROGRESSING` | `Starting` | `STARTING` |
 | `Ready` | `READY` | `Running` | `RUNNING` |
 | — | — | `Stopping` | `STOPPING` |
 | — | — | `Stopped` | `STOPPED` |
@@ -186,7 +183,7 @@ This enhancement modifies existing API types rather than adding new CRDs or webh
 | `Available` | `READY` | `Available` | `AVAILABLE` | Rename in protobuf |
 | `Deleting` | — | — | — | Remove (phase represents this) |
 | — | `FAILED` | — | — | Remove (phase represents this) |
-| — | `DEGRADED` | `Degraded` | `DEGRADED` | Keep, add to CRD |
+| — | `DEGRADED` | — | — | Remove (see Open Questions) |
 | — | `RESTART_IN_PROGRESS` | — | `RESTART_IN_PROGRESS` | Keep (API only) |
 | — | `RESTART_FAILED` | — | `RESTART_FAILED` | Keep (API only) |
 | — | — | `Provisioned` | `PROVISIONED` | New |
@@ -206,7 +203,7 @@ The controller determines the ComputeInstance phase based on the KubeVirt `Virtu
 | Condition | ComputeInstance Phase |
 |-----------|----------------------|
 | `DeletionTimestamp` is set | `Deleting` |
-| KubeVirt VM does not exist | `Pending` |
+| KubeVirt VM does not exist | `Starting` |
 | PrintableStatus = `Starting` | `Starting` |
 | PrintableStatus = `Running` AND VMI `Paused` condition = True | `Paused` |
 | PrintableStatus = `Running` | `Running` |
@@ -216,28 +213,16 @@ The controller determines the ComputeInstance phase based on the KubeVirt `Virtu
 
 > **Note:** KubeVirt does not have a transitional "Pausing" state. When a VM is paused, `PrintableStatus` remains "Running" but the VMI has a `Paused` condition set to `True`. The controller checks this condition to determine the `Paused` phase.
 
-**Condition Semantics by Phase**
+**Available Condition Logic**
 
-The following table shows the expected values of `Available` and `Degraded` conditions for each phase. These conditions are orthogonal to the phase - they represent the health and usability of the VM independent of its lifecycle state.
+The `Available` condition has a simple rule: it is `True` only when the VM is in the `Running` phase.
 
-| Phase | Available | Degraded | Description |
-|-------|-----------|----------|-------------|
-| `Pending` | False | False | VM is being provisioned, not yet usable |
-| `Starting` | False | False | VM is booting, not yet usable |
-| `Running` | True | False | VM is healthy and operational |
-| `Running` | True | True | VM is usable but has issues (e.g., performance degraded) |
-| `Running` | False | True | VM has issues preventing normal use |
-| `Stopping` | False | False | VM is shutting down |
-| `Stopped` | False | False | VM is powered off |
-| `Paused` | False | False | VM is paused, not usable until resumed |
-| `Deleting` | False | False | VM is being deleted |
-| `Failed` | False | False | VM encountered an unrecoverable error |
+| Phase | Available |
+|-------|-----------|
+| `Running` | True |
+| All other phases | False |
 
-**Key observations:**
-- `Available = True` only when phase is `Running` and the VM is usable
-- `Degraded = True` indicates issues, but the VM may still be usable (`Available = True`) or not (`Available = False`)
-- During transitional phases (`Starting`, `Stopping`, `Deleting`), both conditions are `False`
-- In terminal states (`Stopped`, `Paused`, `Failed`), both conditions are `False`
+This straightforward logic reflects that a VM is only "available for use" when it is actively running.
 
 **Files to Modify**
 
@@ -261,7 +246,7 @@ Since the product is in development with no external clients, old enum values (`
 | **Developer scripts tied to old values** - Developers may have local scripts or automation that check for `Progressing`, `Ready`, or `Failed` conditions | Communicate changes clearly in release notes; provide migration guidance |
 | **Incorrect phase mapping from KubeVirt** - Controller could incorrectly map KubeVirt states, showing wrong phase values | Comprehensive unit tests for phase determination logic; manual testing with real VMs in dev environment |
 | **Edge cases in KubeVirt state transitions** - KubeVirt may have transitional states or error conditions not fully mapped | Review KubeVirt documentation; manual testing with various VM scenarios (create, stop, start, pause, resume, delete, error conditions) |
-| **Condition logic complexity** - Determining when `Available` and `Degraded` should be True/False adds controller complexity | Document condition semantics clearly; use table-driven logic in controller for maintainability |
+| **Condition logic complexity** - Determining when `Available` should be True/False adds controller complexity | Document condition semantics clearly; use table-driven logic in controller for maintainability |
 
 ### 3.5 Drawbacks
 
@@ -271,7 +256,7 @@ Any UI components, scripts, or automation that reference current phase/condition
 
 **Increased state complexity**
 
-Expanding from 4 phases to 8 phases means more states to reason about in controllers, tests, and documentation. However, the additional granularity aligns with industry standards and provides the operational visibility users expect.
+Expanding from 4 phases to 7 phases means more states to reason about in controllers, tests, and documentation. However, the additional granularity aligns with industry standards and provides the operational visibility users expect.
 
 **No transitional Pausing phase**
 
@@ -293,13 +278,14 @@ We could add a `Pausing` phase to mirror the `Stopping` transitional phase.
 
 ## 5. Open Questions
 
-- **NetworkReady condition** - Requires networking design to be finalized before this condition can be defined
-- **RestartRequired condition** - Requires configuration change detection logic to be designed
+- **Should we add a Degraded condition?** The existing `DEGRADED` enum value in the API is never set. What signals from KubeVirt would indicate a VM is "degraded" (running but with issues) vs "failed" (not running)? The KubeVirt signals considered (CrashLoopBackOff, ErrorUnschedulable, etc.) mostly indicate failure rather than degradation.
+
+- **Should we expose a RestartRequired condition?** KubeVirt has a `RestartRequired` condition that indicates the VM needs a restart for configuration changes to take effect. Should we expose this in the OSAC API, and if so, what configuration change detection logic is needed?
 
 ## 6. Test Plan
 
 - **Unit tests**: Phase determination logic in `computeinstance_controller.go` - test each KubeVirt `PrintableStatus` → ComputeInstance phase mapping
-- **Unit tests**: Condition setting logic - test `Available` and `Degraded` conditions for each phase
+- **Unit tests**: Condition setting logic - test `Available` condition for each phase
 - **Unit tests**: Feedback controller phase-to-state mapping
 - **Manual testing**: Create VMs in dev environment and verify phase transitions through lifecycle operations (create, stop, start, pause, resume, delete)
 - **Manual testing**: Verify error scenarios produce `Failed` phase

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -38,6 +38,7 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 * As a tenant, I want to see when my VM is starting or stopping, so that I know an operation is in progress
 * As a tenant, I want to see clear health indicators for my VM, so that I can identify issues without interpreting phase values
 * As a tenant, I want to see when my VM is being deleted, so that I can track deletion progress and identify if resource removal fails
+* As a tenant, I want to know when my VM requires a restart for configuration changes to take effect, so that I can initiate a reboot when convenient
 
 **For Cloud Providers:**
 
@@ -60,7 +61,7 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 
 ### 2.3 Non-Goals
 
-* Additional conditions - Conditions such as Degraded and RestartRequired are deferred pending further discussion (see Open Questions)
+* Additional conditions - The Degraded condition is deferred pending further discussion (see Open Questions)
 * New VM operations - This enhancement is about status representation, not adding pause/resume/stop operations themselves
 * Hibernate (suspend to disk) - Only in-memory pause is supported by KubeVirt; hibernate is out of scope
 
@@ -99,10 +100,11 @@ This enhancement modifies the `ComputeInstance` status model across three layers
 | `Provisioned` | `PROVISIONED` | CRD + API | Infrastructure resources (compute, storage) are allocated |
 | `Available` | `AVAILABLE` | CRD + API | VM is ready for user workloads |
 | `ConfigurationApplied` | `CONFIGURATION_APPLIED` | CRD + API | Desired configuration matches actual |
+| `RestartRequired` | `RESTART_REQUIRED` | CRD + API | VM needs a restart for configuration changes to take effect |
 | — | `RESTART_IN_PROGRESS` | API only | Restart operation is in progress |
 | — | `RESTART_FAILED` | API only | Restart operation failed |
 
-> **Note:** CRD conditions use PascalCase (Kubernetes convention). Protobuf conditions use UPPER_SNAKE_CASE with prefix (e.g., `COMPUTE_INSTANCE_CONDITION_TYPE_AVAILABLE`). Restart conditions exist only in the protobuf API because restart functionality is implemented at the fulfillment service layer.
+> **Note:** CRD conditions use PascalCase (Kubernetes convention). Protobuf conditions use UPPER_SNAKE_CASE with prefix (e.g., `COMPUTE_INSTANCE_CONDITION_TYPE_AVAILABLE`). `RESTART_IN_PROGRESS` and `RESTART_FAILED` exist only in the protobuf API because restart operation tracking is implemented at the fulfillment service layer.
 
 The phase values are derived from the underlying KubeVirt `VirtualMachine.Status.PrintableStatus`, ensuring accurate representation of VM power state.
 
@@ -158,7 +160,7 @@ This enhancement modifies existing API types rather than adding new CRDs or webh
 |-------|----------|--------|
 | OSAC Operator | `ComputeInstance` CRD | Expand `status.phase` values, refactor `status.conditions` |
 | Fulfillment API | `ComputeInstanceState` enum | Replace 4 values with 7 new phase values |
-| Fulfillment API | `ComputeInstanceConditionType` enum | Keep 3 conditions, remove 4, add 2 new |
+| Fulfillment API | `ComputeInstanceConditionType` enum | Keep 3 conditions, remove 4, add 3 new |
 | Fulfillment Service | `ComputeInstanceState` enum | Mirror public API changes |
 | Fulfillment Service | `ComputeInstanceConditionType` enum | Mirror public API changes |
 
@@ -188,6 +190,7 @@ This enhancement modifies existing API types rather than adding new CRDs or webh
 | — | `RESTART_FAILED` | — | `RESTART_FAILED` | Keep (API only) |
 | — | — | `Provisioned` | `PROVISIONED` | New |
 | — | — | `ConfigurationApplied` | `CONFIGURATION_APPLIED` | New |
+| — | — | `RestartRequired` | `RESTART_REQUIRED` | New |
 
 **Behavioral Changes:**
 
@@ -223,6 +226,17 @@ The `Available` condition has a simple rule: it is `True` only when the VM is in
 | All other phases | False |
 
 This straightforward logic reflects that a VM is only "available for use" when it is actively running.
+
+**RestartRequired Condition Logic**
+
+The `RestartRequired` condition is derived from KubeVirt's `VirtualMachine.Status.Conditions` where `type = RestartRequired`. This condition is set by KubeVirt when configuration changes (such as adding or removing resources like CPUs, memory, or devices) have been applied to the VM spec but require a restart to take effect since they can't be live-propagated to the VMI. 
+
+| KubeVirt VM Condition | RestartRequired |
+|-----------------------|-----------------|
+| `RestartRequired` = True | True |
+| `RestartRequired` = False or absent | False |
+
+This enables tenants to see when their VM needs a restart and decide when to initiate the reboot based on their workload needs.
 
 **Files to Modify**
 
@@ -280,15 +294,14 @@ We could add a `Pausing` phase to mirror the `Stopping` transitional phase.
 
 - **Should we add a Degraded condition?** The existing `DEGRADED` enum value in the API is never set. What signals from KubeVirt would indicate a VM is "degraded" (running but with issues) vs "failed" (not running)? The KubeVirt signals considered (CrashLoopBackOff, ErrorUnschedulable, etc.) mostly indicate failure rather than degradation.
 
-- **Should we expose a RestartRequired condition?** KubeVirt has a `RestartRequired` condition that indicates the VM needs a restart for configuration changes to take effect. Should we expose this in the OSAC API, and if so, what configuration change detection logic is needed?
-
 ## 6. Test Plan
 
 - **Unit tests**: Phase determination logic in `computeinstance_controller.go` - test each KubeVirt `PrintableStatus` → ComputeInstance phase mapping
-- **Unit tests**: Condition setting logic - test `Available` condition for each phase
+- **Unit tests**: Condition setting logic - test `Available` and `RestartRequired` conditions
 - **Unit tests**: Feedback controller phase-to-state mapping
 - **Manual testing**: Create VMs in dev environment and verify phase transitions through lifecycle operations (create, stop, start, pause, resume, delete)
 - **Manual testing**: Verify error scenarios produce `Failed` phase
+- **Manual testing**: Modify VM configuration (e.g., CPU/memory) and verify `RestartRequired` condition is surfaced; reboot VM and verify condition clears
 
 ## 7. Graduation Criteria
 

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -300,174 +300,47 @@ Unlike Stopping, we cannot show a "Pausing" transitional phase because KubeVirt 
 
 ## Alternatives (Not Implemented)
 
-Similar to the `Drawbacks` section the `Alternatives` section is used
-to highlight and record other possible approaches to delivering the
-value proposed by an enhancement, including especially information
-about why the alternative was not selected.
+**1. Deprecate old values instead of removing them**
+
+We could deprecate old phase/condition values and maintain them for several releases before removal.
+
+*Why not selected:* Since the product is in development with no external clients, deprecation adds unnecessary complexity. A clean break is simpler and avoids carrying legacy values.
+
+**2. Add a Pausing transitional phase**
+
+We could add a `Pausing` phase to mirror the `Stopping` transitional phase.
+
+*Why not selected:* KubeVirt does not expose a transitional "pausing" state - pause is instantaneous. Adding a phase we cannot accurately populate would be misleading.
 
 ## Open Questions [optional]
 
-This is where to call out areas of the design that require closure before deciding
-to implement the design.  For instance,
- > 1. This requires exposing previously private resources which contain sensitive
-  information.  Can we do this?
+- **NetworkReady condition** - Requires networking design to be finalized before this condition can be defined
+- **RestartRequired condition** - Requires configuration change detection logic to be designed
 
 ## Test Plan
 
-**Note:** *Section not required until targeted at a release.*
-
-Consider the following in developing a test plan for this enhancement:
-- Will there be e2e and integration tests, in addition to unit tests?
-- How will it be tested in isolation vs with other components?
-- What additional testing is necessary to support managed OpenShift service-based offerings?
-
-No need to outline all of the test cases, just the general strategy. Anything
-that would count as tricky in the implementation and anything particularly
-challenging to test should be called out.
-
-All code is expected to have adequate tests (eventually with coverage
-expectations).
+- **Unit tests**: Phase determination logic in `computeinstance_controller.go` - test each KubeVirt `PrintableStatus` → ComputeInstance phase mapping
+- **Unit tests**: Condition setting logic - test `Available` and `Degraded` conditions for each phase
+- **Unit tests**: Feedback controller phase-to-state mapping
+- **Manual testing**: Create VMs in dev environment and verify phase transitions through lifecycle operations (create, stop, start, pause, resume, delete)
+- **Manual testing**: Verify error scenarios produce `Failed` phase
 
 ## Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-
-- Maturity levels
-  - [`alpha`, `beta`, `stable` in upstream Kubernetes][maturity-levels]
-  - `Dev Preview`, `Tech Preview`, `GA` in OpenShift
-- [Deprecation policy][deprecation-policy]
-
-Clearly define what graduation means by either linking to the [API doc definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning),
-or by redefining what graduation means.
-
-In general, we try to use the same stages (alpha, beta, GA), regardless how the functionality is accessed.
-
-[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
-[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
-
-**If this is a user facing change requiring new or updated documentation in [openshift-docs](https://github.com/openshift/openshift-docs/),
-please be sure to include in the graduation criteria.**
-
-**Examples**: These are generalized examples to consider, in addition
-to the aforementioned [maturity levels][maturity-levels].
-
-### Removing a deprecated feature
-
-- Announce deprecation and support policy of the existing feature
-- Deprecate the feature
+TBD
 
 ## Upgrade / Downgrade Strategy
 
-If applicable, how will the component be upgraded and downgraded? Make sure this
-is in the test plan.
-
-Consider the following in developing an upgrade/downgrade strategy for this
-enhancement:
-- What changes (in invocations, configurations, API use, etc.) is an existing
-  cluster required to make on upgrade in order to keep previous behavior?
-- What changes (in invocations, configurations, API use, etc.) is an existing
-  cluster required to make on upgrade in order to make use of the enhancement?
-
-Upgrade expectations:
-- Each component should remain available for user requests and
-  workloads during upgrades. Ensure the components leverage best practices in handling [voluntary
-  disruption](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/). Any exception to
-  this should be identified and discussed here.
-- Micro version upgrades - users should be able to skip forward versions within a
-  minor release stream without being required to pass through intermediate
-  versions - i.e. `x.y.N->x.y.N+2` should work without requiring `x.y.N->x.y.N+1`
-  as an intermediate step.
-- Minor version upgrades - you only need to support `x.N->x.N+1` upgrade
-  steps. So, for example, it is acceptable to require a user running 4.3 to
-  upgrade to 4.5 with a `4.3->4.4` step followed by a `4.4->4.5` step.
-- While an upgrade is in progress, new component versions should
-  continue to operate correctly in concert with older component
-  versions (aka "version skew"). For example, if a node is down, and
-  an operator is rolling out a daemonset, the old and new daemonset
-  pods must continue to work correctly even while the cluster remains
-  in this partially upgraded state for some time.
-
-Downgrade expectations:
-- If an `N->N+1` upgrade fails mid-way through, or if the `N+1` cluster is
-  misbehaving, it should be possible for the user to rollback to `N`. It is
-  acceptable to require some documented manual steps in order to fully restore
-  the downgraded cluster to its previous state. Examples of acceptable steps
-  include:
-  - Deleting any CVO-managed resources added by the new version. The
-    CVO does not currently delete resources that no longer exist in
-    the target version.
+TBD
 
 ## Version Skew Strategy
 
-How will the component handle version skew with other components?
-What are the guarantees? Make sure this is in the test plan.
-
-Consider the following in developing a version skew strategy for this
-enhancement:
-- During an upgrade, we will always have skew among components, how will this impact your work?
-- Does this enhancement involve coordinating behavior in the control plane and
-  in the kubelet? How does an n-2 kubelet without this feature available behave
-  when this feature is used?
-- Will any other components on the node change? For example, changes to CSI, CRI
-  or CNI may require updating that component before the kubelet.
+N/A
 
 ## Support Procedures
 
-Describe how to
-- detect the failure modes in a support situation, describe possible symptoms (events, metrics,
-  alerts, which log output in which component)
-
-  Examples:
-  - If the webhook is not running, kube-apiserver logs will show errors like "failed to call admission webhook xyz".
-  - Operator X will degrade with message "Failed to launch webhook server" and reason "WehhookServerFailed".
-  - The metric `webhook_admission_duration_seconds("openpolicyagent-admission", "mutating", "put", "false")`
-    will show >1s latency and alert `WebhookAdmissionLatencyHigh` will fire.
-
-- disable the API extension (e.g. remove MutatingWebhookConfiguration `xyz`, remove APIService `foo`)
-
-  - What consequences does it have on the cluster health?
-
-    Examples:
-    - Garbage collection in kube-controller-manager will stop working.
-    - Quota will be wrongly computed.
-    - Disabling/removing the CRD is not possible without removing the CR instances. Customer will lose data.
-      Disabling the conversion webhook will break garbage collection.
-
-  - What consequences does it have on existing, running workloads?
-
-    Examples:
-    - New namespaces won't get the finalizer "xyz" and hence might leak resource X
-      when deleted.
-    - SDN pod-to-pod routing will stop updating, potentially breaking pod-to-pod
-      communication after some minutes.
-
-  - What consequences does it have for newly created workloads?
-
-    Examples:
-    - New pods in namespace with Istio support will not get sidecars injected, breaking
-      their networking.
-
-- Does functionality fail gracefully and will work resume when re-enabled without risking
-  consistency?
-
-  Examples:
-  - The mutating admission webhook "xyz" has FailPolicy=Ignore and hence
-    will not block the creation or updates on objects when it fails. When the
-    webhook comes back online, there is a controller reconciling all objects, applying
-    labels that were not applied during admission webhook downtime.
-  - Namespaces deletion will not delete all objects in etcd, leading to zombie
-    objects when another namespace with the same name is created.
+TBD
 
 ## Infrastructure Needed [optional]
 
-Use this section if you need things from the project. Examples include a new
-subproject, repos requested, github details, and/or testing infrastructure.
+N/A

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -18,9 +18,11 @@ superseded-by:
 
 This enhancement proposes a cleanup and expansion of the `ComputeInstancePhaseType` and `ComputeInstanceConditionType` values for the OSAC VMaaS offering.
 
-The current 4-phase model (`Progressing`, `Ready`, `Failed`, `Deleting`) was designed for initial provisioning workflows. As VMaaS matures to support full lifecycle operations (stop, start, pause, resume), the phase model needs to expand to represent these power states. Additionally, the current conditions overlap with phases rather than providing orthogonal health information, and there are inconsistencies between the public and private APIs that need to be addressed.
+The current 4-phase model (`Progressing`, `Ready`, `Failed`, `Deleting`) was designed for initial provisioning workflows. As VMaaS matures to support full lifecycle operations (start, stop, pause, resume), the phase model needs to expand to represent these power states. Additionally, the current conditions overlap with phases rather than providing orthogonal health information.
 
-The redesign expands from 4 phases to 9 phases to properly represent the full VM lifecycle, aligning with industry standards from AWS, GCE, and KubeVirt. Conditions are redesigned to be orthogonal health indicators that complement, rather than duplicate, the lifecycle phase.
+The redesign expands from 4 phases to 8 phases to properly represent the full VM lifecycle, aligning with industry standards from AWS, GCE, and KubeVirt. Conditions are redesigned to be orthogonal health indicators that complement, rather than duplicate, the lifecycle phase.
+
+> **Note:** You can find more details on industry standards [here](https://docs.google.com/document/d/1wgqAblnT7OHlT5bvaI4bi842kyeR3u4VfC_TAJXbGcI/edit?tab=t.oocbc3frwt7c). 
 
 This change enables users to understand VM power state (running, stopped, paused), see transitional progress (starting, stopping), and receive clear health signals through conditions - providing the operational visibility expected from a modern cloud platform.
 
@@ -44,17 +46,15 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 
 **For Developers:**
 
-* As a developer integrating with the OSAC API, I want consistent terminology (RESTART vs REBOOT), so that I don't have to handle inconsistencies between public and private APIs
 * As a developer, I want a phase/condition model where conditions are orthogonal to phases, so that new conditions can be added in future releases without breaking my existing integrations
 * As a developer, I want a well-defined phase model that can accommodate future VM operations (e.g., live migration), so that the API can evolve to support new capabilities
 
 ### Goals
 
 * Represent VM power state clearly - Users can see if a VM is Running, Stopped, or Paused
-* Expose transitional states - Users can see when operations are in progress (Starting, Stopping, Pausing, Deleting)
+* Expose transitional states - Users can see when operations are in progress (Starting, Stopping, Deleting)
 * Align with industry standards - Phase values match what users expect from AWS, GCE, and KubeVirt
 * Make conditions orthogonal to phases - Conditions represent health/status attributes, not lifecycle state
-* Fix API inconsistencies - Unify RESTART/REBOOT terminology between public and private APIs
 * Expose DELETING in API - The K8s operator's Deleting phase should be visible in the public API
 
 ### Non-Goals
@@ -78,7 +78,6 @@ This enhancement modifies the `ComputeInstance` status model across three layers
 
 **3. Fulfillment Service (Private protobuf)**
 - Mirror public API changes
-- Fix RESTART/REBOOT terminology inconsistency
 
 **Proposed Phases (8):**
 
@@ -95,14 +94,16 @@ This enhancement modifies the `ComputeInstance` status model across three layers
 
 **Proposed Conditions (orthogonal to phases):**
 
-| Condition | Description |
-|-----------|-------------|
-| `Provisioned` | Infrastructure resources (compute, storage) are allocated |
-| `Available` | VM is ready for user workloads |
-| `Degraded` | VM is running but with reduced capability |
-| `ConfigurationApplied` | Desired configuration matches actual |
-| `RestartInProgress` | Restart operation is in progress |
-| `RestartFailed` | Restart operation failed |
+| Condition (CRD) | Condition (Protobuf) | Layer | Description |
+|-----------------|---------------------|-------|-------------|
+| `Provisioned` | `PROVISIONED` | CRD + API | Infrastructure resources (compute, storage) are allocated |
+| `Available` | `AVAILABLE` | CRD + API | VM is ready for user workloads |
+| `Degraded` | `DEGRADED` | CRD + API | VM is running but with reduced capability |
+| `ConfigurationApplied` | `CONFIGURATION_APPLIED` | CRD + API | Desired configuration matches actual |
+| — | `RESTART_IN_PROGRESS` | API only | Restart operation is in progress |
+| — | `RESTART_FAILED` | API only | Restart operation failed |
+
+> **Note:** CRD conditions use PascalCase (Kubernetes convention). Protobuf conditions use UPPER_SNAKE_CASE with prefix (e.g., `COMPUTE_INSTANCE_CONDITION_TYPE_AVAILABLE`). Restart conditions exist only in the protobuf API because restart functionality is implemented at the fulfillment service layer.
 
 The phase values are derived from the underlying KubeVirt `VirtualMachine.Status.PrintableStatus`, ensuring accurate representation of VM power state.
 
@@ -125,9 +126,9 @@ A tenant creates a ComputeInstance and observes its lifecycle through phases:
 
 Restart is not a separate phase. When a tenant restarts a VM:
 - Phase transitions: `Running` → `Stopping` → `Stopped` → `Starting` → `Running`
-- Condition `RestartInProgress` is set to `True` throughout the operation
-- On completion, `RestartInProgress` is set to `False`
-- On failure, phase becomes `Failed` and condition `RestartFailed` is set to `True`
+- Condition `RESTART_IN_PROGRESS` is set to `True` throughout the operation (API only)
+- On completion, `RESTART_IN_PROGRESS` is set to `False`
+- On failure, phase becomes `Failed` and condition `RESTART_FAILED` is set to `True`
 
 **State Transition Diagram**
 
@@ -161,25 +162,39 @@ This enhancement modifies existing API types rather than adding new CRDs or webh
 | Fulfillment API | `ComputeInstanceState` enum | Replace 4 values with 8 new phase values |
 | Fulfillment API | `ComputeInstanceConditionType` enum | Keep 3 conditions, remove 3, add 3 new |
 | Fulfillment Service | `ComputeInstanceState` enum | Mirror public API changes |
-| Fulfillment Service | `ComputeInstanceConditionType` enum | Mirror public API, rename REBOOT_* to RESTART_* |
+| Fulfillment Service | `ComputeInstanceConditionType` enum | Mirror public API changes |
 
-**Condition Changes:**
+**Phase Mapping (Current → Proposed):**
 
-| Condition | Action | Notes |
-|-----------|--------|-------|
-| `DEGRADED` | Keep | No changes |
-| `RESTART_IN_PROGRESS` | Keep | Private API: rename from REBOOT_IN_PROGRESS |
-| `RESTART_FAILED` | Keep | Private API: rename from REBOOT_FAILED |
-| `PROGRESSING` | Remove | Phase now represents this |
-| `READY` | Remove | Replaced by `Available` |
-| `FAILED` | Remove | Phase now represents this |
-| `Provisioned` | New | Infrastructure resources are allocated |
-| `Available` | New | VM is ready for user workloads |
-| `ConfigurationApplied` | New | Desired configuration matches actual |
+| Current (CRD) | Current (Protobuf) | Proposed (CRD) | Proposed (Protobuf) |
+|---------------|-------------------|----------------|---------------------|
+| `Progressing` | `PROGRESSING` | `Pending` | `PENDING` |
+| — | — | `Starting` | `STARTING` |
+| `Ready` | `READY` | `Running` | `RUNNING` |
+| — | — | `Stopping` | `STOPPING` |
+| — | — | `Stopped` | `STOPPED` |
+| — | — | `Paused` | `PAUSED` |
+| `Deleting` | — | `Deleting` | `DELETING` |
+| `Failed` | `FAILED` | `Failed` | `FAILED` |
+
+**Condition Mapping (Current → Proposed):**
+
+| Current (CRD) | Current (Protobuf) | Proposed (CRD) | Proposed (Protobuf) | Action |
+|---------------|-------------------|----------------|---------------------|--------|
+| `Accepted` | — | — | — | Remove (no longer needed) |
+| `Progressing` | `PROGRESSING` | — | — | Remove (phase represents this) |
+| `Available` | `READY` | `Available` | `AVAILABLE` | Rename in protobuf |
+| `Deleting` | — | — | — | Remove (phase represents this) |
+| — | `FAILED` | — | — | Remove (phase represents this) |
+| — | `DEGRADED` | `Degraded` | `DEGRADED` | Keep, add to CRD |
+| — | `RESTART_IN_PROGRESS` | — | `RESTART_IN_PROGRESS` | Keep (API only) |
+| — | `RESTART_FAILED` | — | `RESTART_FAILED` | Keep (API only) |
+| — | — | `Provisioned` | `PROVISIONED` | New |
+| — | — | `ConfigurationApplied` | `CONFIGURATION_APPLIED` | New |
 
 **Behavioral Changes:**
 
-- `ComputeInstance.status.phase` will reflect VM power state (Running, Stopped, Paused) rather than reconciliation status
+- `ComputeInstance.status.phase` will reflect VM power state (`Running`, `Stopped`, `Paused`) rather than reconciliation status
 - Conditions are orthogonal to phases - a condition like `Available` can be True or False independent of the phase
 
 ### Implementation Details/Notes/Constraints
@@ -232,7 +247,7 @@ The following table shows the expected values of `Available` and `Degraded` cond
 | osac-operator | `internal/controller/computeinstance_controller.go` | Update phase determination logic |
 | osac-operator | `internal/controller/computeinstance_feedback_controller.go` | Update phase-to-state mapping |
 | fulfillment-api | `proto/fulfillment/v1/compute_instance_type.proto` | Replace enum values |
-| fulfillment-service | `proto/private/v1/compute_instance_type.proto` | Replace enum values, rename REBOOT to RESTART |
+| fulfillment-service | `proto/private/v1/compute_instance_type.proto` | Replace enum values |
 
 **Migration Approach**
 

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -3,7 +3,7 @@ title: computeinstance-phase-condition-expansion
 authors:
   - Akshay Nadkarni
 creation-date: 2026-01-29
-last-updated: 2026-02-03
+last-updated: 2026-02-05
 tracking-link:
   - TBD
 see-also:

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -101,10 +101,10 @@ This enhancement modifies the `ComputeInstance` status model across three layers
 | `Available` | `AVAILABLE` | CRD + API | VM infrastructure is running and ready (does not indicate guest OS readiness) |
 | `ConfigurationApplied` | `CONFIGURATION_APPLIED` | CRD + API | Desired configuration matches actual |
 | `RestartRequired` | `RESTART_REQUIRED` | CRD + API | VM needs a restart for configuration changes to take effect |
-| — | `RESTART_IN_PROGRESS` | API only | Restart operation is in progress |
-| — | `RESTART_FAILED` | API only | Restart operation failed |
+| `RestartInProgress` | `RESTART_IN_PROGRESS` | CRD + API | Restart operation is in progress |
+| `RestartFailed` | `RESTART_FAILED` | CRD + API | Restart operation failed |
 
-> **Note:** CRD conditions use PascalCase (Kubernetes convention). Protobuf conditions use UPPER_SNAKE_CASE with prefix (e.g., `COMPUTE_INSTANCE_CONDITION_TYPE_AVAILABLE`). `RESTART_IN_PROGRESS` and `RESTART_FAILED` exist only in the protobuf API because restart operation tracking is implemented at the fulfillment service layer.
+> **Note:** CRD conditions use PascalCase (Kubernetes convention). Protobuf conditions use UPPER_SNAKE_CASE with prefix (e.g., `COMPUTE_INSTANCE_CONDITION_TYPE_AVAILABLE`).
 
 The phase values are derived from the underlying KubeVirt `VirtualMachine.Status.PrintableStatus`, ensuring accurate representation of VM power state.
 
@@ -126,9 +126,9 @@ A tenant creates a ComputeInstance and observes its lifecycle through phases:
 
 Restart is not a separate phase. When a tenant restarts a VM:
 - Phase transitions: `Running` → `Stopping` → `Stopped` → `Starting` → `Running`
-- Condition `RESTART_IN_PROGRESS` is set to `True` throughout the operation (API only)
-- On completion, `RESTART_IN_PROGRESS` is set to `False`
-- On failure, phase becomes `Failed` and condition `RESTART_FAILED` is set to `True`
+- Condition `RestartInProgress` is set to `True` throughout the operation
+- On completion, `RestartInProgress` is set to `False`
+- On failure, phase becomes `Failed` and condition `RestartFailed` is set to `True`
 
 **State Transition Diagram**
 
@@ -186,8 +186,8 @@ This enhancement modifies existing API types rather than adding new CRDs or webh
 | `Deleting` | — | — | — | Remove (phase represents this) |
 | — | `FAILED` | — | — | Remove (phase represents this) |
 | — | `DEGRADED` | — | — | Remove (see Open Questions) |
-| — | `RESTART_IN_PROGRESS` | — | `RESTART_IN_PROGRESS` | Keep (API only) |
-| — | `RESTART_FAILED` | — | `RESTART_FAILED` | Keep (API only) |
+| `RestartInProgress` | `RESTART_IN_PROGRESS` | `RestartInProgress` | `RESTART_IN_PROGRESS` | Keep |
+| `RestartFailed` | `RESTART_FAILED` | `RestartFailed` | `RESTART_FAILED` | Keep |
 | — | — | `Provisioned` | `PROVISIONED` | New |
 | — | — | `ConfigurationApplied` | `CONFIGURATION_APPLIED` | New |
 | — | — | `RestartRequired` | `RESTART_REQUIRED` | New |

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -101,48 +101,89 @@ As VMaaS matures to support full VM lifecycle operations, users need clear visib
 
 ## Proposal
 
-This section should explain what the proposal actually is. Enumerate
-*all* of the proposed changes at a *high level*, including all of the
-components that need to be modified and how they will be
-different. Include the reason for each choice in the design and
-implementation that is proposed here.
+This enhancement modifies the `ComputeInstance` status model across three layers:
 
-To keep this section succinct, document the details like API field
-changes, new images, and other implementation details in the
-**Implementation Details** section and record the reasons for not
-choosing alternatives in the **Alternatives** section at the end of
-the document.
+**1. OSAC Operator (Kubernetes CRD)**
+- Expand `ComputeInstancePhaseType` from 4 phases to 9 phases
+- Redesign `ComputeInstanceConditionType` to be orthogonal to phases
+
+**2. Fulfillment API (Public protobuf)**
+- Add corresponding `ComputeInstanceState` enum values
+- Update `ComputeInstanceConditionType` enum to match the orthogonal design
+- Deprecate old values (`PROGRESSING`, `READY`) while maintaining backward compatibility
+
+**3. Fulfillment Service (Private protobuf)**
+- Mirror public API changes
+- Fix RESTART/REBOOT terminology inconsistency
+
+**Proposed Phases (9):**
+
+| Phase | Description |
+|-------|-------------|
+| `Pending` | VM is being provisioned, infrastructure resources allocating |
+| `Starting` | VM is powering on, guest OS booting |
+| `Running` | VM is running and operational |
+| `Stopping` | VM is powering off, guest OS shutting down |
+| `Stopped` | VM is powered off, resources retained |
+| `Pausing` | VM memory state is being saved |
+| `Paused` | VM is paused, memory preserved, no CPU allocated |
+| `Deleting` | VM is being permanently deleted |
+| `Failed` | VM encountered an error |
+
+**Proposed Conditions (orthogonal to phases):**
+
+| Condition | Description |
+|-----------|-------------|
+| `Provisioned` | Infrastructure resources (compute, storage) are allocated |
+| `Available` | VM is ready for user workloads |
+| `Degraded` | VM is running but with reduced capability |
+| `ConfigurationApplied` | Desired configuration matches actual |
+| `RestartInProgress` | Restart operation is in progress |
+| `RestartFailed` | Restart operation failed |
+
+The phase values are derived from the underlying KubeVirt `VirtualMachine.Status.PrintableStatus`, ensuring accurate representation of VM power state.
 
 ### Workflow Description
 
-Explain how the user will use the feature. Be detailed and explicit.
-Describe all of the actors, their roles, and the APIs or interfaces
-involved. Define a starting state and then list the steps that the
-user would need to go through to trigger the feature described in the
-enhancement. Optionally add a
-[mermaid](https://github.com/mermaid-js/mermaid#readme) sequence
-diagram.
+**Phase Transitions**
 
-Use sub-sections to explain variations, such as for error handling,
-failure recovery, or alternative outcomes.
+A tenant creates a ComputeInstance and observes its lifecycle through phases:
 
-For example:
+1. **Create**: Tenant requests a new VM → Phase: `Pending`
+2. **Provisioning completes**: KubeVirt VM is created, booting → Phase: `Starting`
+3. **Boot completes**: VM is operational → Phase: `Running`
+4. **Stop requested**: Tenant stops the VM → Phase: `Stopping` → `Stopped`
+5. **Start requested**: Tenant starts the VM → Phase: `Starting` → `Running`
+6. **Pause requested**: Tenant pauses the VM → Phase: `Pausing` → `Paused`
+7. **Resume requested**: Tenant resumes the VM → Phase: `Running`
+8. **Delete requested**: Tenant deletes the VM → Phase: `Deleting` → (resource removed)
 
-**cluster creator** is a human user responsible for deploying a
-cluster.
+**Restart Handling**
 
-**application administrator** is a human user responsible for
-deploying an application in a cluster.
+Restart is not a separate phase. When a tenant restarts a VM:
+- Phase transitions: `Running` → `Stopping` → `Stopped` → `Starting` → `Running`
+- Condition `RestartInProgress` is set to `True` throughout the operation
+- On completion, `RestartInProgress` is set to `False`
+- On failure, phase becomes `Failed` and condition `RestartFailed` is set to `True`
 
-1. The cluster creator sits down at their keyboard...
-2. ...
-3. The cluster creator sees that their cluster is ready to receive
-   applications, and gives the application administrator their
-   credentials.
+**State Transition Diagram**
 
-See
-https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/management-workload-partitioning.md#high-level-end-to-end-workflow
-and https://github.com/openshift/enhancements/blob/master/enhancements/agent-installer/automated-workflow-for-agent-based-installer.md for more detailed examples.
+```
+[Create] → Pending → Starting → Running
+                                  │
+                ┌─────────────────┼─────────────────┐
+                ↓                 ↓                 ↓
+            Stopping          Pausing           Deleting
+                ↓                 ↓                 ↓
+            Stopped            Paused          (removed)
+                │                 │
+                └──→ Starting ←───┘
+                        ↓
+                     Running
+
+[Any state] → Failed (on error)
+[Any state] → Deleting → (removed)
+```
 
 ### API Extensions
 

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -22,7 +22,7 @@ The current 4-phase model (`Progressing`, `Ready`, `Failed`, `Deleting`) was des
 
 The redesign expands from 4 phases to 8 phases to properly represent the full VM lifecycle, aligning with industry standards from AWS, GCE, and KubeVirt. Conditions are redesigned to be orthogonal health indicators that complement, rather than duplicate, the lifecycle phase.
 
-> **Note:** You can find more details on industry standards [here](https://docs.google.com/document/d/1wgqAblnT7OHlT5bvaI4bi842kyeR3u4VfC_TAJXbGcI/edit?tab=t.oocbc3frwt7c). 
+> **Note:** You can find more details on industry standards [here](https://docs.google.com/document/d/1wgqAblnT7OHlT5bvaI4bi842kyeR3u4VfC_TAJXbGcI/edit?tab=t.oocbc3frwt7c).
 
 This change enables users to understand VM power state (running, stopped, paused), see transitional progress (starting, stopping), and receive clear health signals through conditions - providing the operational visibility expected from a modern cloud platform.
 

--- a/enhancements/computeinstance-phase-condition-expansion/README.md
+++ b/enhancements/computeinstance-phase-condition-expansion/README.md
@@ -1,54 +1,18 @@
 ---
-title: neat-enhancement-idea
+title: computeinstance-phase-condition-expansion
 authors:
-  - TBD
-creation-date: yyyy-mm-dd
-last-updated: yyyy-mm-dd
-tracking-link: # link to the tracking ticket (for example: Github issue) that corresponds to this enhancement
+  - Akshay Nadkarni
+creation-date: 2026-01-29
+last-updated: 2026-01-29
+tracking-link:
   - TBD
 see-also:
-  - "/enhancements/this-other-neat-thing"
 replaces:
-  - "/enhancements/that-less-than-great-idea"
+  - "[ComputeInstance-VM_PhasesAndConditions_Proposal (Google Doc)](https://docs.google.com/document/d/1wgqAblnT7OHlT5bvaI4bi842kyeR3u4VfC_TAJXbGcI/edit?usp=sharing)"
 superseded-by:
-  - "/enhancements/our-past-effort"
 ---
 
-To get started with this template:``
-1. **Create a directory.** Create the directory for your enhancement proposal.
-1. **Make a copy of this template.** Copy this template into the directory for
-   the proposal as `README.md`.
-1. **Fill out the metadata at the top.** The embedded YAML document is
-   checked by the linter.
-1. **Fill out the "overview" sections.** This includes the Summary and
-   Motivation sections. These should be easy and explain why the community
-   should desire this enhancement.
-1. **Create a PR.** Assign it to folks with expertise in that domain to help
-   sponsor the process.
-1. **Merge after reaching consensus.** Merge when there is consensus
-   that the design is complete and all reviewer questions have been
-   answered so that work can begin.  Come back and update the document
-   if important details (API field names, workflow, etc.) change
-   during code review.
-1. **Keep all required headers.** If a section does not apply to an
-   enhancement, explain why but do not remove the section. This part
-   of the process is enforced by the linter CI job.
-
-See ../README.md for background behind these instructions.
-
-Start by filling out the header with the metadata for this enhancement.
-
-# Neat Enhancement Idea
-
-This is the title of the enhancement. Keep it simple and descriptive. A good
-title can help communicate what the enhancement is and should be considered as
-part of any review.
-
-The YAML `title` should be lowercased and spaces/punctuation should be
-replaced with `-`.
-
-The `Metadata` section above is intended to support the creation of tooling
-around the enhancement process.
+# ComputeInstance Phase and Condition Expansion
 
 ## Summary
 


### PR DESCRIPTION
## Summary

This PR adds a new enhancement proposal for expanding ComputeInstance phases and conditions to support full VM lifecycle operations.

**Key Changes:**
- Expand from 4 phases to 8 phases to represent VM power states (Running, Stopped, Paused) and transitions (Starting, Stopping)
- Refactor conditions to be orthogonal to phases, representing health/status rather than duplicating lifecycle state
- Align with industry standards (AWS, GCE, KubeVirt)

## What's Proposed

| Area | Current | Proposed |
|------|---------|----------|
| Phases | 4 (`Progressing`, `Ready`, `Failed`, `Deleting`) | 8 (`Pending`, `Starting`, `Running`, `Stopping`, `Stopped`, `Paused`, `Deleting`, `Failed`) |
| Conditions | Overlap with phases | Orthogonal health indicators (`Provisioned`, `Available`, `Degraded`, `ConfigurationApplied`) |
| Migration | — | Clean break (remove old values, no deprecation) |

## Layers Affected

- **OSAC Operator**: Expand CRD phase/condition types
- **Fulfillment API**: Update protobuf enums
- **Fulfillment Service**: Mirror public API changes

## Document Structure

- Summary & Motivation with user stories for Tenants, Cloud Providers, and Developers
- Detailed proposal with phase/condition tables and state transition diagram
- Mapping tables showing current → proposed values for both CRD and protobuf layers
- Implementation details including KubeVirt mapping and condition semantics
- Risks, drawbacks, and alternatives considered

## Related

Replaces: [ComputeInstance-VM_PhasesAndConditions_Proposal (Google Doc)](https://docs.google.com/document/d/1wgqAblnT7OHlT5bvaI4bi842kyeR3u4VfC_TAJXbGcI/edit?usp=sharing)