### PR TITLE
MGMT-23499: add storage tier support to tenant-specific StorageClasses

### DIFF
--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -3,9 +3,9 @@ title: tenant-storage-tiers
 authors:
   - akshaynadkarni
 creation-date: 2026-03-26
-last-updated: 2026-03-31
+last-updated: 2026-04-20
 tracking-link:
-  - TBD
+  - https://redhat.atlassian.net/browse/MGMT-23669
 see-also:
   - "/enhancements/tenant-specific-storageclasses"
 replaces:
@@ -288,12 +288,12 @@ parameters:
 status:
   phase: Ready
   storageClasses:
-    - storageClassName: "ceph-shared-default"
-      storageTier: "default"
-    - storageClassName: "ceph-acme-fast"
-      storageTier: "fast"
-    - storageClassName: "ceph-acme-slow"
-      storageTier: "slow"
+    - name: "ceph-shared-default"
+      tier: "default"
+    - name: "ceph-acme-fast"
+      tier: "fast"
+    - name: "ceph-acme-slow"
+      tier: "slow"
 ```
 
 **Expected result:** `tenant-acme` has three resolved tiers. The `fast` and
@@ -452,14 +452,14 @@ status:
   phase: Ready
   namespace: "tenant-acme-ns"
   storageClasses:
-    - storageClassName: "ceph-acme-default"
-      storageTier: "default"
-    - storageClassName: "ceph-acme-fast"
-      storageTier: "fast"
-    - storageClassName: "ceph-acme-standard"
-      storageTier: "standard"
-    - storageClassName: "ceph-shared-archival"
-      storageTier: "archival"
+    - name: "ceph-acme-default"
+      tier: "default"
+    - name: "ceph-acme-fast"
+      tier: "fast"
+    - name: "ceph-acme-standard"
+      tier: "standard"
+    - name: "ceph-shared-archival"
+      tier: "archival"
 ```
 
 Each entry in `storageClasses` is either a tenant-specific StorageClass or a
@@ -471,18 +471,18 @@ Go type:
 
 ```go
 type ResolvedStorageClass struct {
-    // StorageClassName is the name of the resolved StorageClass.
+    // Name is the name of the resolved StorageClass.
     // +kubebuilder:validation:Required
     // +kubebuilder:validation:MinLength=1
-    StorageClassName string `json:"storageClassName"`
+    Name string `json:"name"`
 
-    // StorageTier is the storage tier this StorageClass provides,
+    // Tier is the storage tier this StorageClass provides,
     // taken from the osac.openshift.io/storage-tier label.
     // +kubebuilder:validation:Required
     // +kubebuilder:validation:MinLength=1
     // +kubebuilder:validation:MaxLength=63
     // +kubebuilder:validation:Pattern=`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`
-    StorageTier string `json:"storageTier"`
+    Tier string `json:"tier"`
 }
 ```
 
@@ -525,8 +525,7 @@ with `osac.openshift.io/tenant=<tenantName>` or
      the Tenant level; individual provisioning requests that ask for this
      tier will fail at the Ansible role level).
 
-The resolved list is stored in `tenant.status.storageClasses`. Downstream
-consumers never implement fallback logic; they look up the requested tier in
+The resolved list is stored in `tenant.status.storageClasses`. Consumers never implement fallback logic; they look up the requested tier in
 the pre-resolved list.
 
 #### Tier selection at provisioning time
@@ -602,8 +601,8 @@ The `tenant_storage_class` role currently reads `tenant.status.storageClass`
 2. **Require** the `tenant_storage_class_storage_tier` input parameter (no
    default value). Fail immediately if the parameter is not provided, with an
    error message listing available tiers.
-3. Find the entry in the list whose `storageTier` matches the request.
-4. Set `tenant_storage_class_name` to the matching `storageClassName`.
+3. Find the entry in the list whose `tier` matches the request.
+4. Set `tenant_storage_class_name` to the matching `name`.
 5. Fail with a descriptive error if the requested tier is not in the list,
    including the available tiers.
 
@@ -888,7 +887,7 @@ This was rejected because:
 - Upgrade to the new controller.
 - Verify:
   - `status.storageClasses` (list) is populated with one entry:
-    `{storageClassName: "...", storageTier: "default"}`.
+    `{name: "...", tier: "default"}`.
   - `status.storageClass` (singular) is no longer present.
   - Templates updated to pass `tenant_storage_class_storage_tier: "default"`
     continue to provision successfully.

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -98,10 +98,12 @@ StorageClass. The new `osac.openshift.io/storage-tier` label identifies *what
 kind* of storage it provides.
 
 Each StorageClass is identified by a composite key: `(tenant, storage-tier)`.
-The `tenant` axis retains its existing fallback behavior (tenant-specific, then
-shared `Default`). The `storage-tier` axis is an exact match with no fallback:
-both labels are required on every StorageClass that participates in OSAC storage
-resolution.
+The two axes have different resolution rules. The `tenant` axis retains its
+existing fallback behavior (tenant-specific, then shared `Default`), and this
+fallback is applied independently per tier. The `storage-tier` axis is an exact
+match with no inter-tier fallback: a request for tier `fast` never silently
+resolves to `standard`. Both labels are required on every StorageClass that
+participates in OSAC storage resolution.
 
 Tier names are freeform: CSPs choose values that make sense for their storage
 offering (e.g., `fast`, `standard`, `archival`, `default`). OSAC does not
@@ -361,10 +363,10 @@ Both the tenant label and the storage-tier label are required on every
 StorageClass that participates in OSAC storage resolution. The Tenant
 controller ignores StorageClasses that are missing either label.
 
-| Label key | Required | Values | Default if absent |
+| Label key | Required | Values | Behavior when absent |
 |---|---|---|---|
-| `osac.openshift.io/tenant` | Yes | `<tenantName>` or `Default` | N/A (required) |
-| `osac.openshift.io/storage-tier` | Yes | Lowercase Kubernetes label value (e.g., `fast`, `standard`, `archival`, `nvme-1`, `default`) | N/A (required) |
+| `osac.openshift.io/tenant` | Yes | `<tenantName>` or `Default` | StorageClass ignored |
+| `osac.openshift.io/storage-tier` | Yes | Lowercase Kubernetes label value (e.g., `fast`, `standard`, `archival`, `nvme-1`, `default`) | StorageClass ignored |
 
 The `osac.openshift.io/tenant` label retains the `Default` (capitalized)
 sentinel convention for shared StorageClasses. The `osac.openshift.io/tenant`
@@ -442,10 +444,16 @@ Go type:
 ```go
 type ResolvedStorageClass struct {
     // StorageClassName is the name of the resolved StorageClass.
+    // +kubebuilder:validation:Required
+    // +kubebuilder:validation:MinLength=1
     StorageClassName string `json:"storageClassName"`
 
     // StorageTier is the storage tier this StorageClass provides,
     // taken from the osac.openshift.io/storage-tier label.
+    // +kubebuilder:validation:Required
+    // +kubebuilder:validation:MinLength=1
+    // +kubebuilder:validation:MaxLength=63
+    // +kubebuilder:validation:Pattern=`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`
     StorageTier string `json:"storageTier"`
 }
 ```
@@ -635,12 +643,17 @@ environments.
 
 Add the `osac.openshift.io/storage-tier` label to every existing StorageClass
 that has an `osac.openshift.io/tenant` label. For StorageClasses that serve as
-the general-purpose tier, use the conventional value `default`:
+the general-purpose tier, use the conventional value `default`.
+
+The script below only labels StorageClasses that do not already have a
+`storage-tier` label, so it is safe to run multiple times:
 
 ```bash
-# Find all OSAC-managed StorageClasses and add the tier label
-for sc in $(oc get storageclass -l osac.openshift.io/tenant \
+# Label OSAC-managed StorageClasses that are missing a storage-tier label
+for sc in $(oc get storageclass \
+  -l osac.openshift.io/tenant,\!osac.openshift.io/storage-tier \
   -o jsonpath='{.items[*].metadata.name}'); do
+  echo "Labeling $sc with storage-tier=default"
   oc label storageclass "$sc" osac.openshift.io/storage-tier=default
 done
 ```

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -374,7 +374,8 @@ Storage tier values are freeform. OSAC does not define a fixed vocabulary or
 treat any tier name as special. CSPs choose tier names that make sense for
 their storage offering. Recommended conventions include `fast`, `standard`,
 `archival`, and `default`, but these are documentation guidance, not enforced
-constraints. Tier values must conform to Kubernetes label value syntax:
+constraints. Tier values must be lowercase and conform to Kubernetes label
+value syntax:
 alphanumeric, dashes, dots, and underscores, up to 63 characters, beginning
 and ending with an alphanumeric character.
 

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -120,6 +120,14 @@ This proposal assumes the following:
    individual storage pools or volumes. Tier names are expected to change
    infrequently, on the order of storage infrastructure changes.
 
+4. **A shared StorageClass with tier `default` exists on every VMaaS
+   cluster.** OSAC-shipped templates use the conventional tier name `default`.
+   For these templates to work out of the box, a shared StorageClass with
+   `osac.openshift.io/tenant: Default` and
+   `osac.openshift.io/storage-tier: default` must exist. See
+   [OSAC-shipped templates and the `default` tier convention](#osac-shipped-templates-and-the-default-tier-convention)
+   for details.
+
 ## Proposal
 
 This proposal adds a second label axis to the StorageClass labeling convention.
@@ -139,7 +147,10 @@ Tier names are freeform: CSPs choose values that make sense for their storage
 offering (e.g., `fast`, `standard`, `archival`, `default`). OSAC does not
 define a fixed vocabulary or treat any tier name as special. A CSP that wants a
 general-purpose tier can label it `default` (lowercase, by convention), but the
-controller does not assign it any magic behavior.
+controller does not assign it any magic behavior. OSAC-shipped templates use
+the tier name `default` so they work on any deployment without customization.
+A shared StorageClass with `tenant: Default` and `storage-tier: default` is
+expected on every VMaaS cluster.
 
 ### Workflow Description
 
@@ -406,7 +417,10 @@ Storage tier values are currently freeform. OSAC does not define a fixed
 vocabulary or treat any tier name as special. CSPs choose tier names that make
 sense for their storage offering. Recommended conventions include `fast`,
 `standard`, `archival`, and `default`, but these are documentation guidance,
-not enforced constraints. As noted in [Assumptions](#assumptions), an external
+not enforced constraints. However, OSAC-shipped templates rely on the tier name
+`default`; a shared StorageClass with `tenant: Default, storage-tier: default`
+is expected on every VMaaS cluster for these templates to work out of the box.
+As noted in [Assumptions](#assumptions), an external
 system will own the source of truth for valid tier names. A future proposal
 addressing tier discovery and StorageClass lifecycle management may introduce
 validation of tier names against that registry. Tier values must be lowercase and conform to Kubernetes label

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -1,0 +1,798 @@
+---
+title: tenant-storage-tiers
+authors:
+  - akshaynadkarni
+creation-date: 2026-03-26
+last-updated: 2026-03-26
+tracking-link:
+  - TBD
+see-also:
+  - "/enhancements/tenant-specific-storageclasses"
+replaces:
+superseded-by:
+---
+
+# Tenant Storage Tiers
+
+## Summary
+
+This proposal extends the tenant-specific StorageClass mechanism introduced in
+[tenant-specific-storageclasses](/enhancements/tenant-specific-storageclasses) to
+support multiple storage tiers per tenant. A CSP may need to offer different
+classes of storage to each tenant, for example fast NVMe storage for databases
+alongside slower HDD storage for archival. This proposal adds an optional
+`osac.openshift.io/storage-tier` label to StorageClasses, evolves
+`tenant.status.storageClass` (string) to `tenant.status.storageClasses` (list),
+and updates the `tenant_storage_class` Ansible role to accept a storage tier
+parameter so that consumers can select the appropriate StorageClass for a given
+workload.
+
+This proposal focuses on the infrastructure layer: tier labeling, resolution,
+and selection. How the tier value reaches the Ansible role (whether from a VM
+template or a user-facing API field) is a consumption pattern that this proposal
+describes at a high level but does not prescribe.
+
+## Motivation
+
+The current implementation supports exactly one StorageClass per tenant (or a
+shared Default). As OSAC matures, CSPs will need to differentiate storage
+offerings within a single tenant. For example, a tenant running a database
+workload needs fast SSD-backed storage, while the same tenant's archival VMs
+can use cheaper, slower storage. Without storage tiers, CSPs would need to
+either over-provision expensive storage for all workloads or maintain manual
+workarounds outside of OSAC.
+
+### User Stories
+
+As a **CSP Admin**, I want to configure multiple StorageClasses for a single
+tenant with different performance characteristics (fast, standard, archival) so
+that tenants can run diverse workloads at appropriate cost points.
+
+As a **CSP Admin**, I want to provide shared Default StorageClasses at different
+tiers so that tenants without dedicated storage still have access to tiered
+storage options.
+
+As a **Tenant Admin**, I want to create VM templates that automatically select
+the right storage tier for their workload type (e.g., a database template uses
+fast storage, an archival template uses standard storage) so that my users do
+not need to think about storage infrastructure.
+
+As a **CSP Admin**, I want the system to be backward compatible so that existing
+single-StorageClass-per-tenant configurations continue working without any
+changes.
+
+### Goals
+
+* Enable CSPs to offer multiple storage tiers per tenant using labels on
+  StorageClasses.
+* Expose all resolved storage tiers in the Tenant status so that any consumer
+  (VM templates, Ansible roles, future API fields) can select the appropriate
+  StorageClass by tier.
+* Maintain full backward compatibility with the existing single StorageClass
+  per tenant model.
+* Keep the Tenant controller as the single source of truth for StorageClass
+  resolution. Consumers (Ansible, CI controller) read from Tenant status, not
+  from StorageClass labels directly.
+
+### Non-Goals
+
+* Storage quota enforcement per tier. Quota is a separate concern that may be
+  addressed by a future enhancement.
+* Automated StorageClass provisioning. The CSP Admin remains responsible for
+  creating StorageClasses and their backing storage.
+* Dynamic tier negotiation. Tiers are static labels; the CSP defines what tiers
+  are available.
+* Prescribing the mechanism by which the tier value reaches the provisioning
+  layer. This proposal builds the infrastructure; the consumption pattern
+  (template-driven, user-facing, or hybrid) is discussed but not mandated.
+
+## Proposal
+
+This proposal adds a second, optional label axis to the StorageClass labeling
+convention. The existing `osac.openshift.io/tenant` label identifies *which
+tenant* owns a StorageClass. The new `osac.openshift.io/storage-tier` label
+identifies *what kind* of storage it provides.
+
+Each StorageClass is identified by a composite key: `(tenant, storage-tier)`.
+The `tenant` axis retains its existing fallback behavior (tenant-specific, then
+shared `Default`). The `storage-tier` axis is an exact match that defaults to
+`Default` when absent.
+
+The `Default` sentinel value follows the same convention established for the
+`osac.openshift.io/tenant` label: real values are lowercase (`fast`,
+`standard`, `archival`), and the sentinel/fallback value is capitalized
+(`Default`). This keeps the labeling convention predictable across both axes.
+
+### Workflow Description
+
+#### Personas
+
+| Persona | Role | Relevant actions |
+|---|---|---|
+| **CSP Admin** | Cloud Provider Admin (infrastructure) | Creates StorageClasses with tenant and tier labels |
+| **Tenant Admin** | Tenant organization administrator | Creates and configures VM templates for their users |
+| **Tenant User** | End user within a tenant organization | Creates ComputeInstances using available templates |
+
+#### Workflow 1: CSP Admin configures tiered storage for a tenant
+
+**Actors:** CSP Admin
+
+**Starting state:** A tenant `tenant-acme` exists. The CSP has provisioned
+fast and standard storage pools in their storage solution.
+
+1. The CSP Admin creates two StorageClasses on the virtualization cluster,
+   each labeled with the tenant and the appropriate tier:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-acme-fast
+  labels:
+    osac.openshift.io/tenant: tenant-acme
+    osac.openshift.io/storage-tier: fast
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  pool: acme-ssd-pool
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-acme-standard
+  labels:
+    osac.openshift.io/tenant: tenant-acme
+    osac.openshift.io/storage-tier: standard
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  pool: acme-hdd-pool
+```
+
+2. The Tenant controller detects the new StorageClasses via its watch,
+   reconciles, and populates `tenant.status.storageClasses` with both
+   resolved entries.
+
+3. The Tenant phase remains `Ready` because at least one StorageClass is
+   available.
+
+**Expected result:** `tenant-acme` has two resolved storage tiers in its
+status. VM templates and provisioning roles can now select either `fast` or
+`standard` storage.
+
+#### Workflow 2: Backward-compatible single StorageClass (no storage-tier label)
+
+**Actors:** CSP Admin
+
+**Starting state:** The CSP has a single StorageClass per tenant, labeled with
+only `osac.openshift.io/tenant` (no `storage-tier` label). This is the
+configuration that exists today.
+
+1. The existing StorageClass has no `osac.openshift.io/storage-tier` label:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-acme
+  labels:
+    osac.openshift.io/tenant: tenant-acme
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  pool: acme-pool
+```
+
+2. The Tenant controller treats the missing `storage-tier` label as
+   `storage-tier: Default`.
+
+3. `tenant.status.storageClasses` contains a single entry with
+   `storageTier: "Default"`. The backward-compatible
+   `tenant.status.storageClass` field also contains the StorageClass name.
+
+**Expected result:** The tenant continues to work exactly as before. No
+configuration changes are required. Consumers that do not specify a tier
+automatically use the `Default` tier.
+
+#### Workflow 3: CSP Admin configures shared Default storage tiers
+
+**Actors:** CSP Admin
+
+**Starting state:** The CSP wants to provide shared storage tiers that any
+tenant without a dedicated StorageClass can use.
+
+1. The CSP Admin creates shared Default StorageClasses with tier labels:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-shared-fast
+  labels:
+    osac.openshift.io/tenant: Default
+    osac.openshift.io/storage-tier: fast
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  pool: shared-ssd-pool
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-shared-standard
+  labels:
+    osac.openshift.io/tenant: Default
+    osac.openshift.io/storage-tier: standard
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  pool: shared-hdd-pool
+```
+
+2. For tenants that have no dedicated StorageClass for a given tier, the
+   Tenant controller falls back to the shared Default StorageClass for that
+   tier. The fallback is applied independently per tier.
+
+**Expected result:** Tenants without dedicated storage still have access to
+tiered storage options through the shared Defaults.
+
+**Note:** A shared Default StorageClass without a `storage-tier` label is
+treated as `(tenant: Default, storage-tier: Default)`, following the same
+rule as Workflow 2. This is the configuration that exists today and continues
+to work without changes.
+
+#### Workflow 4: Mixed tenant-specific and shared Default tiers
+
+**Actors:** CSP Admin
+
+**Starting state:** The CSP has a shared Default StorageClass (no tier label)
+for all tenants, and has configured tenant-specific `fast` and `slow`
+StorageClasses for `tenant-acme`.
+
+StorageClasses on the cluster:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-shared-default
+  labels:
+    osac.openshift.io/tenant: Default
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  pool: shared-pool
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-acme-fast
+  labels:
+    osac.openshift.io/tenant: tenant-acme
+    osac.openshift.io/storage-tier: fast
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  pool: acme-ssd-pool
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-acme-slow
+  labels:
+    osac.openshift.io/tenant: tenant-acme
+    osac.openshift.io/storage-tier: slow
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  pool: acme-hdd-pool
+```
+
+1. The Tenant controller resolves each tier independently for `tenant-acme`:
+   - `fast`: tenant-specific SC found (`ceph-acme-fast`).
+   - `slow`: tenant-specific SC found (`ceph-acme-slow`).
+   - `Default`: no tenant-specific SC without a tier label. Falls back to the
+     shared Default SC (`ceph-shared-default`).
+
+2. The resulting Tenant status:
+
+```yaml
+status:
+  phase: Ready
+  storageClass: "ceph-shared-default"
+  storageClasses:
+    - storageClassName: "ceph-shared-default"
+      storageTier: "Default"
+    - storageClassName: "ceph-acme-fast"
+      storageTier: "fast"
+    - storageClassName: "ceph-acme-slow"
+      storageTier: "slow"
+```
+
+**Expected result:** `tenant-acme` has three resolved tiers. The `fast` and
+`slow` tiers use tenant-specific StorageClasses. The `Default` tier falls back
+to the shared Default StorageClass. `status.storageClass` (singular) contains
+the shared Default SC name, so backward-compatible consumers continue to work.
+
+#### Workflow 5: Template-driven tier selection during provisioning (Strategy A)
+
+**Actors:** Tenant Admin (creates the template), Tenant User (creates the CI)
+
+**Starting state:** `tenant-acme` has `fast` and `standard` tiers resolved.
+The Tenant Admin has created a `database_vm` template that is configured to
+use `fast` storage for boot disks.
+
+1. The Tenant User creates a ComputeInstance using the database template:
+
+```yaml
+apiVersion: osac.openshift.io/v1alpha1
+kind: ComputeInstance
+metadata:
+  name: db-server-01
+spec:
+  templateID: osac.templates.database_vm
+  cores: 4
+  memoryGiB: 16
+  bootDisk:
+    sizeGiB: 100
+  image:
+    sourceType: registry
+    sourceRef: "quay.io/containerdisks/fedora:latest"
+  runStrategy: Always
+```
+
+2. The CI controller triggers provisioning. The `tenant_storage_class` Ansible
+   role receives the full `tenant.status.storageClasses` list.
+
+3. The `database_vm` template role requests tier `fast` from the
+   `tenant_storage_class` role, which resolves it to `ceph-acme-fast`.
+
+4. The template creates the DataVolume with `storageClassName: ceph-acme-fast`.
+
+**Expected result:** The user did not need to specify a storage tier. The
+template knew which tier to use for a database workload. The
+`tenant_storage_class` role resolved the tier to the correct StorageClass.
+
+#### Workflow 6: Default tier selection (no tier specified)
+
+**Actors:** Tenant User
+
+**Starting state:** `tenant-acme` has at least a `Default` tier resolved.
+
+1. The Tenant User creates a ComputeInstance using a generic template that does
+   not specify a storage tier:
+
+```yaml
+apiVersion: osac.openshift.io/v1alpha1
+kind: ComputeInstance
+metadata:
+  name: web-server-01
+spec:
+  templateID: osac.templates.ocp_virt_vm
+  cores: 2
+  memoryGiB: 4
+  bootDisk:
+    sizeGiB: 20
+  image:
+    sourceType: registry
+    sourceRef: "quay.io/containerdisks/fedora:latest"
+  runStrategy: Always
+```
+
+2. The `tenant_storage_class` role defaults to tier `"Default"` when no tier
+   is specified and resolves it from `tenant.status.storageClasses`.
+
+**Expected result:** All disks use the `Default` tier StorageClass. This is
+identical to the current single-StorageClass behavior.
+
+#### Workflow 7: Requested storage tier is not available
+
+**Actors:** Tenant User (indirectly, via a template that requests an
+unavailable tier)
+
+**Starting state:** `tenant-acme` has only `Default` and `standard` tiers.
+A template requests `fast` storage.
+
+1. The `tenant_storage_class` role attempts to resolve tier `fast` from
+   `tenant.status.storageClasses` but finds no matching entry.
+
+2. The role fails with a descriptive error:
+
+   > Storage tier "fast" is not available for tenant "tenant-acme".
+   > Available tiers: Default, standard.
+
+3. The ComputeInstance transitions to `Failed` with a descriptive message.
+
+**Expected result:** The provisioning fails with a clear error identifying the
+missing tier and listing the available alternatives.
+
+### API Extensions
+
+#### StorageClass labels
+
+A new optional label is added alongside the existing tenant label:
+
+| Label key | Required | Values | Default if absent |
+|---|---|---|---|
+| `osac.openshift.io/tenant` | Yes | `<tenantName>` or `Default` | N/A (required) |
+| `osac.openshift.io/storage-tier` | No | Any lowercase alphanumeric string (e.g., `fast`, `standard`, `archival`, `nvme`) | `Default` |
+
+Both label axes use the same sentinel convention: real values are lowercase,
+and the sentinel/fallback value is `Default` (capitalized). This is consistent
+with the `osac.openshift.io/tenant: Default` convention established in the
+predecessor proposal, where capitalization prevents collisions with actual
+resource names (which are always lowercase in Kubernetes).
+
+Storage tier values are freeform. OSAC does not define a fixed vocabulary.
+CSPs choose tier names that make sense for their storage offering. Tier values
+must conform to Kubernetes label value syntax: alphanumeric, dashes, dots, and
+underscores, up to 63 characters, beginning and ending with an alphanumeric
+character.
+
+**Example: Tenant-specific StorageClass with a storage tier**
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: netapp-tenant123-fast
+  labels:
+    osac.openshift.io/tenant: tenant123
+    osac.openshift.io/storage-tier: fast
+provisioner: csi.trident.netapp.io
+parameters:
+  backendType: "ontap-nas"
+  media: "ssd"
+```
+
+**Example: Shared Default StorageClass with a storage tier**
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: netapp-shared-standard
+  labels:
+    osac.openshift.io/tenant: Default
+    osac.openshift.io/storage-tier: standard
+provisioner: csi.trident.netapp.io
+parameters:
+  backendType: "ontap-nas"
+  media: "hdd"
+```
+
+**Example: StorageClass without a storage-tier label (treated as `Default`)**
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: netapp-tenant123
+  labels:
+    osac.openshift.io/tenant: tenant123
+provisioner: csi.trident.netapp.io
+parameters:
+  backendType: "ontap-nas"
+```
+
+#### Tenant CRD status changes
+
+The singular `status.storageClass` field (string) is replaced by a
+`status.storageClasses` list that captures all resolved StorageClass mappings
+for the tenant:
+
+```yaml
+status:
+  phase: Ready
+  namespace: "tenant-acme-ns"
+  storageClass: "ceph-acme-default"       # Default tier (= storageClasses entry with storageTier: Default)
+  storageClasses:
+    - storageClassName: "ceph-acme-default"    # tenant-specific
+      storageTier: "Default"
+    - storageClassName: "ceph-acme-fast"       # tenant-specific
+      storageTier: "fast"
+    - storageClassName: "ceph-acme-standard"   # tenant-specific
+      storageTier: "standard"
+    - storageClassName: "ceph-shared-archival" # resolved from shared Default fallback
+      storageTier: "archival"
+```
+
+Each entry in `storageClasses` is either a tenant-specific StorageClass or a
+shared Default StorageClass resolved via fallback. A tenant only sees its own
+StorageClasses and the shared Defaults; it never sees StorageClasses belonging
+to other tenants.
+
+Go type:
+
+```go
+type ResolvedStorageClass struct {
+    // StorageClassName is the name of the resolved StorageClass
+    StorageClassName string `json:"storageClassName"`
+
+    // StorageTier is the storage tier this StorageClass provides.
+    // Set to "Default" when the StorageClass has no
+    // osac.openshift.io/storage-tier label.
+    StorageTier string `json:"storageTier"`
+}
+```
+
+The `tenant` value is NOT included in `ResolvedStorageClass` because the Tenant
+CR itself is the tenant context. The tenant-to-Default fallback has already been
+applied by the time the resolved list is populated.
+
+**Backward compatibility:** The existing `status.storageClass` (string) field
+is kept as a convenience accessor for the `Default` tier. When a StorageClass
+resolves with tier `Default` (either explicitly labeled or with no tier label),
+`status.storageClass` contains its name. This allows consumers that are not yet
+tier-aware to continue working without changes.
+
+If no `Default` tier resolves for a tenant (neither a tenant-specific SC
+without a tier label, nor a shared Default SC without a tier label),
+`status.storageClass` will be empty, even if other tiers (`fast`, `standard`)
+resolved successfully. Consumers that are not tier-aware would fail in this
+case, which is the correct signal: the CSP must configure a `Default` tier
+(tenant-specific or shared) for backward compatibility. This edge case is
+related to Open Question #1 (whether the Tenant should require a `Default`
+tier to be `Ready`).
+
+### Implementation Details/Notes/Constraints
+
+#### Resolution algorithm
+
+The Tenant controller resolves **all available tier combinations** for each
+tenant at reconciliation time. For each distinct `storage-tier` value `T` found
+across all StorageClasses labeled with `osac.openshift.io/tenant`:
+
+1. Find StorageClasses labeled `osac.openshift.io/tenant=<tenantName>` AND
+   `osac.openshift.io/storage-tier=T` (or no `storage-tier` label when
+   `T` is `Default`).
+   - Exactly one: use it.
+   - More than one: duplicate error for this tier (same as the existing
+     behavior for the single-tier case).
+   - None: proceed to step 2.
+
+2. Find StorageClasses labeled `osac.openshift.io/tenant=Default` AND
+   `osac.openshift.io/storage-tier=T` (or no `storage-tier` label when
+   `T` is `Default`).
+   - Exactly one: use it (shared Default fallback for this tier).
+   - More than one: duplicate error for this tier.
+   - None: tier `T` is not available for this tenant (not an error at
+     the Tenant level; individual provisioning requests that ask for this
+     tier will fail at the Ansible role level).
+
+The resolved list is stored in `tenant.status.storageClasses`. Downstream
+consumers never implement fallback logic; they look up the requested tier in
+the pre-resolved list.
+
+#### Tier selection at provisioning time
+
+The `tenant_storage_class` Ansible role is the selection interface. It accepts
+a `storage_tier` input parameter (defaulting to `"Default"`) and resolves it
+against the tenant's `status.storageClasses` list.
+
+**Who provides the `storage_tier` value** is a separate concern from how the
+role resolves it. This proposal identifies three strategies:
+
+**Strategy A: Template-driven (recommended initial approach).** The VM template
+role (e.g., `osac.templates.database_vm`) hardcodes which tier each disk needs.
+The template author chooses the tier based on the workload type. The tenant
+user selects a template when creating a ComputeInstance and does not need to
+know about storage tiers.
+
+```yaml
+# Inside osac.templates.database_vm/tasks/create.yaml
+- name: Resolve boot disk StorageClass
+  ansible.builtin.include_role:
+    name: osac.service.tenant_storage_class
+  vars:
+    tenant_storage_class_storage_tier: "fast"
+```
+
+**Strategy B: User-facing DiskSpec field.** A `storageTier` field is added to
+the ComputeInstance `DiskSpec`. The CI controller or Ansible role reads the
+field from the CI spec and passes it to the `tenant_storage_class` role. This
+gives users direct control over storage selection but exposes infrastructure
+details.
+
+**Strategy C: Hybrid.** The template sets a default tier, and a user-facing
+field can override it. This provides flexibility while keeping the common case
+simple.
+
+All three strategies use the same underlying infrastructure: the
+`tenant_storage_class` role receives a `storage_tier` parameter and resolves it
+from `tenant.status.storageClasses`. The initial implementation targets
+Strategy A.
+
+#### StorageClassReady condition updates
+
+The existing `StorageClassReady` condition is extended:
+
+- `Ready` requires at least one tier to resolve successfully.
+- Duplicate detection applies per tier. Two StorageClasses for `(tenantX,
+  fast)` produces a `MultipleFound` condition, but does not affect
+  `(tenantX, standard)`.
+- The condition message lists which tiers resolved successfully and which
+  had errors.
+
+#### Ansible role changes
+
+The `tenant_storage_class` role currently reads `tenant.status.storageClass`
+(a single string) and sets `tenant_storage_class_name`. It will be updated to:
+
+1. Read `tenant.status.storageClasses` (the resolved list).
+2. Accept a `tenant_storage_class_storage_tier` input parameter (defaulting to
+   `"Default"`).
+3. Find the entry in the list whose `storageTier` matches the request.
+4. Set `tenant_storage_class_name` to the matching `storageClassName`.
+5. Fail with a descriptive error if the requested tier is not in the list,
+   including the available tiers.
+
+For backward compatibility, if `tenant.status.storageClasses` is not present
+(older Tenant controller), the role falls back to reading
+`tenant.status.storageClass` and treats it as the `Default` tier.
+
+#### Changes per repository
+
+**osac-operator:**
+
+- Evolve `getTenantStorageClass()` to `getTenantStorageClasses()`: group
+  StorageClasses by `(tenant, storage-tier)` combination and resolve each
+  independently.
+- Add `ResolvedStorageClass` Go type to the Tenant CRD API.
+- Add `tenant.status.storageClasses` (list of `ResolvedStorageClass`). Keep
+  `status.storageClass` as a convenience field for the `Default` tier.
+- Update `StorageClassReady` condition with per-tier resolution detail.
+- Update unit tests for multi-tier scenarios (multiple tiers resolved,
+  duplicate within one tier, missing tier, fallback to shared Default per
+  tier).
+
+**osac-aap:**
+
+- Update `tenant_storage_class` role to read `tenant.status.storageClasses`
+  and accept a `tenant_storage_class_storage_tier` input parameter.
+- Update template roles to pass the appropriate tier to
+  `tenant_storage_class` when invoking it.
+- Update tests for tier-aware lookup.
+
+**fulfillment-service:**
+
+- No changes expected in the initial implementation (Strategy A). The
+  fulfillment-service remains a pass-through. If Strategy B is adopted later,
+  the `DiskSpec` proto message will need a `storage_tier` field.
+
+**osac-installer:**
+
+- No changes expected.
+
+### Risks and Mitigations
+
+**Risk: Label sprawl.** CSPs could create an unbounded number of tier labels,
+making the Tenant status large and hard to reason about.
+
+**Mitigation:** Documentation will recommend a small, well-defined set of tiers
+(e.g., `fast`, `standard`, `archival`). The system does not enforce a fixed
+vocabulary, but operational guidance will discourage excessive granularity.
+
+**Risk: Backward compatibility during upgrade.** Existing deployments have
+`tenant.status.storageClass` (string). If the field is removed, consumers
+that have not been updated will break.
+
+**Mitigation:** The singular `status.storageClass` field is retained as a
+convenience accessor that points to the `Default` tier. Consumers are migrated
+to read from `status.storageClasses` but are not immediately broken.
+
+**Risk: Duplicate detection complexity.** With multiple tiers, the number of
+potential duplicate scenarios increases.
+
+**Mitigation:** Duplicate detection is per-tier. Each `(tenant, tier)` pair is
+resolved independently. The existing duplicate detection logic is reused at
+each resolution step.
+
+### Drawbacks
+
+This design adds a dimension of complexity to the StorageClass selection
+process. For CSPs that only need a single StorageClass per tenant, the new
+`storage-tier` label is unnecessary overhead. The backward-compatible defaults
+(omitted label = `Default` tier, omitted parameter = `Default` tier) ensure
+these CSPs are not burdened by the feature, but the Tenant controller must
+still handle the multi-tier resolution path.
+
+## Alternatives (Not Implemented)
+
+**Alternative 1: Use a map instead of a list in Tenant status.** The resolved
+tiers could be stored as `map[string]string` (tier to StorageClass name)
+instead of a list of structs. This was considered but rejected because:
+
+- A list of structs is more extensible. If additional metadata per tier is
+  needed later (e.g., quota, capacity information), it can be added to the
+  struct without changing the container type.
+- Kubernetes CRD validation works better with lists than with maps of
+  arbitrary keys.
+
+## Open Questions
+
+1. Should the Tenant require a `Default` tier to be `Ready`, or is it
+   sufficient to have any tier resolve? If a tenant only has `fast` storage
+   and a template requests `Default`, should the system error?
+
+2. Should tier names be validated against a predefined vocabulary, or remain
+   freeform? Freeform is more flexible but risks inconsistency across tenants.
+
+3. **Should tenant users be able to specify storage tiers?** In Strategy A,
+   the template author (Tenant Admin) decides which tier each disk uses and
+   the user has no control. If user-specified tiers are desired, there are
+   two mechanisms: a configurable template that reads the tier from
+   `templateParameters`, or a dedicated `storageTier` field on the
+   ComputeInstance `DiskSpec` (Strategy B). Both achieve the same result
+   (user provides the tier value), but differ in scope: a template parameter
+   is scoped to templates that opt in, while a DiskSpec field is available
+   on every ComputeInstance. If Strategy B is adopted, the proto/public API
+   would also need a `storage_tier` field, requiring buf regeneration and
+   fulfillment-service proto updates.
+
+## Test Plan
+
+**Unit tests (osac-operator):**
+
+- Tenant controller: resolve multiple tiers per tenant, duplicate detection
+  per tier, fallback to shared Default per tier, mixed (some tiers from tenant,
+  some from Default), backward-compatible single SC with no tier label.
+- Verify `status.storageClasses` list is populated correctly.
+- Verify `status.storageClass` (singular) still contains the `Default` tier.
+
+**Unit tests (osac-aap):**
+
+- `tenant_storage_class` role with `tenant_storage_class_storage_tier`
+  parameter: resolve `fast` tier, resolve `Default` tier, resolve when no
+  tier parameter is provided (defaults to `Default`), fail when requested
+  tier is not in the list (verify error message includes available tiers),
+  backward-compatible fallback to `status.storageClass` when
+  `status.storageClasses` is absent.
+
+**E2E tests:**
+
+- Tenant with `fast` and `standard` tiers: verify both resolve correctly in
+  Tenant status.
+- Template requests `fast` tier: verify the DataVolume uses the `fast`
+  StorageClass.
+- Template requests no tier (Default): verify the DataVolume uses the
+  `Default` StorageClass.
+- Shared Default fallback per tier: tenant has no dedicated `fast` SC, verify
+  the shared Default `fast` SC is used.
+- Tier not available: template requests `fast` but only `standard` is
+  configured. Verify descriptive error with available tier list.
+- Backward compatibility: existing single-SC tenant (no `storage-tier` label)
+  continues to work without any changes.
+- Duplicate detection per tier: two SCs for `(tenantX, fast)` produces
+  `MultipleFound` for that tier, but `(tenantX, standard)` is unaffected.
+
+## Graduation Criteria
+
+**Note:** *Section not required until targeted at a release.*
+
+This enhancement would follow the same maturity progression as the broader OSAC
+project. Initial implementation targets Dev Preview with the expectation that
+the label vocabulary and API fields will stabilize through operational
+experience before GA.
+
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+## Upgrade / Downgrade Strategy
+
+**Upgrade from single-tier to multi-tier:**
+
+- Existing StorageClasses without the `osac.openshift.io/storage-tier` label
+  continue to work. The Tenant controller treats them as tier `Default`.
+- Existing `tenant.status.storageClass` (string) is retained for backward
+  compatibility. Consumers that read the old field continue to get the
+  `Default` tier StorageClass name.
+- The new `tenant.status.storageClasses` (list) is additive. Old consumers
+  that do not read it are unaffected.
+- Templates and roles that do not specify a tier parameter continue to use
+  the `Default` tier.
+
+## Version Skew Strategy
+
+N/A. OSAC is in active development and has not been released to customers.
+
+## Support Procedures
+
+N/A. OSAC is in active development and has not been released to customers.
+
+## Infrastructure Needed
+
+No new infrastructure is required. This enhancement extends existing CRDs and
+controller logic.

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -90,6 +90,31 @@ not need to think about storage infrastructure.
 * Backward compatibility with the singular `status.storageClass` field. OSAC is
   pre-release; see [Migration Path](#migration-path) for upgrade guidance.
 
+### Assumptions
+
+This proposal assumes the following:
+
+1. **An external system maintains the source of truth for valid storage tier
+   names.** The Tenant controller does not define, validate, or discover which
+   tiers are available in the underlying storage infrastructure. Some external
+   process (CSP onboarding tooling, storage vendor integration, or manual CSP
+   Admin action) is responsible for knowing what storage tiers the data center
+   can provide (e.g., which pools exist on the Ceph/NetApp/Pure Storage cluster)
+   and mapping those to tier names used in OSAC labels.
+
+2. **An external system is responsible for creating and maintaining Tenant
+   StorageClasses with the correct labels.** This proposal defines how the
+   Tenant controller *consumes* labeled StorageClasses, not how they are
+   *created*. Whether StorageClass creation is automated (e.g., as part of
+   tenant onboarding via the OSAC API) or manual (CSP Admin runs `oc apply`)
+   is outside the scope of this proposal. Automation for tier discovery and
+   StorageClass lifecycle management will be addressed in a subsequent proposal.
+
+3. **The set of available tiers is relatively static.** Tiers represent
+   categories of storage capability (e.g., fast, standard, archival), not
+   individual storage pools or volumes. Tier names are expected to change
+   infrequently, on the order of storage infrastructure changes.
+
 ## Proposal
 
 This proposal adds a second label axis to the StorageClass labeling convention.
@@ -534,15 +559,31 @@ default, user override) can be added as a separate enhancement. These
 strategies would require proto changes, fulfillment-service updates, and API
 versioning.
 
-#### StorageClassReady condition updates
+#### StorageClassReady condition and Tenant readiness
+
+A Tenant cannot reach `Ready` phase without at least one StorageClass that
+carries **both** required labels (`osac.openshift.io/tenant` and
+`osac.openshift.io/storage-tier`). If a CSP creates a StorageClass for a
+tenant but omits the `storage-tier` label (or the `tenant` label), the
+controller ignores it entirely. The Tenant remains in `Progressing` phase and
+the `StorageClassReady` condition is `False`, signaling that storage is not
+configured correctly.
+
+This approach uses **status reflection** rather than admission webhooks. The
+controller does not actively prevent the creation of incorrectly labeled
+StorageClasses. Instead, the misconfiguration is surfaced through the Tenant
+CR's status, which operators and monitoring systems can observe. Admission
+webhooks were considered but rejected due to the operational complexity of
+managing webhooks for a resource type (StorageClass) that is not owned by OSAC.
 
 The existing `StorageClassReady` condition is extended:
 
 - `Ready` requires at least one tier to resolve successfully.
-- If **no tier resolves successfully** (all have duplicates,
-  MultipleDefaultsFound, or are not found), the Tenant `phase` is set to
-  `Progressing` and the `StorageClassReady` condition is `False` with a
-  message listing all tier resolution failures.
+- If **no tier resolves successfully** (all tiers have duplicates,
+  MultipleDefaultsFound, or no StorageClass with both required labels exists
+  for the tenant), the Tenant `phase` is set to `Progressing` and the
+  `StorageClassReady` condition is `False` with a message listing all tier
+  resolution failures.
 - Duplicate detection applies per tier. Two StorageClasses for `(tenantX,
   fast)` produces a `MultipleFound` condition, but does not affect
   `(tenantX, standard)`.

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -760,15 +760,8 @@ instead of a list of structs. This was considered but rejected because:
 
 ## Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
-
-This enhancement would follow the same maturity progression as the broader OSAC
-project. Initial implementation targets Dev Preview with the expectation that
-the label vocabulary and API fields will stabilize through operational
-experience before GA.
-
-[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
-[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+N/A. OSAC is in active development and has not been released to customers.
+Initial implementation targets Dev Preview.
 
 ## Upgrade / Downgrade Strategy
 

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -71,8 +71,9 @@ not need to think about storage infrastructure.
   (VM templates, Ansible roles, future API fields) can select the appropriate
   StorageClass by tier.
 * Keep the Tenant controller as the single source of truth for StorageClass
-  resolution. Consumers (Ansible, CI controller) read from Tenant status, not
-  from StorageClass labels directly.
+  resolution, so that osac-operator and osac-aap do not each implement the
+  same resolution logic. Consumers use `status.storageClasses` to determine
+  which StorageClass to use for a given tier.
 * Require all StorageClasses to declare their tier explicitly. No implicit
   fallback behavior.
 

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -407,7 +407,7 @@ A new optional label is added alongside the existing tenant label:
 | Label key | Required | Values | Default if absent |
 |---|---|---|---|
 | `osac.openshift.io/tenant` | Yes | `<tenantName>` or `Default` | N/A (required) |
-| `osac.openshift.io/storage-tier` | No | Any lowercase alphanumeric string (e.g., `fast`, `standard`, `archival`, `nvme`) | `Default` |
+| `osac.openshift.io/storage-tier` | No | Lowercase Kubernetes label value (e.g., `fast`, `standard`, `archival`, `nvme-1`) | `Default` |
 
 Both label axes use the same sentinel convention: real values are lowercase,
 and the sentinel/fallback value is `Default` (capitalized). This is consistent
@@ -469,9 +469,9 @@ parameters:
 
 #### Tenant CRD status changes
 
-The singular `status.storageClass` field (string) is replaced by a
-`status.storageClasses` list that captures all resolved StorageClass mappings
-for the tenant:
+The singular `status.storageClass` field (string) is retained for backward
+compatibility, and a new `status.storageClasses` list captures all resolved
+StorageClass mappings for the tenant:
 
 ```yaml
 status:
@@ -519,7 +519,8 @@ resolves with tier `Default` (either explicitly labeled or with no tier label),
 tier-aware to continue working without changes.
 
 If no `Default` tier resolves for a tenant (neither a tenant-specific SC
-without a tier label, nor a shared Default SC without a tier label),
+with `storage-tier: Default` or without a tier label, nor a shared Default SC
+with `storage-tier: Default` or without a tier label),
 `status.storageClass` will be empty, even if other tiers (`fast`, `standard`)
 resolved successfully. Consumers that are not tier-aware would fail in this
 case, which is the correct signal: the CSP must configure a `Default` tier

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -58,10 +58,14 @@ As a **CSP Admin**, I want to provide shared Default StorageClasses at different
 tiers so that tenants without dedicated storage still have access to tiered
 storage options.
 
-As a **Tenant Admin**, I want to create VM templates that automatically select
-the right storage tier for their workload type (e.g., a database template uses
-fast storage, an archival template uses standard storage) so that my users do
-not need to think about storage infrastructure.
+As an **OSAC Contributor**, I want to ship VM templates that work out of the
+box on any OSAC deployment, so that CSPs can use them without needing to fork
+and customize each template for their storage tier names.
+
+As a **CSP Admin**, I want to customize or extend OSAC-shipped templates to
+use specialized storage tiers (e.g., `fast` for database templates) that match
+my infrastructure, so that my tenants get the right storage for each workload
+type.
 
 ### Goals
 
@@ -143,8 +147,8 @@ controller does not assign it any magic behavior.
 
 | Persona | Role | Relevant actions |
 |---|---|---|
-| **CSP Admin** | Cloud Provider Admin (infrastructure) | Creates StorageClasses with tenant and tier labels |
-| **Tenant Admin** | Tenant organization administrator | Creates and configures VM templates for their users |
+| **OSAC Contributor** | OSAC project developer | Creates and maintains OSAC-shipped VM templates |
+| **CSP Admin** | Cloud Provider Admin (infrastructure) | Creates StorageClasses with tenant and tier labels; customizes templates for specialized tiers |
 | **Tenant User** | End user within a tenant organization | Creates ComputeInstances using available templates |
 
 #### Workflow 1: CSP Admin configures tiered storage for a tenant
@@ -303,11 +307,11 @@ to the shared Default StorageClass.
 
 #### Workflow 4: Template-driven tier selection during provisioning
 
-**Actors:** Tenant Admin (creates the template), Tenant User (creates the CI)
+**Actors:** CSP Admin (customizes the template), Tenant User (creates the CI)
 
 **Starting state:** `tenant-acme` has `fast` and `default` tiers resolved.
-The Tenant Admin has created a `database_vm` template that is configured to
-use `fast` storage for boot disks.
+The CSP Admin has customized the `database_vm` template to use `fast` storage
+for boot disks.
 
 1. The Tenant User creates a ComputeInstance using the database template:
 
@@ -364,7 +368,7 @@ missing tier and listing the available alternatives.
 
 #### Workflow 6: Tier parameter not specified in template
 
-**Actors:** Tenant Admin (creates a template without specifying a tier)
+**Actors:** CSP Admin or OSAC Contributor (creates a template without specifying a tier)
 
 **Starting state:** `tenant-acme` has `fast` and `default` tiers resolved.
 
@@ -553,15 +557,40 @@ error listing the available tiers for the tenant. This forces template authors
 to be explicit about which storage tier their workload needs.
 
 **Who provides the `storage_tier` value** is a separate concern from how the
-role resolves it. The initial implementation uses **Strategy A:
-template-driven** selection. The VM template role (e.g.,
-`osac.templates.database_vm`) hardcodes which tier each disk needs. The
-template author chooses the tier based on the workload type. The tenant user
-selects a template when creating a ComputeInstance and does not need to know
-about storage tiers.
+role resolves it. The initial implementation uses **template-driven**
+selection. Each VM template hardcodes which tier its disks need. The tenant
+user selects a template when creating a ComputeInstance and does not need to
+know about storage tiers.
+
+#### OSAC-shipped templates and the `default` tier convention
+
+OSAC-shipped templates (written by OSAC contributors) must work out of the box
+on any OSAC deployment without requiring CSPs to fork or customize them for
+their specific tier names. To achieve this, OSAC-shipped templates use the
+conventional tier name `default`:
 
 ```yaml
-# Inside osac.templates.database_vm/tasks/create.yaml
+# Inside osac.templates.ocp_virt_vm/tasks/create.yaml (OSAC-shipped)
+- name: Resolve boot disk StorageClass
+  ansible.builtin.include_role:
+    name: osac.service.tenant_storage_class
+  vars:
+    tenant_storage_class_storage_tier: "default"
+```
+
+For this to work, every VMaaS cluster must have at least one shared
+StorageClass with `osac.openshift.io/tenant: Default` and
+`osac.openshift.io/storage-tier: default`. This is the baseline that ensures
+OSAC-shipped templates resolve a StorageClass for any tenant through the
+existing shared Default fallback. CSPs can override it per-tenant by creating
+a StorageClass with `tenant: <tenantName>, storage-tier: default`.
+
+CSPs that want specialized templates (e.g., a `database_vm` template that uses
+`fast` storage) customize or extend OSAC-shipped templates for their
+environment:
+
+```yaml
+# Inside a CSP-customized database_vm template
 - name: Resolve boot disk StorageClass
   ansible.builtin.include_role:
     name: osac.service.tenant_storage_class
@@ -569,11 +598,10 @@ about storage tiers.
     tenant_storage_class_storage_tier: "fast"
 ```
 
-If user-specified tiers are needed in the future, Strategy B (a `storageTier`
-field on the ComputeInstance `DiskSpec`) or Strategy C (hybrid: template
-default, user override) can be added as a separate enhancement. These
-strategies would require proto changes, fulfillment-service updates, and API
-versioning.
+If user-specified tiers are needed in the future, a `storageTier` field on the
+ComputeInstance `DiskSpec` or a hybrid approach (template default, user
+override) can be added as a separate enhancement. These strategies would
+require proto changes, fulfillment-service updates, and API versioning.
 
 #### StorageClassReady condition and Tenant readiness
 
@@ -654,9 +682,9 @@ instead of querying the K8s API:
 
 **fulfillment-service:**
 
-- No changes expected in the initial implementation (Strategy A). The
-  fulfillment-service remains a pass-through. If Strategy B is adopted later,
-  the `DiskSpec` proto message will need a `storage_tier` field.
+- No changes expected. The fulfillment-service remains a pass-through.
+  If user-specified tiers are added in the future (via a `storageTier` field
+  on `DiskSpec`), the proto message will need updating.
 
 **osac-installer:**
 
@@ -795,16 +823,19 @@ source of truth for valid tier names is built (see
 
 ### 3. Should tenant users be able to specify storage tiers?
 
-**Decision: Start with Strategy A (template-driven) only.** Templates encode
-the storage requirement. Users select templates based on workload type, not
-infrastructure details.
+**Decision: Template-driven only.** Templates encode the storage requirement.
+Users select templates based on workload type, not infrastructure details.
+OSAC-shipped templates use the conventional tier name `default`; CSPs customize
+templates for specialized tiers.
 
 **Rationale:** Templates are the right abstraction layer for storage decisions.
-A `database_vm` template knows it needs `fast` storage; a user does not need to
-think about it. Adding user-specified tiers (Strategy B/C) introduces
+OSAC contributors write base templates that work on any deployment by using the
+`default` tier. CSPs customize templates for specialized tiers (e.g.,
+`database_vm` uses `fast`). Users do not need to think about storage. Adding
+user-specified tiers (e.g., a `storageTier` field on `DiskSpec`) introduces
 complexity: proto changes, fulfillment-service updates, API versioning, and two
 paths to the same outcome. If tenant feedback shows a need for user-specified
-tiers, Strategy C (hybrid: template default, user override) can be added as a
+tiers, a hybrid approach (template default, user override) can be added as a
 future enhancement.
 
 ### 4. Should `status.storageClass` (singular) be deprecated or removed?

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -120,11 +120,11 @@ This proposal assumes the following:
    individual storage pools or volumes. Tier names are expected to change
    infrequently, on the order of storage infrastructure changes.
 
-4. **A shared StorageClass with tier `default` exists on every VMaaS
+4. **A `default` storage tier resolves for every tenant on each VMaaS
    cluster.** OSAC-shipped templates use the conventional tier name `default`.
-   For these templates to work out of the box, a shared StorageClass with
-   `osac.openshift.io/tenant: Default` and
-   `osac.openshift.io/storage-tier: default` must exist. See
+   For these templates to work out of the box, every tenant must have a
+   `default` tier available, either through a tenant-specific StorageClass
+   or through a shared Default StorageClass. See
    [OSAC-shipped templates and the `default` tier convention](#osac-shipped-templates-and-the-default-tier-convention)
    for details.
 
@@ -146,10 +146,9 @@ participates in OSAC storage resolution.
 Tier names are freeform: CSPs choose values that make sense for their storage
 offering (e.g., `fast`, `standard`, `archival`, `default`). The controller does
 not enforce a fixed vocabulary. However, OSAC-shipped templates depend on the
-tier name `default`, so a shared StorageClass with
-`osac.openshift.io/tenant: Default` and
-`osac.openshift.io/storage-tier: default` is required on every VMaaS cluster
-for these templates to work without customization.
+tier name `default`. For these templates to work without customization, every
+tenant must have a `default` tier available, either through a tenant-specific
+StorageClass or through a shared Default StorageClass.
 
 ### Workflow Description
 
@@ -416,8 +415,8 @@ Storage tier values are freeform beyond the `default` convention. CSPs choose
 tier names that make sense for their storage offering. Recommended conventions
 include `fast`, `standard`, and `archival`, but these are not enforced. The
 tier name `default` is required for OSAC-shipped templates to work out of the
-box; a shared StorageClass with `tenant: Default, storage-tier: default` must
-exist on every VMaaS cluster.
+box; every tenant must have a `default` tier available, either through a
+tenant-specific StorageClass or through a shared Default StorageClass.
 As noted in [Assumptions](#assumptions), an external
 system will own the source of truth for valid tier names. A future proposal
 addressing tier discovery and StorageClass lifecycle management may introduce
@@ -590,12 +589,11 @@ conventional tier name `default`:
     tenant_storage_class_storage_tier: "default"
 ```
 
-For this to work, every VMaaS cluster must have at least one shared
-StorageClass with `osac.openshift.io/tenant: Default` and
-`osac.openshift.io/storage-tier: default`. This is the baseline that ensures
-OSAC-shipped templates resolve a StorageClass for any tenant through the
-existing shared Default fallback. CSPs can override it per-tenant by creating
-a StorageClass with `tenant: <tenantName>, storage-tier: default`.
+For this to work, every tenant must have a `default` tier available. CSPs can
+achieve this either by creating a tenant-specific StorageClass with
+`storage-tier: default` for each tenant, or by creating a shared Default
+StorageClass (`tenant: Default, storage-tier: default`) that serves as the
+fallback for all tenants without a dedicated one.
 
 CSPs that want specialized templates (e.g., a `database_vm` template that uses
 `fast` storage) customize or extend OSAC-shipped templates for their
@@ -733,7 +731,7 @@ singular `status.storageClass` field is removed and all StorageClasses must
 carry a `storage-tier` label. For CSPs that only need a single StorageClass per
 tenant, the required `storage-tier` label is additional configuration overhead.
 However, the label is a single key-value pair, and the explicit-over-implicit
-approach prevents the ambiguity that an optional label with a magic fallback
+approach prevents the ambiguity that an optional label with an implicit fallback
 would create.
 
 ## Migration Path
@@ -871,27 +869,27 @@ the `osac.openshift.io/storage-tier` label.
 **Rationale:** An optional label with an implicit "Default" fallback creates
 ambiguity: is `Default` a real tier name or an internal sentinel? Making the
 label required eliminates this confusion. CSPs that want a general-purpose tier
-label it `default` (lowercase, by convention), but the controller assigns no
-magic behavior to any tier name. Since OSAC is pre-release, there is no
+label it `default` (lowercase, by convention), but the controller does not
+assign special behavior to any tier name. Since OSAC is pre-release, there is no
 backward-compatibility cost to making this required.
 
 ### 6. Should OSAC require a `default` tier for shipped templates to work?
 
-**Decision: Yes.** A shared StorageClass with
-`osac.openshift.io/tenant: Default` and
-`osac.openshift.io/storage-tier: default` is required on every VMaaS cluster.
+**Decision: Yes.** Every tenant must have a `default` tier available for
+OSAC-shipped templates to work.
 
 **Rationale:** OSAC contributors write base templates that must work out of the
 box on any OSAC deployment. Since tier names are freeform and CSPs choose their
 own, templates cannot hardcode CSP-specific tier names. By convention,
-OSAC-shipped templates use the tier name `default`. Requiring a shared
-StorageClass with `tenant: Default, storage-tier: default` ensures every tenant
-resolves a `default` tier through the shared Default fallback, making
-OSAC-shipped templates portable across deployments. CSPs can override it
-per-tenant and customize templates for specialized tiers. The Tenant controller
-itself does not enforce this; it only requires at least one tier to resolve
-(see Decision #1). The `default` tier requirement is an operational convention
-for template portability, not a controller-level constraint.
+OSAC-shipped templates use the tier name `default`. CSPs can provide this tier
+either through a tenant-specific StorageClass with `storage-tier: default` for
+each tenant, or through a shared Default StorageClass
+(`tenant: Default, storage-tier: default`) that serves as the fallback for all
+tenants without a dedicated one. CSPs can also customize templates for
+specialized tiers. The Tenant controller itself does not enforce this; it only
+requires at least one tier to resolve (see Decision #1). The `default` tier
+requirement is an operational convention for template portability, not a
+controller-level constraint.
 
 ## Alternatives (Not Implemented)
 

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -526,14 +526,27 @@ with `osac.openshift.io/tenant=<tenantName>` or
      the Tenant level; individual provisioning requests that ask for this
      tier will fail at the Ansible role level).
 
-The resolved list is stored in `tenant.status.storageClasses`. Consumers never implement fallback logic; they look up the requested tier in
-the pre-resolved list.
+The resolved list is stored in `tenant.status.storageClasses`. Consumers never
+implement fallback logic; they look up the requested tier in the pre-resolved
+list.
+
+#### Data flow: operator to Ansible
+
+The resolved `storageClasses` list is passed to Ansible as part of the job
+context (extra_vars) when the CI controller triggers a provisioning job.
+The CI controller already fetches the Tenant CR to verify readiness before
+triggering; it reads `tenant.status.storageClasses` at that point and injects
+the list into the extra_vars alongside the ComputeInstance payload. This
+eliminates the need for Ansible to make a separate K8s API call to fetch the
+Tenant CR, since Ansible has no informer cache and every `k8s_info` call is a
+direct API server hit.
 
 #### Tier selection at provisioning time
 
 The `tenant_storage_class` Ansible role is the selection interface. It
 **requires** a `tenant_storage_class_storage_tier` input parameter (no default
-value) and resolves it against the tenant's `status.storageClasses` list.
+value) and resolves it against the `storageClasses` list injected via
+extra_vars.
 
 If the parameter is not provided, the role fails immediately with a descriptive
 error listing the available tiers for the tenant. This forces template authors
@@ -595,10 +608,13 @@ The existing `StorageClassReady` condition is extended:
 
 #### Ansible role changes
 
-The `tenant_storage_class` role currently reads `tenant.status.storageClass`
-(a single string) and sets `tenant_storage_class_name`. It will be updated to:
+The `tenant_storage_class` role currently queries the K8s API for the Tenant CR
+and reads `tenant.status.storageClass` (a single string). It will be updated
+to read the resolved `storageClasses` list from the injected extra_vars
+instead of querying the K8s API:
 
-1. Read `tenant.status.storageClasses` (the resolved list).
+1. Read the `storageClasses` list from extra_vars (injected by the CI
+   controller at job creation time).
 2. **Require** the `tenant_storage_class_storage_tier` input parameter (no
    default value). Fail immediately if the parameter is not provided, with an
    error message listing available tiers.
@@ -618,15 +634,19 @@ The `tenant_storage_class` role currently reads `tenant.status.storageClass`
 - Add `tenant.status.storageClasses` (list of `ResolvedStorageClass`).
 - Remove `status.storageClass` (singular) from the Tenant CRD API.
 - Update `StorageClassReady` condition with per-tier resolution detail.
+- Update the CI controller to read the resolved `storageClasses` list from
+  the Tenant status and inject it into the extra_vars when launching the
+  provisioning job.
 - Update unit tests for multi-tier scenarios (multiple tiers resolved,
   duplicate within one tier, missing tier, fallback to shared Default per
   tier, StorageClass without tier label is ignored).
 
 **osac-aap:**
 
-- Update `tenant_storage_class` role to read `tenant.status.storageClasses`
-  and **require** a `tenant_storage_class_storage_tier` input parameter (no
-  default).
+- Update `tenant_storage_class` role to read the `storageClasses` list from
+  extra_vars (injected by the CI controller) instead of querying the K8s API
+  for the Tenant CR. **Require** a `tenant_storage_class_storage_tier` input
+  parameter (no default).
 - Update all template roles to explicitly pass the appropriate tier to
   `tenant_storage_class` when invoking it.
 - Update tests for tier-aware lookup and for the missing-parameter failure

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -144,13 +144,12 @@ resolves to `standard`. Both labels are required on every StorageClass that
 participates in OSAC storage resolution.
 
 Tier names are freeform: CSPs choose values that make sense for their storage
-offering (e.g., `fast`, `standard`, `archival`, `default`). OSAC does not
-define a fixed vocabulary or treat any tier name as special. A CSP that wants a
-general-purpose tier can label it `default` (lowercase, by convention), but the
-controller does not assign it any magic behavior. OSAC-shipped templates use
-the tier name `default` so they work on any deployment without customization.
-A shared StorageClass with `tenant: Default` and `storage-tier: default` is
-expected on every VMaaS cluster.
+offering (e.g., `fast`, `standard`, `archival`, `default`). The controller does
+not enforce a fixed vocabulary. However, OSAC-shipped templates depend on the
+tier name `default`, so a shared StorageClass with
+`osac.openshift.io/tenant: Default` and
+`osac.openshift.io/storage-tier: default` is required on every VMaaS cluster
+for these templates to work without customization.
 
 ### Workflow Description
 
@@ -413,13 +412,12 @@ The `osac.openshift.io/tenant` label retains the `Default` (capitalized)
 sentinel convention for shared StorageClasses. The `osac.openshift.io/tenant`
 axis is the only axis that uses a capitalized sentinel.
 
-Storage tier values are currently freeform. OSAC does not define a fixed
-vocabulary or treat any tier name as special. CSPs choose tier names that make
-sense for their storage offering. Recommended conventions include `fast`,
-`standard`, `archival`, and `default`, but these are documentation guidance,
-not enforced constraints. However, OSAC-shipped templates rely on the tier name
-`default`; a shared StorageClass with `tenant: Default, storage-tier: default`
-is expected on every VMaaS cluster for these templates to work out of the box.
+Storage tier values are freeform beyond the `default` convention. CSPs choose
+tier names that make sense for their storage offering. Recommended conventions
+include `fast`, `standard`, and `archival`, but these are not enforced. The
+tier name `default` is required for OSAC-shipped templates to work out of the
+box; a shared StorageClass with `tenant: Default, storage-tier: default` must
+exist on every VMaaS cluster.
 As noted in [Assumptions](#assumptions), an external
 system will own the source of truth for valid tier names. A future proposal
 addressing tier discovery and StorageClass lifecycle management may introduce
@@ -816,16 +814,19 @@ proposal was finalized.
 **Decision: No.** The only requirement is that at least one tier resolves
 successfully. Which tier(s) exist is the CSP's choice.
 
-**Rationale:** Requiring a specific tier name couples the controller to naming
-conventions. A CSP that only provides specialized tiers (`fast`, `gpu`) should
-not be forced to also create a `default` tier. Templates must specify which
-tier they need; there are no assumptions about which tiers exist.
+**Rationale:** Requiring a specific tier name for the Tenant to reach Ready
+couples the controller to naming conventions. The controller only cares that
+at least one tier resolves. However, OSAC-shipped templates depend on a
+`default` tier existing (see Decision #6), so in practice CSPs should ensure
+a `default` tier is available if they want those templates to work out of the
+box.
 
 ### 2. Should tier names be validated against a predefined vocabulary?
 
 **Decision: No, for now. Tier names are freeform.** Values must follow
 Kubernetes label value syntax, but OSAC does not enforce a fixed list in this
-proposal.
+proposal. The one convention that OSAC-shipped templates depend on is the tier
+name `default` (see Decision #6).
 
 **Rationale:** Different CSPs have different storage offerings. Hardcoding tier
 names in the controller is inflexible and would require controller updates as
@@ -873,6 +874,24 @@ label required eliminates this confusion. CSPs that want a general-purpose tier
 label it `default` (lowercase, by convention), but the controller assigns no
 magic behavior to any tier name. Since OSAC is pre-release, there is no
 backward-compatibility cost to making this required.
+
+### 6. Should OSAC require a `default` tier for shipped templates to work?
+
+**Decision: Yes.** A shared StorageClass with
+`osac.openshift.io/tenant: Default` and
+`osac.openshift.io/storage-tier: default` is required on every VMaaS cluster.
+
+**Rationale:** OSAC contributors write base templates that must work out of the
+box on any OSAC deployment. Since tier names are freeform and CSPs choose their
+own, templates cannot hardcode CSP-specific tier names. By convention,
+OSAC-shipped templates use the tier name `default`. Requiring a shared
+StorageClass with `tenant: Default, storage-tier: default` ensures every tenant
+resolves a `default` tier through the shared Default fallback, making
+OSAC-shipped templates portable across deployments. CSPs can override it
+per-tenant and customize templates for specialized tiers. The Tenant controller
+itself does not enforce this; it only requires at least one tier to resolve
+(see Decision #1). The `default` tier requirement is an operational convention
+for template portability, not a controller-level constraint.
 
 ## Alternatives (Not Implemented)
 

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -397,11 +397,14 @@ The `osac.openshift.io/tenant` label retains the `Default` (capitalized)
 sentinel convention for shared StorageClasses. The `osac.openshift.io/tenant`
 axis is the only axis that uses a capitalized sentinel.
 
-Storage tier values are freeform. OSAC does not define a fixed vocabulary or
-treat any tier name as special. CSPs choose tier names that make sense for
-their storage offering. Recommended conventions include `fast`, `standard`,
-`archival`, and `default`, but these are documentation guidance, not enforced
-constraints. Tier values must be lowercase and conform to Kubernetes label
+Storage tier values are currently freeform. OSAC does not define a fixed
+vocabulary or treat any tier name as special. CSPs choose tier names that make
+sense for their storage offering. Recommended conventions include `fast`,
+`standard`, `archival`, and `default`, but these are documentation guidance,
+not enforced constraints. As noted in [Assumptions](#assumptions), an external
+system will own the source of truth for valid tier names. A future proposal
+addressing tier discovery and StorageClass lifecycle management may introduce
+validation of tier names against that registry. Tier values must be lowercase and conform to Kubernetes label
 value syntax:
 alphanumeric, dashes, dots, and underscores, up to 63 characters, beginning
 and ending with an alphanumeric character.
@@ -758,14 +761,17 @@ tier they need; there are no assumptions about which tiers exist.
 
 ### 2. Should tier names be validated against a predefined vocabulary?
 
-**Decision: No. Tier names are freeform.** Values must follow Kubernetes label
-syntax, but OSAC does not enforce a fixed list.
+**Decision: No, for now. Tier names are freeform.** Values must follow
+Kubernetes label value syntax, but OSAC does not enforce a fixed list in this
+proposal.
 
 **Rationale:** Different CSPs have different storage offerings. Hardcoding tier
 names in the controller is inflexible and would require controller updates as
 storage technology evolves (e.g., `nvme-gen5`, `persistent-memory`). Instead,
 the proposal documents recommended conventions (`fast`, `standard`, `archival`,
-`default`) without enforcing them.
+`default`) without enforcing them. Once the external system that owns the
+source of truth for valid tier names is built (see
+[Assumptions](#assumptions)), tier validation may be introduced at that layer.
 
 ### 3. Should tenant users be able to specify storage tiers?
 

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -3,7 +3,7 @@ title: tenant-storage-tiers
 authors:
   - akshaynadkarni
 creation-date: 2026-03-26
-last-updated: 2026-04-20
+last-updated: 2026-04-22
 tracking-link:
   - https://redhat.atlassian.net/browse/MGMT-23669
 see-also:

--- a/enhancements/tenant-storage-tiers/README.md
+++ b/enhancements/tenant-storage-tiers/README.md
@@ -3,7 +3,7 @@ title: tenant-storage-tiers
 authors:
   - akshaynadkarni
 creation-date: 2026-03-26
-last-updated: 2026-03-26
+last-updated: 2026-03-31
 tracking-link:
   - TBD
 see-also:
@@ -20,12 +20,18 @@ This proposal extends the tenant-specific StorageClass mechanism introduced in
 [tenant-specific-storageclasses](/enhancements/tenant-specific-storageclasses) to
 support multiple storage tiers per tenant. A CSP may need to offer different
 classes of storage to each tenant, for example fast NVMe storage for databases
-alongside slower HDD storage for archival. This proposal adds an optional
-`osac.openshift.io/storage-tier` label to StorageClasses, evolves
-`tenant.status.storageClass` (string) to `tenant.status.storageClasses` (list),
-and updates the `tenant_storage_class` Ansible role to accept a storage tier
-parameter so that consumers can select the appropriate StorageClass for a given
-workload.
+alongside slower HDD storage for archival. This proposal adds a **required**
+`osac.openshift.io/storage-tier` label to StorageClasses, introduces a new
+`tenant.status.storageClasses` list (replacing the singular
+`tenant.status.storageClass` field), and updates the `tenant_storage_class`
+Ansible role to **require** a storage tier parameter so that consumers
+explicitly select the appropriate StorageClass for a given workload.
+
+Since OSAC is pre-release with no deployed consumers, this proposal takes a
+clean-slate approach: tier labels are required (not optional), there is no
+implicit "Default" fallback, and the singular `status.storageClass` field is
+removed rather than deprecated. A migration path is provided for existing
+development and test environments.
 
 This proposal focuses on the infrastructure layer: tier labeling, resolution,
 and selection. How the tier value reaches the Ansible role (whether from a VM
@@ -57,10 +63,6 @@ the right storage tier for their workload type (e.g., a database template uses
 fast storage, an archival template uses standard storage) so that my users do
 not need to think about storage infrastructure.
 
-As a **CSP Admin**, I want the system to be backward compatible so that existing
-single-StorageClass-per-tenant configurations continue working without any
-changes.
-
 ### Goals
 
 * Enable CSPs to offer multiple storage tiers per tenant using labels on
@@ -68,11 +70,11 @@ changes.
 * Expose all resolved storage tiers in the Tenant status so that any consumer
   (VM templates, Ansible roles, future API fields) can select the appropriate
   StorageClass by tier.
-* Maintain full backward compatibility with the existing single StorageClass
-  per tenant model.
 * Keep the Tenant controller as the single source of truth for StorageClass
   resolution. Consumers (Ansible, CI controller) read from Tenant status, not
   from StorageClass labels directly.
+* Require all StorageClasses to declare their tier explicitly. No implicit
+  fallback behavior.
 
 ### Non-Goals
 
@@ -85,23 +87,27 @@ changes.
 * Prescribing the mechanism by which the tier value reaches the provisioning
   layer. This proposal builds the infrastructure; the consumption pattern
   (template-driven, user-facing, or hybrid) is discussed but not mandated.
+* Backward compatibility with the singular `status.storageClass` field. OSAC is
+  pre-release; see [Migration Path](#migration-path) for upgrade guidance.
 
 ## Proposal
 
-This proposal adds a second, optional label axis to the StorageClass labeling
-convention. The existing `osac.openshift.io/tenant` label identifies *which
-tenant* owns a StorageClass. The new `osac.openshift.io/storage-tier` label
-identifies *what kind* of storage it provides.
+This proposal adds a second label axis to the StorageClass labeling convention.
+The existing `osac.openshift.io/tenant` label identifies *which tenant* owns a
+StorageClass. The new `osac.openshift.io/storage-tier` label identifies *what
+kind* of storage it provides.
 
 Each StorageClass is identified by a composite key: `(tenant, storage-tier)`.
 The `tenant` axis retains its existing fallback behavior (tenant-specific, then
-shared `Default`). The `storage-tier` axis is an exact match that defaults to
-`Default` when absent.
+shared `Default`). The `storage-tier` axis is an exact match with no fallback:
+both labels are required on every StorageClass that participates in OSAC storage
+resolution.
 
-The `Default` sentinel value follows the same convention established for the
-`osac.openshift.io/tenant` label: real values are lowercase (`fast`,
-`standard`, `archival`), and the sentinel/fallback value is capitalized
-(`Default`). This keeps the labeling convention predictable across both axes.
+Tier names are freeform: CSPs choose values that make sense for their storage
+offering (e.g., `fast`, `standard`, `archival`, `default`). OSAC does not
+define a fixed vocabulary or treat any tier name as special. A CSP that wants a
+general-purpose tier can label it `default` (lowercase, by convention), but the
+controller does not assign it any magic behavior.
 
 ### Workflow Description
 
@@ -158,40 +164,7 @@ parameters:
 status. VM templates and provisioning roles can now select either `fast` or
 `standard` storage.
 
-#### Workflow 2: Backward-compatible single StorageClass (no storage-tier label)
-
-**Actors:** CSP Admin
-
-**Starting state:** The CSP has a single StorageClass per tenant, labeled with
-only `osac.openshift.io/tenant` (no `storage-tier` label). This is the
-configuration that exists today.
-
-1. The existing StorageClass has no `osac.openshift.io/storage-tier` label:
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: ceph-acme
-  labels:
-    osac.openshift.io/tenant: tenant-acme
-provisioner: rook-ceph.rbd.csi.ceph.com
-parameters:
-  pool: acme-pool
-```
-
-2. The Tenant controller treats the missing `storage-tier` label as
-   `storage-tier: Default`.
-
-3. `tenant.status.storageClasses` contains a single entry with
-   `storageTier: "Default"`. The backward-compatible
-   `tenant.status.storageClass` field also contains the StorageClass name.
-
-**Expected result:** The tenant continues to work exactly as before. No
-configuration changes are required. Consumers that do not specify a tier
-automatically use the `Default` tier.
-
-#### Workflow 3: CSP Admin configures shared Default storage tiers
+#### Workflow 2: CSP Admin configures storage tiers on shared Default StorageClasses
 
 **Actors:** CSP Admin
 
@@ -215,10 +188,10 @@ parameters:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: ceph-shared-standard
+  name: ceph-shared-default
   labels:
     osac.openshift.io/tenant: Default
-    osac.openshift.io/storage-tier: standard
+    osac.openshift.io/storage-tier: default
 provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
   pool: shared-hdd-pool
@@ -231,18 +204,13 @@ parameters:
 **Expected result:** Tenants without dedicated storage still have access to
 tiered storage options through the shared Defaults.
 
-**Note:** A shared Default StorageClass without a `storage-tier` label is
-treated as `(tenant: Default, storage-tier: Default)`, following the same
-rule as Workflow 2. This is the configuration that exists today and continues
-to work without changes.
-
-#### Workflow 4: Mixed tenant-specific and shared Default tiers
+#### Workflow 3: Mixed tenant-specific and shared Default tiers
 
 **Actors:** CSP Admin
 
-**Starting state:** The CSP has a shared Default StorageClass (no tier label)
-for all tenants, and has configured tenant-specific `fast` and `slow`
-StorageClasses for `tenant-acme`.
+**Starting state:** The CSP has shared Default StorageClasses labeled with
+tiers, and has configured tenant-specific `fast` and `slow` StorageClasses
+for `tenant-acme`.
 
 StorageClasses on the cluster:
 
@@ -253,6 +221,7 @@ metadata:
   name: ceph-shared-default
   labels:
     osac.openshift.io/tenant: Default
+    osac.openshift.io/storage-tier: default
 provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
   pool: shared-pool
@@ -283,7 +252,7 @@ parameters:
 1. The Tenant controller resolves each tier independently for `tenant-acme`:
    - `fast`: tenant-specific SC found (`ceph-acme-fast`).
    - `slow`: tenant-specific SC found (`ceph-acme-slow`).
-   - `Default`: no tenant-specific SC without a tier label. Falls back to the
+   - `default`: no tenant-specific SC for this tier. Falls back to the
      shared Default SC (`ceph-shared-default`).
 
 2. The resulting Tenant status:
@@ -291,10 +260,9 @@ parameters:
 ```yaml
 status:
   phase: Ready
-  storageClass: "ceph-shared-default"
   storageClasses:
     - storageClassName: "ceph-shared-default"
-      storageTier: "Default"
+      storageTier: "default"
     - storageClassName: "ceph-acme-fast"
       storageTier: "fast"
     - storageClassName: "ceph-acme-slow"
@@ -302,15 +270,14 @@ status:
 ```
 
 **Expected result:** `tenant-acme` has three resolved tiers. The `fast` and
-`slow` tiers use tenant-specific StorageClasses. The `Default` tier falls back
-to the shared Default StorageClass. `status.storageClass` (singular) contains
-the shared Default SC name, so backward-compatible consumers continue to work.
+`slow` tiers use tenant-specific StorageClasses. The `default` tier falls back
+to the shared Default StorageClass.
 
-#### Workflow 5: Template-driven tier selection during provisioning (Strategy A)
+#### Workflow 4: Template-driven tier selection during provisioning
 
 **Actors:** Tenant Admin (creates the template), Tenant User (creates the CI)
 
-**Starting state:** `tenant-acme` has `fast` and `standard` tiers resolved.
+**Starting state:** `tenant-acme` has `fast` and `default` tiers resolved.
 The Tenant Admin has created a `database_vm` template that is configured to
 use `fast` storage for boot disks.
 
@@ -345,44 +312,12 @@ spec:
 template knew which tier to use for a database workload. The
 `tenant_storage_class` role resolved the tier to the correct StorageClass.
 
-#### Workflow 6: Default tier selection (no tier specified)
-
-**Actors:** Tenant User
-
-**Starting state:** `tenant-acme` has at least a `Default` tier resolved.
-
-1. The Tenant User creates a ComputeInstance using a generic template that does
-   not specify a storage tier:
-
-```yaml
-apiVersion: osac.openshift.io/v1alpha1
-kind: ComputeInstance
-metadata:
-  name: web-server-01
-spec:
-  templateID: osac.templates.ocp_virt_vm
-  cores: 2
-  memoryGiB: 4
-  bootDisk:
-    sizeGiB: 20
-  image:
-    sourceType: registry
-    sourceRef: "quay.io/containerdisks/fedora:latest"
-  runStrategy: Always
-```
-
-2. The `tenant_storage_class` role defaults to tier `"Default"` when no tier
-   is specified and resolves it from `tenant.status.storageClasses`.
-
-**Expected result:** All disks use the `Default` tier StorageClass. This is
-identical to the current single-StorageClass behavior.
-
-#### Workflow 7: Requested storage tier is not available
+#### Workflow 5: Requested storage tier is not available
 
 **Actors:** Tenant User (indirectly, via a template that requests an
 unavailable tier)
 
-**Starting state:** `tenant-acme` has only `Default` and `standard` tiers.
+**Starting state:** `tenant-acme` has `default` and `standard` tiers.
 A template requests `fast` storage.
 
 1. The `tenant_storage_class` role attempts to resolve tier `fast` from
@@ -390,36 +325,58 @@ A template requests `fast` storage.
 
 2. The role fails with a descriptive error:
 
+   > `tenant_storage_class_storage_tier` parameter is required.
    > Storage tier "fast" is not available for tenant "tenant-acme".
-   > Available tiers: Default, standard.
+   > Available tiers: default, standard.
 
 3. The ComputeInstance transitions to `Failed` with a descriptive message.
 
 **Expected result:** The provisioning fails with a clear error identifying the
 missing tier and listing the available alternatives.
 
+#### Workflow 6: Tier parameter not specified in template
+
+**Actors:** Tenant Admin (creates a template without specifying a tier)
+
+**Starting state:** `tenant-acme` has `fast` and `default` tiers resolved.
+
+1. A template invokes the `tenant_storage_class` role without setting
+   `tenant_storage_class_storage_tier`.
+
+2. The role fails immediately with:
+
+   > `tenant_storage_class_storage_tier` parameter is required.
+   > Available tiers for tenant "tenant-acme": default, fast.
+
+3. The ComputeInstance transitions to `Failed`.
+
+**Expected result:** The template author is forced to be explicit about which
+storage tier the workload needs. There is no silent fallback to a default tier.
+
 ### API Extensions
 
 #### StorageClass labels
 
-A new optional label is added alongside the existing tenant label:
+Both the tenant label and the storage-tier label are required on every
+StorageClass that participates in OSAC storage resolution. The Tenant
+controller ignores StorageClasses that are missing either label.
 
 | Label key | Required | Values | Default if absent |
 |---|---|---|---|
 | `osac.openshift.io/tenant` | Yes | `<tenantName>` or `Default` | N/A (required) |
-| `osac.openshift.io/storage-tier` | No | Lowercase Kubernetes label value (e.g., `fast`, `standard`, `archival`, `nvme-1`) | `Default` |
+| `osac.openshift.io/storage-tier` | Yes | Lowercase Kubernetes label value (e.g., `fast`, `standard`, `archival`, `nvme-1`, `default`) | N/A (required) |
 
-Both label axes use the same sentinel convention: real values are lowercase,
-and the sentinel/fallback value is `Default` (capitalized). This is consistent
-with the `osac.openshift.io/tenant: Default` convention established in the
-predecessor proposal, where capitalization prevents collisions with actual
-resource names (which are always lowercase in Kubernetes).
+The `osac.openshift.io/tenant` label retains the `Default` (capitalized)
+sentinel convention for shared StorageClasses. The `osac.openshift.io/tenant`
+axis is the only axis that uses a capitalized sentinel.
 
-Storage tier values are freeform. OSAC does not define a fixed vocabulary.
-CSPs choose tier names that make sense for their storage offering. Tier values
-must conform to Kubernetes label value syntax: alphanumeric, dashes, dots, and
-underscores, up to 63 characters, beginning and ending with an alphanumeric
-character.
+Storage tier values are freeform. OSAC does not define a fixed vocabulary or
+treat any tier name as special. CSPs choose tier names that make sense for
+their storage offering. Recommended conventions include `fast`, `standard`,
+`archival`, and `default`, but these are documentation guidance, not enforced
+constraints. Tier values must conform to Kubernetes label value syntax:
+alphanumeric, dashes, dots, and underscores, up to 63 characters, beginning
+and ending with an alphanumeric character.
 
 **Example: Tenant-specific StorageClass with a storage tier**
 
@@ -453,39 +410,24 @@ parameters:
   media: "hdd"
 ```
 
-**Example: StorageClass without a storage-tier label (treated as `Default`)**
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: netapp-tenant123
-  labels:
-    osac.openshift.io/tenant: tenant123
-provisioner: csi.trident.netapp.io
-parameters:
-  backendType: "ontap-nas"
-```
-
 #### Tenant CRD status changes
 
-The singular `status.storageClass` field (string) is retained for backward
-compatibility, and a new `status.storageClasses` list captures all resolved
-StorageClass mappings for the tenant:
+The singular `status.storageClass` field (string) is **removed** and replaced
+by a `status.storageClasses` list that captures all resolved StorageClass
+mappings for the tenant:
 
 ```yaml
 status:
   phase: Ready
   namespace: "tenant-acme-ns"
-  storageClass: "ceph-acme-default"       # Default tier (= storageClasses entry with storageTier: Default)
   storageClasses:
-    - storageClassName: "ceph-acme-default"    # tenant-specific
-      storageTier: "Default"
-    - storageClassName: "ceph-acme-fast"       # tenant-specific
+    - storageClassName: "ceph-acme-default"
+      storageTier: "default"
+    - storageClassName: "ceph-acme-fast"
       storageTier: "fast"
-    - storageClassName: "ceph-acme-standard"   # tenant-specific
+    - storageClassName: "ceph-acme-standard"
       storageTier: "standard"
-    - storageClassName: "ceph-shared-archival" # resolved from shared Default fallback
+    - storageClassName: "ceph-shared-archival"
       storageTier: "archival"
 ```
 
@@ -498,12 +440,11 @@ Go type:
 
 ```go
 type ResolvedStorageClass struct {
-    // StorageClassName is the name of the resolved StorageClass
+    // StorageClassName is the name of the resolved StorageClass.
     StorageClassName string `json:"storageClassName"`
 
-    // StorageTier is the storage tier this StorageClass provides.
-    // Set to "Default" when the StorageClass has no
-    // osac.openshift.io/storage-tier label.
+    // StorageTier is the storage tier this StorageClass provides,
+    // taken from the osac.openshift.io/storage-tier label.
     StorageTier string `json:"storageTier"`
 }
 ```
@@ -512,41 +453,35 @@ The `tenant` value is NOT included in `ResolvedStorageClass` because the Tenant
 CR itself is the tenant context. The tenant-to-Default fallback has already been
 applied by the time the resolved list is populated.
 
-**Backward compatibility:** The existing `status.storageClass` (string) field
-is kept as a convenience accessor for the `Default` tier. When a StorageClass
-resolves with tier `Default` (either explicitly labeled or with no tier label),
-`status.storageClass` contains its name. This allows consumers that are not yet
-tier-aware to continue working without changes.
-
-If no `Default` tier resolves for a tenant (neither a tenant-specific SC
-with `storage-tier: Default` or without a tier label, nor a shared Default SC
-with `storage-tier: Default` or without a tier label),
-`status.storageClass` will be empty, even if other tiers (`fast`, `standard`)
-resolved successfully. Consumers that are not tier-aware would fail in this
-case, which is the correct signal: the CSP must configure a `Default` tier
-(tenant-specific or shared) for backward compatibility. This edge case is
-related to Open Question #1 (whether the Tenant should require a `Default`
-tier to be `Ready`).
+The singular `status.storageClass` field is removed entirely. See
+[Migration Path](#migration-path) for upgrade guidance.
 
 ### Implementation Details/Notes/Constraints
 
 #### Resolution algorithm
 
 The Tenant controller resolves **all available tier combinations** for each
-tenant at reconciliation time. For each distinct `storage-tier` value `T` found
-across all StorageClasses labeled with `osac.openshift.io/tenant`:
+tenant at reconciliation time. The controller considers only StorageClasses
+labeled with `osac.openshift.io/tenant=<tenantName>` or
+`osac.openshift.io/tenant=Default`. StorageClasses belonging to other tenants
+are never visible.
+
+StorageClasses missing the `osac.openshift.io/storage-tier` label are ignored
+entirely and are not included in resolution.
+
+For each distinct `storage-tier` value `T` found across StorageClasses labeled
+with `osac.openshift.io/tenant=<tenantName>` or
+`osac.openshift.io/tenant=Default`:
 
 1. Find StorageClasses labeled `osac.openshift.io/tenant=<tenantName>` AND
-   `osac.openshift.io/storage-tier=T` (or no `storage-tier` label when
-   `T` is `Default`).
+   `osac.openshift.io/storage-tier=T`.
    - Exactly one: use it.
    - More than one: duplicate error for this tier (same as the existing
      behavior for the single-tier case).
    - None: proceed to step 2.
 
 2. Find StorageClasses labeled `osac.openshift.io/tenant=Default` AND
-   `osac.openshift.io/storage-tier=T` (or no `storage-tier` label when
-   `T` is `Default`).
+   `osac.openshift.io/storage-tier=T`.
    - Exactly one: use it (shared Default fallback for this tier).
    - More than one: duplicate error for this tier.
    - None: tier `T` is not available for this tenant (not an error at
@@ -559,18 +494,21 @@ the pre-resolved list.
 
 #### Tier selection at provisioning time
 
-The `tenant_storage_class` Ansible role is the selection interface. It accepts
-a `storage_tier` input parameter (defaulting to `"Default"`) and resolves it
-against the tenant's `status.storageClasses` list.
+The `tenant_storage_class` Ansible role is the selection interface. It
+**requires** a `tenant_storage_class_storage_tier` input parameter (no default
+value) and resolves it against the tenant's `status.storageClasses` list.
+
+If the parameter is not provided, the role fails immediately with a descriptive
+error listing the available tiers for the tenant. This forces template authors
+to be explicit about which storage tier their workload needs.
 
 **Who provides the `storage_tier` value** is a separate concern from how the
-role resolves it. This proposal identifies three strategies:
-
-**Strategy A: Template-driven (recommended initial approach).** The VM template
-role (e.g., `osac.templates.database_vm`) hardcodes which tier each disk needs.
-The template author chooses the tier based on the workload type. The tenant
-user selects a template when creating a ComputeInstance and does not need to
-know about storage tiers.
+role resolves it. The initial implementation uses **Strategy A:
+template-driven** selection. The VM template role (e.g.,
+`osac.templates.database_vm`) hardcodes which tier each disk needs. The
+template author chooses the tier based on the workload type. The tenant user
+selects a template when creating a ComputeInstance and does not need to know
+about storage tiers.
 
 ```yaml
 # Inside osac.templates.database_vm/tasks/create.yaml
@@ -581,26 +519,21 @@ know about storage tiers.
     tenant_storage_class_storage_tier: "fast"
 ```
 
-**Strategy B: User-facing DiskSpec field.** A `storageTier` field is added to
-the ComputeInstance `DiskSpec`. The CI controller or Ansible role reads the
-field from the CI spec and passes it to the `tenant_storage_class` role. This
-gives users direct control over storage selection but exposes infrastructure
-details.
-
-**Strategy C: Hybrid.** The template sets a default tier, and a user-facing
-field can override it. This provides flexibility while keeping the common case
-simple.
-
-All three strategies use the same underlying infrastructure: the
-`tenant_storage_class` role receives a `storage_tier` parameter and resolves it
-from `tenant.status.storageClasses`. The initial implementation targets
-Strategy A.
+If user-specified tiers are needed in the future, Strategy B (a `storageTier`
+field on the ComputeInstance `DiskSpec`) or Strategy C (hybrid: template
+default, user override) can be added as a separate enhancement. These
+strategies would require proto changes, fulfillment-service updates, and API
+versioning.
 
 #### StorageClassReady condition updates
 
 The existing `StorageClassReady` condition is extended:
 
 - `Ready` requires at least one tier to resolve successfully.
+- If **no tier resolves successfully** (all have duplicates,
+  MultipleDefaultsFound, or are not found), the Tenant `phase` is set to
+  `Progressing` and the `StorageClassReady` condition is `False` with a
+  message listing all tier resolution failures.
 - Duplicate detection applies per tier. Two StorageClasses for `(tenantX,
   fast)` produces a `MultipleFound` condition, but does not affect
   `(tenantX, standard)`.
@@ -613,16 +546,13 @@ The `tenant_storage_class` role currently reads `tenant.status.storageClass`
 (a single string) and sets `tenant_storage_class_name`. It will be updated to:
 
 1. Read `tenant.status.storageClasses` (the resolved list).
-2. Accept a `tenant_storage_class_storage_tier` input parameter (defaulting to
-   `"Default"`).
+2. **Require** the `tenant_storage_class_storage_tier` input parameter (no
+   default value). Fail immediately if the parameter is not provided, with an
+   error message listing available tiers.
 3. Find the entry in the list whose `storageTier` matches the request.
 4. Set `tenant_storage_class_name` to the matching `storageClassName`.
 5. Fail with a descriptive error if the requested tier is not in the list,
    including the available tiers.
-
-For backward compatibility, if `tenant.status.storageClasses` is not present
-(older Tenant controller), the role falls back to reading
-`tenant.status.storageClass` and treats it as the `Default` tier.
 
 #### Changes per repository
 
@@ -630,22 +560,24 @@ For backward compatibility, if `tenant.status.storageClasses` is not present
 
 - Evolve `getTenantStorageClass()` to `getTenantStorageClasses()`: group
   StorageClasses by `(tenant, storage-tier)` combination and resolve each
-  independently.
+  independently. Ignore StorageClasses missing the `storage-tier` label.
 - Add `ResolvedStorageClass` Go type to the Tenant CRD API.
-- Add `tenant.status.storageClasses` (list of `ResolvedStorageClass`). Keep
-  `status.storageClass` as a convenience field for the `Default` tier.
+- Add `tenant.status.storageClasses` (list of `ResolvedStorageClass`).
+- Remove `status.storageClass` (singular) from the Tenant CRD API.
 - Update `StorageClassReady` condition with per-tier resolution detail.
 - Update unit tests for multi-tier scenarios (multiple tiers resolved,
   duplicate within one tier, missing tier, fallback to shared Default per
-  tier).
+  tier, StorageClass without tier label is ignored).
 
 **osac-aap:**
 
 - Update `tenant_storage_class` role to read `tenant.status.storageClasses`
-  and accept a `tenant_storage_class_storage_tier` input parameter.
-- Update template roles to pass the appropriate tier to
+  and **require** a `tenant_storage_class_storage_tier` input parameter (no
+  default).
+- Update all template roles to explicitly pass the appropriate tier to
   `tenant_storage_class` when invoking it.
-- Update tests for tier-aware lookup.
+- Update tests for tier-aware lookup and for the missing-parameter failure
+  case.
 
 **fulfillment-service:**
 
@@ -663,16 +595,16 @@ For backward compatibility, if `tenant.status.storageClasses` is not present
 making the Tenant status large and hard to reason about.
 
 **Mitigation:** Documentation will recommend a small, well-defined set of tiers
-(e.g., `fast`, `standard`, `archival`). The system does not enforce a fixed
-vocabulary, but operational guidance will discourage excessive granularity.
+(e.g., `fast`, `standard`, `archival`, `default`). The system does not enforce
+a fixed vocabulary, but operational guidance will discourage excessive
+granularity.
 
-**Risk: Backward compatibility during upgrade.** Existing deployments have
-`tenant.status.storageClass` (string). If the field is removed, consumers
-that have not been updated will break.
+**Risk: Breaking change for existing dev/test environments.** Existing
+StorageClasses may lack the `storage-tier` label, and existing code may read
+`status.storageClass` (singular).
 
-**Mitigation:** The singular `status.storageClass` field is retained as a
-convenience accessor that points to the `Default` tier. Consumers are migrated
-to read from `status.storageClasses` but are not immediately broken.
+**Mitigation:** OSAC is pre-release with no production deployments. A one-time
+migration is documented in the [Migration Path](#migration-path) section.
 
 **Risk: Duplicate detection complexity.** With multiple tiers, the number of
 potential duplicate scenarios increases.
@@ -683,12 +615,138 @@ each resolution step.
 
 ### Drawbacks
 
-This design adds a dimension of complexity to the StorageClass selection
-process. For CSPs that only need a single StorageClass per tenant, the new
-`storage-tier` label is unnecessary overhead. The backward-compatible defaults
-(omitted label = `Default` tier, omitted parameter = `Default` tier) ensure
-these CSPs are not burdened by the feature, but the Tenant controller must
-still handle the multi-tier resolution path.
+This design introduces a breaking change to the Tenant CRD status API. The
+singular `status.storageClass` field is removed and all StorageClasses must
+carry a `storage-tier` label. For CSPs that only need a single StorageClass per
+tenant, the required `storage-tier` label is additional configuration overhead.
+However, the label is a single key-value pair, and the explicit-over-implicit
+approach prevents the ambiguity that an optional label with a magic fallback
+would create.
+
+## Migration Path
+
+This section describes the one-time migration from the current single-tier
+system to the multi-tier system. OSAC is pre-release with no production
+deployments, so this migration applies only to development and test
+environments.
+
+### Step 1: Label existing StorageClasses
+
+Add the `osac.openshift.io/storage-tier` label to every existing StorageClass
+that has an `osac.openshift.io/tenant` label. For StorageClasses that serve as
+the general-purpose tier, use the conventional value `default`:
+
+```bash
+# Find all OSAC-managed StorageClasses and add the tier label
+for sc in $(oc get storageclass -l osac.openshift.io/tenant \
+  -o jsonpath='{.items[*].metadata.name}'); do
+  oc label storageclass "$sc" osac.openshift.io/storage-tier=default
+done
+```
+
+After this step, the Tenant controller will include these StorageClasses in its
+resolution. Before this step, the updated controller ignores them (missing
+required label).
+
+### Step 2: Update osac-operator
+
+Deploy the updated osac-operator that:
+
+- Requires the `osac.openshift.io/storage-tier` label on all StorageClasses.
+- Populates `tenant.status.storageClasses` (list).
+- No longer populates `tenant.status.storageClass` (singular).
+
+After the operator is updated and the StorageClasses are labeled, the Tenant
+status will contain the new `storageClasses` list.
+
+### Step 3: Update osac-aap
+
+Deploy the updated osac-aap that:
+
+- Reads `tenant.status.storageClasses` instead of `tenant.status.storageClass`.
+- Requires `tenant_storage_class_storage_tier` on all role invocations.
+
+All template roles must be updated to pass `tenant_storage_class_storage_tier`
+explicitly (e.g., `default` for general-purpose templates, `fast` for database
+templates).
+
+### Step 4: Remove the singular field from the CRD
+
+Once all consumers have been updated, the `status.storageClass` field can be
+removed from the CRD schema. Since osac-operator and osac-aap are deployed
+together in practice, Steps 2-4 can be combined into a single deployment.
+
+### Ordering
+
+Steps 1 and 2 can be applied in either order. If the operator is updated first,
+existing StorageClasses without tier labels will be ignored until they are
+labeled. If StorageClasses are labeled first, the old operator will ignore the
+new label (it does not read it).
+
+The recommended order is: label StorageClasses (Step 1), then deploy the
+updated operator and AAP together (Steps 2-4).
+
+## Design Decisions
+
+The following questions were raised during review and resolved before this
+proposal was finalized.
+
+### 1. Should the Tenant require a `default` tier to be Ready?
+
+**Decision: No.** The only requirement is that at least one tier resolves
+successfully. Which tier(s) exist is the CSP's choice.
+
+**Rationale:** Requiring a specific tier name couples the controller to naming
+conventions. A CSP that only provides specialized tiers (`fast`, `gpu`) should
+not be forced to also create a `default` tier. Templates must specify which
+tier they need; there are no assumptions about which tiers exist.
+
+### 2. Should tier names be validated against a predefined vocabulary?
+
+**Decision: No. Tier names are freeform.** Values must follow Kubernetes label
+syntax, but OSAC does not enforce a fixed list.
+
+**Rationale:** Different CSPs have different storage offerings. Hardcoding tier
+names in the controller is inflexible and would require controller updates as
+storage technology evolves (e.g., `nvme-gen5`, `persistent-memory`). Instead,
+the proposal documents recommended conventions (`fast`, `standard`, `archival`,
+`default`) without enforcing them.
+
+### 3. Should tenant users be able to specify storage tiers?
+
+**Decision: Start with Strategy A (template-driven) only.** Templates encode
+the storage requirement. Users select templates based on workload type, not
+infrastructure details.
+
+**Rationale:** Templates are the right abstraction layer for storage decisions.
+A `database_vm` template knows it needs `fast` storage; a user does not need to
+think about it. Adding user-specified tiers (Strategy B/C) introduces
+complexity: proto changes, fulfillment-service updates, API versioning, and two
+paths to the same outcome. If tenant feedback shows a need for user-specified
+tiers, Strategy C (hybrid: template default, user override) can be added as a
+future enhancement.
+
+### 4. Should `status.storageClass` (singular) be deprecated or removed?
+
+**Decision: Removed.** The field is deleted from the CRD, not deprecated.
+
+**Rationale:** OSAC is pre-release with zero deployed consumers. Retaining a
+deprecated field perpetuates the idea that a single tier is special and creates
+permanent API surface that is unlikely to ever be removed. A clean break is
+simpler and aligns with the explicit-tier-selection philosophy. See
+[Migration Path](#migration-path) for upgrade guidance.
+
+### 5. Should the `storage-tier` label be required or optional?
+
+**Decision: Required.** The Tenant controller ignores StorageClasses missing
+the `osac.openshift.io/storage-tier` label.
+
+**Rationale:** An optional label with an implicit "Default" fallback creates
+ambiguity: is `Default` a real tier name or an internal sentinel? Making the
+label required eliminates this confusion. CSPs that want a general-purpose tier
+label it `default` (lowercase, by convention), but the controller assigns no
+magic behavior to any tier name. Since OSAC is pre-release, there is no
+backward-compatibility cost to making this required.
 
 ## Alternatives (Not Implemented)
 
@@ -702,26 +760,25 @@ instead of a list of structs. This was considered but rejected because:
 - Kubernetes CRD validation works better with lists than with maps of
   arbitrary keys.
 
-## Open Questions
+**Alternative 2: Optional storage-tier label with implicit "Default" fallback.**
+The original proposal made the `storage-tier` label optional, with missing
+labels treated as a capitalized `Default` sentinel. This was rejected during
+review because:
 
-1. Should the Tenant require a `Default` tier to be `Ready`, or is it
-   sufficient to have any tier resolve? If a tenant only has `fast` storage
-   and a template requests `Default`, should the system error?
+- The capitalized `Default` sentinel creates confusion: is it a real tier name
+  or an internal marker?
+- Implicit fallback behavior is harder to reason about and debug.
+- OSAC is pre-release, so backward compatibility is not a constraint.
+- Making the label required eliminates an entire class of ambiguity.
 
-2. Should tier names be validated against a predefined vocabulary, or remain
-   freeform? Freeform is more flexible but risks inconsistency across tenants.
+**Alternative 3: Deprecate `status.storageClass` instead of removing it.** The
+singular field could be deprecated and retained for backward compatibility.
+This was rejected because:
 
-3. **Should tenant users be able to specify storage tiers?** In Strategy A,
-   the template author (Tenant Admin) decides which tier each disk uses and
-   the user has no control. If user-specified tiers are desired, there are
-   two mechanisms: a configurable template that reads the tier from
-   `templateParameters`, or a dedicated `storageTier` field on the
-   ComputeInstance `DiskSpec` (Strategy B). Both achieve the same result
-   (user provides the tier value), but differ in scope: a template parameter
-   is scoped to templates that opt in, while a DiskSpec field is available
-   on every ComputeInstance. If Strategy B is adopted, the proto/public API
-   would also need a `storage_tier` field, requiring buf regeneration and
-   fulfillment-service proto updates.
+- OSAC is pre-release with zero deployed consumers reading this field.
+- Retaining the field perpetuates the idea that a single "default" tier is
+  special, contradicting the explicit-tier-selection philosophy.
+- A deprecated field that is never removed becomes permanent API surface.
 
 ## Test Plan
 
@@ -729,18 +786,21 @@ instead of a list of structs. This was considered but rejected because:
 
 - Tenant controller: resolve multiple tiers per tenant, duplicate detection
   per tier, fallback to shared Default per tier, mixed (some tiers from tenant,
-  some from Default), backward-compatible single SC with no tier label.
+  some from Default).
+- StorageClass without `storage-tier` label is ignored entirely.
 - Verify `status.storageClasses` list is populated correctly.
-- Verify `status.storageClass` (singular) still contains the `Default` tier.
+- Verify `status.storageClass` (singular) is NOT populated.
+- All tiers fail to resolve: Tenant is Progressing, StorageClassReady is
+  False with message listing all failures.
 
 **Unit tests (osac-aap):**
 
 - `tenant_storage_class` role with `tenant_storage_class_storage_tier`
-  parameter: resolve `fast` tier, resolve `Default` tier, resolve when no
-  tier parameter is provided (defaults to `Default`), fail when requested
-  tier is not in the list (verify error message includes available tiers),
-  backward-compatible fallback to `status.storageClass` when
-  `status.storageClasses` is absent.
+  parameter: resolve `fast` tier, resolve `default` tier.
+- Fail when `tenant_storage_class_storage_tier` is not provided (verify error
+  message includes available tiers).
+- Fail when requested tier is not in the list (verify error message includes
+  available tiers).
 
 **E2E tests:**
 
@@ -748,16 +808,29 @@ instead of a list of structs. This was considered but rejected because:
   Tenant status.
 - Template requests `fast` tier: verify the DataVolume uses the `fast`
   StorageClass.
-- Template requests no tier (Default): verify the DataVolume uses the
-  `Default` StorageClass.
+- Template requests `default` tier: verify the DataVolume uses the `default`
+  StorageClass.
 - Shared Default fallback per tier: tenant has no dedicated `fast` SC, verify
   the shared Default `fast` SC is used.
 - Tier not available: template requests `fast` but only `standard` is
   configured. Verify descriptive error with available tier list.
-- Backward compatibility: existing single-SC tenant (no `storage-tier` label)
-  continues to work without any changes.
 - Duplicate detection per tier: two SCs for `(tenantX, fast)` produces
   `MultipleFound` for that tier, but `(tenantX, standard)` is unaffected.
+- StorageClass without tier label: verify it is ignored by the controller.
+- All tiers fail: verify Tenant is Progressing with StorageClassReady=False.
+
+**Upgrade scenario test:**
+
+- Deploy Tenant with the old controller (single SC, no tier label,
+  `status.storageClass` populated).
+- Label the existing StorageClass with `osac.openshift.io/storage-tier=default`.
+- Upgrade to the new controller.
+- Verify:
+  - `status.storageClasses` (list) is populated with one entry:
+    `{storageClassName: "...", storageTier: "default"}`.
+  - `status.storageClass` (singular) is no longer present.
+  - Templates updated to pass `tenant_storage_class_storage_tier: "default"`
+    continue to provision successfully.
 
 ## Graduation Criteria
 
@@ -766,17 +839,9 @@ Initial implementation targets Dev Preview.
 
 ## Upgrade / Downgrade Strategy
 
-**Upgrade from single-tier to multi-tier:**
-
-- Existing StorageClasses without the `osac.openshift.io/storage-tier` label
-  continue to work. The Tenant controller treats them as tier `Default`.
-- Existing `tenant.status.storageClass` (string) is retained for backward
-  compatibility. Consumers that read the old field continue to get the
-  `Default` tier StorageClass name.
-- The new `tenant.status.storageClasses` (list) is additive. Old consumers
-  that do not read it are unaffected.
-- Templates and roles that do not specify a tier parameter continue to use
-  the `Default` tier.
+See [Migration Path](#migration-path) for upgrade guidance. Since OSAC is
+pre-release, there is no downgrade path. The migration is a one-time breaking
+change applied during development.
 
 ## Version Skew Strategy
 


### PR DESCRIPTION
Proposes extending the tenant-specific StorageClass mechanism (#26) to support multiple storage tiers per tenant.

Adds an `osac.openshift.io/storage-tier` label to StorageClasses, evolves `tenant.status.storageClass` to a `storageClasses` list so the Tenant controller resolves all available tiers, and updates the `tenant_storage_class` Ansible role to accept a tier parameter at provisioning time.

The proposal includes end-to-end workflows, backward compatibility considerations, and open questions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Published Tenant Storage Tiers proposal: introduces a required storage-tier label and a composite (tenant, storage-tier) resolution model with tenant-level fallback and exact storage-tier matching.
  * Describes controller behavior to publish per-tier storage-class results (replacing the single storage-class), per-tier readiness/failure semantics, and aggregated condition handling.
  * Documents automation updates requiring a tier parameter, example workflows, and migration steps for existing environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->