### PR TITLE
Add Cluster-as-a-Service enhancement proposal

### DIFF
--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -18,16 +18,16 @@ superseded-by:
 
 ## Summary
 
-This proposal promotes cluster configuration parameters from generic
-`template_parameters` (opaque `map<string, Any>`) to explicit typed fields in
-the `ClusterSpec` protobuf message, following the same approach already taken
-for VMaaS (where `vm_cpu_cores`, `vm_memory`, etc. were promoted to explicit
-`ComputeInstanceSpec` fields like `cores`, `memory_gib`, `boot_disk`).
+This proposal moves cluster configuration out of Ansible templates and into
+the tenant-facing API. Today, key cluster parameters are either buried in the
+opaque `template_parameters` map (`pull_secret`, `ssh_public_key`) or hardcoded
+in Ansible roles (`release_image`, networking CIDRs). Tenants cannot discover
+or control these without knowledge of the underlying templates.
 
-Currently, CaaS still uses the original `template_parameters` pattern, where
-parameters like `pull_secret` and `ssh_public_key` are passed as untyped
-template parameters. This proposal moves them to first-class proto fields,
-providing type safety, discoverability, and proto-level validation.
+This proposal defines explicit typed fields in the `ClusterSpec` protobuf
+message for all tenant-configurable cluster parameters, following the same
+approach already taken for VMaaS (where `vm_cpu_cores`, `vm_memory`, etc. were
+promoted from `template_parameters` to explicit `ComputeInstanceSpec` fields).
 
 This document also formally defines the tenant-facing API contract for the
 Cluster-as-a-Service capability, including lifecycle workflows (create, scale
@@ -36,19 +36,24 @@ nodes, delete) and status semantics.
 
 ## Motivation
 
-The VMaaS API has already been updated to use explicit `ComputeInstanceSpec`
-fields instead of generic `template_parameters`. The CaaS API should follow
-the same pattern for consistency. Cluster configuration parameters (pull secret,
-SSH key) are:
+Currently, creating a cluster requires passing configuration through two
+different mechanisms that are not visible in the API:
 
-- Common across all cluster templates, not template-specific
-- Sensitive credentials that benefit from explicit field semantics
-- Discoverable from the proto definition without inspecting template metadata
+1. **`template_parameters`**: An opaque `map<string, Any>` where `pull_secret`
+   and `ssh_public_key` are passed as untyped values. Tenants must know the
+   parameter names and types by inspecting the template definition.
+2. **Hardcoded values in Ansible roles**: `release_image` (OCP version),
+   `cluster_network_cidr`, and `service_network_cidr` are baked into the
+   playbooks. Tenants have no way to customize these at all.
 
-By promoting these to explicit `ClusterSpec` fields, the API becomes
-self-documenting and the CLI can offer dedicated flags (e.g., `--pull-secret`,
-`--ssh-public-key`) instead of the generic `--template-parameter name=value`
-syntax.
+The VMaaS API has already been updated to move parameters from
+`template_parameters` to explicit `ComputeInstanceSpec` fields (`cores`,
+`memory_gib`, `boot_disk`, etc.). The CaaS API should follow the same pattern.
+
+By defining explicit `ClusterSpec` fields, the API becomes self-documenting,
+the CLI can offer dedicated flags (e.g., `--pull-secret`, `--release-image`,
+`--cluster-network-cidr`), and tenants gain control over configuration that is
+currently hidden in templates or hardcoded.
 
 ### User Stories
 

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -1,0 +1,465 @@
+---
+title: cluster-as-a-service
+authors:
+  - Elad Tabak
+creation-date: 2026-03-31
+last-updated: 2026-03-31
+tracking-link:
+  - https://redhat.atlassian.net/browse/MGMT-23417
+see-also:
+  - "/enhancements/vmaas"
+  - "/enhancements/bare-metal-fulfillment"
+replaces:
+superseded-by:
+---
+
+# Cluster-as-a-Service
+
+
+## Summary
+
+This document proposes a service enabling tenants to provision, manage, and
+operate OpenShift clusters within a self-service environment. The service
+provides APIs for creating clusters from pre-defined templates, scaling node
+sets, accessing cluster credentials, and managing the full cluster lifecycle.
+Clusters are provisioned as HyperShift HostedClusters on bare-metal hosts
+managed through HostPools.
+
+
+## Motivation
+
+Cluster-as-a-Service (CaaS) addresses the need for on-demand OpenShift
+clusters within a multi-tenant environment. By providing a self-service API
+backed by pre-defined templates, tenants can create and manage clusters without
+requiring deep infrastructure knowledge. This addresses a need identified in the
+scope of O-SAC, and will benefit the MOC.
+
+### User Stories
+
+- As a provider, I want to define cluster templates that my tenants will be
+  able to use
+- As a tenant, I want to list pre-defined cluster templates with their
+  available parameters and host classes
+- As a tenant, I want to create an OpenShift cluster based on a pre-defined
+  template
+- As a tenant, I want to scale the number of nodes in my cluster by adjusting
+  node set sizes
+- As a tenant, I want to access my cluster via kubeconfig and web console
+- As a tenant, I want to retrieve the admin password for my cluster
+- As a tenant, I want to delete my cluster and have all associated resources
+  cleaned up
+
+### Goals
+
+- Provide a self-service API for tenants to create, manage, and operate
+  OpenShift clusters with minimal operational overhead
+- Support a catalog of pre-defined cluster templates
+- Enable node scaling by allowing tenants to modify node set sizes
+- Provide credential access (kubeconfig, admin password, console URL)
+- Align with the existing O-SAC fulfillment workflow used by VMaaS
+
+### Non-Goals
+
+The following are explicitly out of scope for this proposal:
+
+- Implementing multi-region cluster placement
+- Implementing cluster auto-scaling based on workload demand
+- Cluster version upgrades (will be addressed in a separate proposal)
+- Advanced networking features such as VPNs, peering, or custom network
+  topologies
+- Storage provisioning beyond the default StorageClass
+- Cluster add-ons management (monitoring, logging, etc.)
+
+
+## Proposal
+
+The process of fulfilling cluster requests is based on two primary APIs:
+
+* **Cluster**: Represents a provisioned OpenShift cluster that a tenant can
+  create and manage. Tenants can only see the clusters they created.
+* **ClusterTemplate**: Defined by the provider, this is a pre-configured
+  blueprint for clusters. Each template is identified by a unique template ID
+  and includes a set of parameters (some required, some optional) that tenants
+  can specify when creating a cluster, as well as initial node set definitions.
+  Templates are available to all tenants to use; they cannot edit them.
+
+To request a new Cluster, tenants must provide:
+
+* The ID of the desired ClusterTemplate
+* Any required or optional parameters for that template
+* Optionally, custom node requests specifying host classes and node counts
+  (defaults are provided by the template)
+
+The cluster fulfillment process aligns with the existing O-SAC fulfillment
+workflows. To support this, the following O-SAC components will be enhanced or
+updated:
+
+* **Fulfillment Service**: Defines and exposes the APIs for managing Cluster
+  and ClusterTemplate resources.
+* **Fulfillment CLI**: Provides tenants with command-line access to the
+  Fulfillment Service APIs.
+* **O-SAC Operator**: Monitors and reconciles ClusterOrder custom resources
+  within the system.
+* **O-SAC AAP (Ansible Automation Platform)**: Executes automation tasks (via
+  Ansible playbooks) to reconcile ClusterOrder resources, including
+  interactions with HyperShift for cluster lifecycle management and ESI for
+  bare-metal host allocation.
+
+### Workflow Description
+
+#### Cluster creation
+
+1. The tenant initiates the creation of a new Cluster using the Fulfillment
+   CLI. The tenant must provide:
+    - The ID of the desired ClusterTemplate
+    - All required and any optional parameters for the template
+    - Optionally, custom node requests specifying the host class and number of
+      nodes for each node set
+
+2. The Fulfillment Service receives this request and performs validation to
+   ensure:
+    - The specified template exists and is available
+    - All required parameters are provided and valid
+    - The requested host classes exist
+
+3. Upon successful validation, the Fulfillment Service creates a new
+   ClusterOrder custom resource (CR) in the appropriate Hub and namespace.
+
+4. The O-SAC Operator detects the new ClusterOrder CR and begins the
+   reconciliation process.
+
+5. The Operator, using Ansible Automation Platform (AAP), automates the
+   following steps:
+    - Creates a HostPool to allocate the required bare-metal hosts (see
+      [Bare Metal Fulfillment](/enhancements/bare-metal-fulfillment) for details)
+    - Creates a HyperShift HostedCluster with the allocated hosts as worker
+      nodes
+    - Configures the cluster according to the template parameters
+    - Performs any additional operations required by the selected template
+
+6. The Operator continuously monitors the cluster's status and updates the
+   ClusterOrder CR status to reflect the current state, including `api_url`
+   and `console_url` when the cluster is ready.
+
+7. The tenant can check the cluster's status at any time using the Fulfillment
+   CLI or API, and can access the cluster via the provided API URL and console
+   URL.
+
+#### Node scaling
+
+When a tenant requests a change to the node set sizes, the following workflow
+is executed:
+
+1. The tenant updates the node set sizes for an existing cluster using the
+   Fulfillment CLI or API.
+
+2. The Fulfillment Service validates the update:
+    - The host class for existing node sets cannot be changed
+    - New node sets can be added
+    - At least one node set must remain
+
+3. The Fulfillment Service updates the ClusterOrder CR with the new node
+   requests.
+
+4. The Operator detects the configuration change and triggers a
+   re-provisioning cycle via AAP.
+
+5. AAP adjusts the HostPool allocation and HyperShift NodePool sizes to match
+   the requested node counts.
+
+6. The cluster status is updated to reflect the new node allocation once
+   complete.
+
+#### Cluster deletion
+
+When a tenant requests the deletion of a Cluster, the following workflow is
+executed:
+
+1. The tenant initiates the deletion of a Cluster using the Fulfillment CLI or
+   API by specifying its identifier.
+
+2. The Fulfillment Service receives the deletion request and performs
+   validation to ensure:
+    - The specified Cluster resource exists
+    - The tenant has permission to delete the resource
+
+3. Upon successful validation, the Fulfillment Service deletes the ClusterOrder
+   custom resource (CR) from the appropriate namespace.
+
+4. The O-SAC Operator detects the deletion of the ClusterOrder CR and begins
+   the cleanup process.
+
+5. The Operator, using AAP, automates the following steps:
+    - Deletes the HyperShift HostedCluster resource
+    - Releases all allocated bare-metal hosts back to the pool
+    - Performs any additional cleanup operations required by the selected
+      cluster template
+
+6. The Operator updates the status of the deletion operation and ensures all
+   resources are properly cleaned up. If the deletion fails, the cluster
+   remains in a Deleting state to prevent orphaned infrastructure.
+
+7. The tenant can confirm the deletion and cleanup via the Fulfillment CLI or
+   API.
+
+This workflow ensures that all resources associated with the Cluster are
+properly deprovisioned and that no orphaned resources remain.
+
+#### Cluster template management
+
+Cluster templates are centrally managed by the provider using a GitOps
+approach. All templates are stored in a version-controlled repository, which
+acts as the single source of truth. At regular intervals, an automated job in
+Ansible Automation Platform (AAP) synchronizes the latest templates from this
+repository to the Fulfillment Service. As a result, any changes to the
+templates are automatically and consistently reflected in the Fulfillment
+Service. This process ensures that tenants always have access to the most
+current catalog of available cluster templates.
+
+### API Extensions
+
+#### Cluster
+
+A tenant requests an OpenShift cluster by requesting a Cluster to the
+Fulfillment Service. Here is an example of a request that creates a cluster
+using a template with two node sets:
+
+```json
+{
+  "object": {
+    "id": "mycluster",
+    "spec": {
+      "template": "hosted_cluster",
+      "template_parameters": {
+        "cluster_version": {
+          "value": "4.16"
+        }
+      },
+      "node_sets": {
+        "compute": {
+          "host_class": "acme_1tb",
+          "size": 3
+        },
+        "gpu": {
+          "host_class": "acme_1tb_h100",
+          "size": 2
+        }
+      }
+    }
+  }
+}
+```
+
+After creating a cluster, tenants can check its current status and details as
+follows:
+
+```json
+{
+  "@type": "type.googleapis.com/fulfillment.v1.Cluster",
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "metadata": {
+    "creation_timestamp": "2026-03-31T10:00:00.000000Z",
+    "creators": [
+      "tenant-user"
+    ]
+  },
+  "spec": {
+    "template": "hosted_cluster",
+    "template_parameters": {
+      "cluster_version": {
+        "value": "4.16"
+      }
+    },
+    "node_sets": {
+      "compute": {
+        "host_class": "acme_1tb",
+        "size": 3
+      },
+      "gpu": {
+        "host_class": "acme_1tb_h100",
+        "size": 2
+      }
+    }
+  },
+  "status": {
+    "state": "CLUSTER_STATE_READY",
+    "api_url": "https://api.mycluster.example.com:6443",
+    "console_url": "https://console.mycluster.example.com",
+    "conditions": [
+      {
+        "type": "CLUSTER_CONDITION_TYPE_READY",
+        "status": "CONDITION_STATUS_TRUE",
+        "last_transition_time": "2026-03-31T10:30:00.000000Z",
+        "message": "The cluster is ready to use"
+      },
+      {
+        "type": "CLUSTER_CONDITION_TYPE_PROGRESSING",
+        "status": "CONDITION_STATUS_FALSE",
+        "last_transition_time": "2026-03-31T10:30:00.000000Z"
+      },
+      {
+        "type": "CLUSTER_CONDITION_TYPE_FAILED",
+        "status": "CONDITION_STATUS_FALSE",
+        "last_transition_time": "2026-03-31T10:00:00.000000Z"
+      },
+      {
+        "type": "CLUSTER_CONDITION_TYPE_DEGRADED",
+        "status": "CONDITION_STATUS_FALSE",
+        "last_transition_time": "2026-03-31T10:00:00.000000Z"
+      }
+    ],
+    "node_sets": {
+      "compute": {
+        "host_class": "acme_1tb",
+        "size": 3
+      },
+      "gpu": {
+        "host_class": "acme_1tb_h100",
+        "size": 2
+      }
+    }
+  }
+}
+```
+
+The cluster can be in one of the following states:
+
+- **Progressing** (`CLUSTER_STATE_PROGRESSING`): The cluster is being created
+  or updated.
+- **Ready** (`CLUSTER_STATE_READY`): The cluster is fully operational and
+  accessible via the API URL and console URL.
+- **Failed** (`CLUSTER_STATE_FAILED`): The cluster creation or update has
+  failed.
+
+The conditions provide additional detail:
+
+- **Progressing** (`CLUSTER_CONDITION_TYPE_PROGRESSING`): The cluster is not
+  yet fully ready.
+- **Ready** (`CLUSTER_CONDITION_TYPE_READY`): The cluster is ready to use.
+- **Failed** (`CLUSTER_CONDITION_TYPE_FAILED`): The cluster is unusable.
+- **Degraded** (`CLUSTER_CONDITION_TYPE_DEGRADED`): The cluster is operational
+  but not at full capacity (e.g., the system cannot allocate all requested
+  nodes).
+
+Tenants can retrieve cluster credentials using the Fulfillment CLI or API:
+
+- **GetKubeconfig**: Returns the admin kubeconfig for the cluster, allowing
+  direct access via `oc`, `kubectl`, or other Kubernetes-compatible tools.
+- **GetPassword**: Returns the admin password for the cluster console.
+
+#### ClusterTemplate
+
+Cluster templates are implemented as Ansible roles, following the same pattern
+as [VMaaS templates](/enhancements/vmaas). Each role defines the cluster
+configuration, including default node sets and available parameters.
+
+A periodic job will publish the Ansible roles as cluster templates to the
+Fulfillment Service. The following is the API format used for this publication:
+
+```json
+{
+  "object": {
+    "id": "hosted_cluster",
+    "title": "Hosted OpenShift Cluster",
+    "description": "Provisions a HyperShift HostedCluster on bare-metal hosts.",
+    "parameters": [
+      {
+        "name": "cluster_version",
+        "title": "OpenShift Version",
+        "description": "The version of OpenShift to install",
+        "required": true,
+        "type": "type.googleapis.com/google.protobuf.StringValue"
+      }
+    ],
+    "node_sets": {
+      "compute": {
+        "host_class": "acme_1tb",
+        "size": 3
+      }
+    }
+  }
+}
+```
+
+### Implementation Details/Notes/Constraints
+
+This proposal is built upon HyperShift, which provides hosted control planes
+for multi-tenant OpenShift cluster provisioning. By using HyperShift, each
+tenant's cluster gets its own dedicated control plane hosted on the hub cluster,
+while worker nodes run on bare-metal hosts allocated via HostPools.
+
+The key architectural decisions are:
+
+- **Hosted control planes**: Each cluster's control plane runs as pods on the
+  hub cluster, providing strong isolation between tenants without requiring
+  dedicated control plane hardware.
+- **Bare-metal worker nodes**: Worker nodes are provisioned on dedicated
+  bare-metal hosts via the HostPool mechanism described in the
+  [Bare Metal Fulfillment](/enhancements/bare-metal-fulfillment) proposal.
+  This provides tenants with full hardware access for their workloads.
+- **Node sets**: Clusters support multiple node sets, each with a different
+  host class. This allows tenants to mix hardware types (e.g., GPU and
+  non-GPU nodes) within a single cluster.
+- **Credential access**: Tenants access their clusters through the API URL
+  (OpenShift API server) and console URL (OpenShift web console). The Fulfillment
+  Service provides endpoints for retrieving the kubeconfig and admin password.
+
+### Risks and Mitigations
+
+TBD
+
+### Drawbacks
+
+#### Cluster creation time
+
+Cluster creation is inherently slower than VM creation due to multi-node
+bare-metal provisioning and HyperShift control plane setup. Tenants should
+expect creation times on the order of minutes rather than seconds.
+
+#### Bare metal availability
+
+Clusters cannot be created without available hosts matching the requested host
+classes. If the system cannot allocate the required number of nodes, the cluster
+will be marked as degraded, and the details will be reported in the `DEGRADED`
+condition.
+
+#### Node set constraints
+
+Node scaling is limited to changing the node count within existing host classes
+or adding new node sets. The host class of an existing node set cannot be
+changed after creation. At least one node set must remain at all times.
+
+
+## Alternatives (Not Implemented)
+
+
+## Open Questions [optional]
+
+
+## Test Plan
+
+TBD
+
+## Graduation Criteria
+
+TBD
+
+### Removing a deprecated feature
+
+N/A
+
+## Upgrade / Downgrade Strategy
+
+N/A
+
+## Version Skew Strategy
+
+N/A
+
+## Support Procedures
+
+TBD
+
+## Infrastructure Needed [optional]
+
+N/A

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -3,7 +3,7 @@ title: cluster-as-a-service
 authors:
   - Elad Tabak
 creation-date: 2026-03-31
-last-updated: 2026-03-31
+last-updated: 2026-04-13
 tracking-link:
   - https://redhat.atlassian.net/browse/MGMT-23417
 see-also:
@@ -18,21 +18,23 @@ superseded-by:
 
 ## Summary
 
-This document proposes a service enabling tenants to provision, manage, and
-operate OpenShift clusters within a self-service environment. The service
-provides APIs for creating clusters from pre-defined templates, scaling node
-sets, accessing cluster credentials, and managing the full cluster lifecycle.
-Clusters are provisioned as HyperShift HostedClusters on bare-metal hosts
-managed through HostPools.
+This document defines the tenant-facing API contract for the Cluster-as-a-Service
+capability. It specifies the Cluster and ClusterTemplate resources, their
+endpoints, request/response formats, status semantics, and lifecycle workflows
+(create, scale nodes, delete). Clusters are provisioned as HyperShift
+HostedClusters on bare-metal hosts managed through HostPools, following the
+existing O-SAC fulfillment workflow.
 
 
 ## Motivation
 
-Cluster-as-a-Service (CaaS) addresses the need for on-demand OpenShift
-clusters within a multi-tenant environment. By providing a self-service API
-backed by pre-defined templates, tenants can create and manage clusters without
-requiring deep infrastructure knowledge. This addresses a need identified in the
-scope of O-SAC, and will benefit the MOC.
+The Cluster-as-a-Service (CaaS) capability already exists in O-SAC, enabling
+on-demand OpenShift clusters within a multi-tenant environment. However, the
+tenant-facing API has not been formally defined. This proposal specifies the
+explicit API contract — the Cluster and ClusterTemplate resources, their
+endpoints, lifecycle workflows, and status semantics — so that tenants can
+create and manage clusters through a well-defined, self-service interface
+without requiring deep infrastructure knowledge.
 
 ### User Stories
 

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -3,7 +3,7 @@ title: cluster-as-a-service
 authors:
   - Elad Tabak
 creation-date: 2026-03-31
-last-updated: 2026-04-15
+last-updated: 2026-04-16
 tracking-link:
   - https://redhat.atlassian.net/browse/MGMT-23417
 see-also:
@@ -33,8 +33,8 @@ discover or control these without knowledge of the underlying templates:
    untyped `Any` values. Tenants must know the parameter names and types by
    inspecting template definitions.
 2. **Hardcoded in Ansible roles**: `release_image` (OCP version),
-   `cluster_network_cidr`, and `service_network_cidr` are baked into the
-   playbooks. Tenants cannot customize these at all.
+   pod network CIDR, and service network CIDR are baked into the playbooks.
+   Tenants cannot customize these at all.
 
 The VMaaS API has already moved parameters from `template_parameters` to
 explicit `ComputeInstanceSpec` fields (`cores`, `memory_gib`, `boot_disk`,
@@ -92,8 +92,8 @@ defaults, so existing behavior is preserved.
   }
 }
 // release_image hardcoded in template defaults/main.yaml
-// cluster_network_cidr (10.132.0.0/14) hardcoded in hosted_cluster role
-// service_network_cidr (172.31.0.0/16) hardcoded in hosted_cluster role
+// pod CIDR (10.128.0.0/14) hardcoded in hosted_cluster role
+// service CIDR (172.30.0.0/16) hardcoded in hosted_cluster role
 ```
 
 **After** (proposed):
@@ -105,8 +105,10 @@ defaults, so existing behavior is preserved.
     "pull_secret": "...",
     "ssh_public_key": "ssh-ed25519 ...",
     "release_image": "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
-    "cluster_network_cidr": "10.132.0.0/14",
-    "service_network_cidr": "172.31.0.0/16"
+    "network": {
+      "pod_cidr": "10.128.0.0/14",
+      "service_cidr": "172.30.0.0/16"
+    }
   }
 }
 ```
@@ -127,8 +129,8 @@ fulfillment-cli create cluster \
   --pull-secret <pull-secret> \
   --ssh-public-key "ssh-ed25519 ..." \
   --release-image "quay.io/.../ocp-release:4.17.0-multi" \
-  --cluster-network-cidr "10.132.0.0/14" \
-  --service-network-cidr "172.31.0.0/16"
+  --pod-cidr "10.128.0.0/14" \
+  --service-cidr "172.30.0.0/16"
 ```
 
 All flags are optional. If omitted, the system uses provider defaults (for
@@ -136,18 +138,24 @@ credentials) or template/role defaults (for release image and CIDRs).
 
 ### API Extensions
 
-Five new fields added to the `ClusterSpec` protobuf message (public and
-private):
+New fields added to the `ClusterSpec` protobuf message (public and private):
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `pull_secret` | string | No | Provider default | Credentials for authenticating to image repositories. Write-only: redacted in GET responses |
 | `ssh_public_key` | string | No | Provider default | SSH public key installed on cluster worker nodes |
 | `release_image` | string | No | Template default | OCP release image URL. Controls the OpenShift version |
-| `cluster_network_cidr` | string | No | `10.132.0.0/14` | CIDR for the cluster's pod network |
-| `service_network_cidr` | string | No | `172.31.0.0/16` | CIDR for the cluster's service network |
+| `network` | `ClusterNetwork` | No | See below | Cluster networking configuration |
 
-CIDRs use plain string notation (e.g., `10.132.0.0/14`), consistent with the
+The `ClusterNetwork` message groups networking fields together for cleaner
+organization as the API grows:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `pod_cidr` | string | No | `10.128.0.0/14` | CIDR for the cluster's pod network |
+| `service_cidr` | string | No | `172.30.0.0/16` | CIDR for the cluster's service network |
+
+CIDRs use plain string notation (e.g., `10.128.0.0/14`), consistent with the
 existing `VirtualNetwork` and `Subnet` proto conventions.
 
 ### Implementation Details/Notes/Constraints

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -223,37 +223,41 @@ current catalog of available cluster templates.
 
 #### Cluster
 
-A tenant requests an OpenShift cluster by requesting a Cluster to the
-Fulfillment Service. Here is an example of a request that creates a cluster
-using a template with two node sets:
+Tenants do not create Cluster resources directly. Instead, they create a
+cluster order via the Fulfillment CLI, which triggers the system to create and
+manage the underlying Cluster resource. The Clusters API (`POST /api/fulfillment/v1/clusters`)
+is a server-internal operation not exposed to tenants.
+
+The following example shows a Cluster resource as it appears in the system after
+creation, with two node sets:
 
 ```json
+POST /api/fulfillment/v1/clusters (server-internal)
+
 {
-  "object": {
-    "spec": {
-      "template": "hosted_cluster",
-      "template_parameters": {
-        "cluster_version": {
-          "value": "4.16"
-        }
+  "spec": {
+    "template": "hosted_cluster",
+    "template_parameters": {
+      "cluster_version": {
+        "value": "4.16"
+      }
+    },
+    "node_sets": {
+      "compute": {
+        "host_class": "acme_1tb",
+        "size": 3
       },
-      "node_sets": {
-        "compute": {
-          "host_class": "acme_1tb",
-          "size": 3
-        },
-        "gpu": {
-          "host_class": "acme_1tb_h100",
-          "size": 2
-        }
+      "gpu": {
+        "host_class": "acme_1tb_h100",
+        "size": 2
       }
     }
   }
 }
 ```
 
-After creating a cluster, tenants can check its current status and details as
-follows:
+Tenants can check the cluster's status via the Fulfillment CLI or the
+`GET /api/fulfillment/v1/clusters/{id}` endpoint:
 
 ```json
 {

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -3,7 +3,7 @@ title: cluster-as-a-service
 authors:
   - Elad Tabak
 creation-date: 2026-03-31
-last-updated: 2026-04-13
+last-updated: 2026-04-15
 tracking-link:
   - https://redhat.atlassian.net/browse/MGMT-23417
 see-also:
@@ -201,7 +201,7 @@ executed:
 
 6. Once cleanup completes successfully, the Operator removes the finalizer,
    allowing Kubernetes to garbage-collect the CR. If the deletion fails, the
-   cluster remains in a Deleting state with the finalizer intact to prevent
+   cluster retains its `deletion_timestamp` and finalizer intact to prevent
    orphaned infrastructure.
 
 7. The tenant can confirm the deletion and cleanup via the Fulfillment CLI or
@@ -339,8 +339,10 @@ The cluster can be in one of the following states:
   to determine if all requested nodes are available.
 - **Failed** (`CLUSTER_STATE_FAILED`): The cluster creation or update has
   failed.
-- **Deleting** (`CLUSTER_STATE_DELETING`): The cluster is being deleted.
-  Resources are being cleaned up (HostedCluster, HostPool, bare-metal hosts).
+Deletion is indicated by the presence of a `deletion_timestamp` in the cluster
+metadata rather than a separate state. While the cluster is being deleted,
+resources are cleaned up (HostedCluster, HostPool, bare-metal hosts) and the
+finalizer prevents garbage collection until cleanup completes.
 
 The conditions provide additional detail:
 

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -141,7 +141,7 @@ private):
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `pull_secret` | string | No | Provider default | Credentials for authenticating to image repositories |
+| `pull_secret` | string | No | Provider default | Credentials for authenticating to image repositories. Write-only: redacted in GET responses |
 | `ssh_public_key` | string | No | Provider default | SSH public key installed on cluster worker nodes |
 | `release_image` | string | No | Template default | OCP release image URL. Controls the OpenShift version |
 | `cluster_network_cidr` | string | No | `10.132.0.0/14` | CIDR for the cluster's pod network |
@@ -155,7 +155,9 @@ existing `VirtualNetwork` and `Subnet` proto conventions.
 The new fields must flow through the full stack:
 
 1. **Proto → Server**: New fields added to `ClusterSpec` proto. Server
-   validates values (e.g., CIDR format) and applies defaults.
+   validates values (e.g., CIDR format) and applies defaults. Templates can
+   override the system defaults for any field (e.g., a template can set a
+   specific `release_image`).
 2. **Server → Controller**: Controller maps new proto fields to ClusterOrder
    CR spec. The CR schema needs corresponding new fields.
 3. **Controller → Operator → AAP**: Operator reads new CR fields and passes

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -325,8 +325,9 @@ The cluster can be in one of the following states:
 
 - **Progressing** (`CLUSTER_STATE_PROGRESSING`): The cluster is being created
   or updated.
-- **Ready** (`CLUSTER_STATE_READY`): The cluster is fully operational and
-  accessible via the API URL and console URL.
+- **Ready** (`CLUSTER_STATE_READY`): The cluster control plane is operational
+  and accessible via the API URL and console URL. Check the DEGRADED condition
+  to determine if all requested nodes are available.
 - **Failed** (`CLUSTER_STATE_FAILED`): The cluster creation or update has
   failed.
 
@@ -337,8 +338,10 @@ The conditions provide additional detail:
 - **Ready** (`CLUSTER_CONDITION_TYPE_READY`): The cluster is ready to use.
 - **Failed** (`CLUSTER_CONDITION_TYPE_FAILED`): The cluster is unusable.
 - **Degraded** (`CLUSTER_CONDITION_TYPE_DEGRADED`): The cluster is operational
-  but not at full capacity (e.g., the system cannot allocate all requested
-  nodes).
+  but not at full capacity (e.g., some requested worker nodes could not be
+  allocated). A cluster can be in READY state with DEGRADED condition TRUE if
+  the control plane is functional but the worker node count is below the
+  requested size.
 
 Tenants can retrieve cluster credentials using the Fulfillment CLI or API:
 

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -88,7 +88,7 @@ The process of fulfilling cluster requests is based on two primary APIs:
 To request a new Cluster, tenants must provide:
 
 * The ID of the desired ClusterTemplate
-* Any required or optional parameters for that template
+* Cluster configuration fields such as `pull_secret` and `ssh_public_key`
 * Optionally, custom node requests specifying host classes and node counts
   (defaults are provided by the template)
 
@@ -114,14 +114,14 @@ updated:
 1. The tenant initiates the creation of a new Cluster using the Fulfillment
    CLI. The tenant must provide:
     - The ID of the desired ClusterTemplate
-    - All required and any optional parameters for the template
+    - Cluster configuration such as `pull_secret` and `ssh_public_key`
     - Optionally, custom node requests specifying the host class and number of
       nodes for each node set
 
 2. The Fulfillment Service receives this request and performs validation to
    ensure:
     - The specified template exists and is available
-    - All required parameters are provided and valid
+    - Required cluster configuration fields are provided
     - The requested host classes exist
 
 3. Upon successful validation, the Fulfillment Service creates a new
@@ -239,11 +239,8 @@ POST /api/fulfillment/v1/clusters (server-internal)
 {
   "spec": {
     "template": "hosted_cluster",
-    "template_parameters": {
-      "cluster_version": {
-        "value": "4.16"
-      }
-    },
+    "pull_secret": "<pull-secret-contents>",
+    "ssh_public_key": "ssh-ed25519 AAAA...",
     "node_sets": {
       "compute": {
         "host_class": "acme_1tb",
@@ -273,11 +270,8 @@ Tenants can check the cluster's status via the Fulfillment CLI or the
   },
   "spec": {
     "template": "hosted_cluster",
-    "template_parameters": {
-      "cluster_version": {
-        "value": "4.16"
-      }
-    },
+    "pull_secret": "<pull-secret-contents>",
+    "ssh_public_key": "ssh-ed25519 AAAA...",
     "node_sets": {
       "compute": {
         "host_class": "acme_1tb",
@@ -362,11 +356,25 @@ Tenants can retrieve cluster credentials using the Fulfillment CLI or API:
   direct access via `oc`, `kubectl`, or other Kubernetes-compatible tools.
 - **GetPassword**: Returns the admin password for the cluster console.
 
+#### ClusterSpec fields
+
+Cluster configuration parameters such as `pull_secret` and `ssh_public_key` are
+defined as explicit typed fields in the `ClusterSpec` protobuf message, rather
+than as generic key-value template parameters. This provides type safety,
+discoverability, and validation at the proto level.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `template` | string | Yes | Reference to the cluster template (immutable after creation) |
+| `pull_secret` | string | No | Credentials for authenticating to image repositories. If not provided, defaults are used from the provider's configuration. |
+| `ssh_public_key` | string | No | SSH public key installed into `authorized_keys` on cluster worker nodes. If not provided, defaults are used from the provider's configuration. |
+| `node_sets` | map | No | Desired node sets (defaults from template if not specified) |
+
 #### ClusterTemplate
 
 Cluster templates are implemented as Ansible roles, following the same pattern
 as [VMaaS templates](/enhancements/vmaas). Each role defines the cluster
-configuration, including default node sets and available parameters.
+configuration, including default node sets.
 
 A periodic job will publish the Ansible roles as cluster templates to the
 Fulfillment Service. The following is the API format used for this publication:
@@ -377,15 +385,6 @@ Fulfillment Service. The following is the API format used for this publication:
     "id": "hosted_cluster",
     "title": "Hosted OpenShift Cluster",
     "description": "Provisions a HyperShift HostedCluster on bare-metal hosts.",
-    "parameters": [
-      {
-        "name": "cluster_version",
-        "title": "OpenShift Version",
-        "description": "The version of OpenShift to install",
-        "required": true,
-        "type": "type.googleapis.com/google.protobuf.StringValue"
-      }
-    ],
     "node_sets": {
       "compute": {
         "host_class": "acme_1tb",

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -193,148 +193,9 @@ The only change is that the new explicit fields flow through the same pipeline
 as the existing `template_parameters` — from `ClusterSpec` to ClusterOrder CR
 to the Ansible provisioning roles.
 
-### API Extensions
+### API Changes
 
-#### Cluster
-
-Tenants do not create Cluster resources directly. Instead, they create a
-cluster order via the Fulfillment CLI, which triggers the system to create and
-manage the underlying Cluster resource. The Clusters API (`POST /api/fulfillment/v1/clusters`)
-is a server-internal operation not exposed to tenants.
-
-The following example shows a Cluster resource as it appears in the system after
-creation, with two node sets:
-
-```json
-POST /api/fulfillment/v1/clusters (server-internal)
-
-{
-  "spec": {
-    "template": "hosted_cluster",
-    "pull_secret": "<pull-secret-contents>",
-    "ssh_public_key": "ssh-ed25519 AAAA...",
-    "release_image": "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
-    "cluster_network_cidr": "10.132.0.0/14",
-    "service_network_cidr": "172.31.0.0/16",
-    "node_sets": {
-      "compute": {
-        "host_class": "acme_1tb",
-        "size": 3
-      },
-      "gpu": {
-        "host_class": "acme_1tb_h100",
-        "size": 2
-      }
-    }
-  }
-}
-```
-
-Tenants can check the cluster's status via the Fulfillment CLI or the
-`GET /api/fulfillment/v1/clusters/{id}` endpoint:
-
-```json
-{
-  "@type": "type.googleapis.com/fulfillment.v1.Cluster",
-  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "metadata": {
-    "creation_timestamp": "2026-03-31T10:00:00.000000Z",
-    "creators": [
-      "tenant-user"
-    ]
-  },
-  "spec": {
-    "template": "hosted_cluster",
-    "pull_secret": "<pull-secret-contents>",
-    "ssh_public_key": "ssh-ed25519 AAAA...",
-    "release_image": "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
-    "cluster_network_cidr": "10.132.0.0/14",
-    "service_network_cidr": "172.31.0.0/16",
-    "node_sets": {
-      "compute": {
-        "host_class": "acme_1tb",
-        "size": 3
-      },
-      "gpu": {
-        "host_class": "acme_1tb_h100",
-        "size": 2
-      }
-    }
-  },
-  "status": {
-    "state": "CLUSTER_STATE_READY",
-    "api_url": "https://api.mycluster.example.com:6443",
-    "console_url": "https://console.mycluster.example.com",
-    "conditions": [
-      {
-        "type": "CLUSTER_CONDITION_TYPE_READY",
-        "status": "CONDITION_STATUS_TRUE",
-        "last_transition_time": "2026-03-31T10:30:00.000000Z",
-        "message": "The cluster is ready to use"
-      },
-      {
-        "type": "CLUSTER_CONDITION_TYPE_PROGRESSING",
-        "status": "CONDITION_STATUS_FALSE",
-        "last_transition_time": "2026-03-31T10:30:00.000000Z"
-      },
-      {
-        "type": "CLUSTER_CONDITION_TYPE_FAILED",
-        "status": "CONDITION_STATUS_FALSE",
-        "last_transition_time": "2026-03-31T10:00:00.000000Z"
-      },
-      {
-        "type": "CLUSTER_CONDITION_TYPE_DEGRADED",
-        "status": "CONDITION_STATUS_FALSE",
-        "last_transition_time": "2026-03-31T10:00:00.000000Z"
-      }
-    ],
-    "node_sets": {
-      "compute": {
-        "host_class": "acme_1tb",
-        "size": 3
-      },
-      "gpu": {
-        "host_class": "acme_1tb_h100",
-        "size": 2
-      }
-    }
-  }
-}
-```
-
-The cluster can be in one of the following states:
-
-- **Progressing** (`CLUSTER_STATE_PROGRESSING`): The cluster is being created
-  or updated.
-- **Ready** (`CLUSTER_STATE_READY`): The cluster control plane is operational
-  and accessible via the API URL and console URL. Check the DEGRADED condition
-  to determine if all requested nodes are available.
-- **Failed** (`CLUSTER_STATE_FAILED`): The cluster creation or update has
-  failed.
-Deletion is indicated by the presence of a `deletion_timestamp` in the cluster
-metadata rather than a separate state. While the cluster is being deleted,
-resources are cleaned up (HostedCluster, HostPool, bare-metal hosts) and the
-finalizer prevents garbage collection until cleanup completes.
-
-The conditions provide additional detail:
-
-- **Progressing** (`CLUSTER_CONDITION_TYPE_PROGRESSING`): The cluster is not
-  yet fully ready.
-- **Ready** (`CLUSTER_CONDITION_TYPE_READY`): The cluster is ready to use.
-- **Failed** (`CLUSTER_CONDITION_TYPE_FAILED`): The cluster is unusable.
-- **Degraded** (`CLUSTER_CONDITION_TYPE_DEGRADED`): The cluster is operational
-  but not at full capacity (e.g., some requested worker nodes could not be
-  allocated). A cluster can be in READY state with DEGRADED condition TRUE if
-  the control plane is functional but the worker node count is below the
-  requested size.
-
-Tenants can retrieve cluster credentials using the Fulfillment CLI or API:
-
-- **GetKubeconfig**: Returns the admin kubeconfig for the cluster, allowing
-  direct access via `oc`, `kubectl`, or other Kubernetes-compatible tools.
-- **GetPassword**: Returns the admin password for the cluster console.
-
-#### ClusterSpec changes
+#### ClusterSpec — new fields
 
 The following fields are promoted from `template_parameters` or hardcoded
 values to explicit `ClusterSpec` fields. This gives tenants direct control over
@@ -356,92 +217,43 @@ Existing fields that remain unchanged:
 | `template_parameters` | map | No | Generic parameters (retained for backward compatibility) |
 | `node_sets` | map | No | Desired node sets (defaults from template if not specified) |
 
-#### ClusterTemplate
+#### ClusterTemplate — no changes
 
-Cluster templates are implemented as Ansible roles, following the same pattern
-as [VMaaS templates](/enhancements/vmaas). Each role defines the cluster
-configuration, including default node sets.
-
-A periodic job will publish the Ansible roles as cluster templates to the
-Fulfillment Service. The following is the API format used for this publication:
-
-```json
-{
-  "object": {
-    "id": "hosted_cluster",
-    "title": "Hosted OpenShift Cluster",
-    "description": "Provisions a HyperShift HostedCluster on bare-metal hosts.",
-    "node_sets": {
-      "compute": {
-        "host_class": "acme_1tb",
-        "size": 3
-      }
-    }
-  }
-}
-```
-
-The template's `node_sets` define the **default** node set configuration. Each
-node set specifies the default `host_class` and initial `size`. Tenants can
-override the `size` (and optionally add new node sets) when creating a cluster
-by including `node_sets` in the cluster creation request. If the tenant does not
-specify `node_sets`, the template defaults are used.
+ClusterTemplate is not modified by this proposal. Templates continue to define
+default node sets and are published from Ansible roles via the existing periodic
+job.
 
 ### Implementation Details/Notes/Constraints
 
-This proposal is built upon HyperShift, which provides hosted control planes
-for multi-tenant OpenShift cluster provisioning. By using HyperShift, each
-tenant's cluster gets its own dedicated control plane hosted on the hub cluster,
-while worker nodes run on bare-metal hosts allocated via HostPools.
+The new `ClusterSpec` fields must flow through the full stack:
 
-The key architectural decisions are:
+1. **Proto → Server**: New fields added to `ClusterSpec` proto. Server
+   validates values (e.g., CIDR format) and applies defaults when not provided.
+2. **Server → Controller**: Controller maps new proto fields to the
+   ClusterOrder CR spec. The CR schema needs new fields to carry them.
+3. **Controller → Operator → AAP**: Operator reads new CR fields and passes
+   them to the AAP provisioning job. The `hosted_cluster` Ansible role is
+   updated to use these values instead of hardcoded defaults.
 
-- **Hosted control planes**: Each cluster's control plane runs as pods on the
-  hub cluster, providing strong isolation between tenants without requiring
-  dedicated control plane hardware.
-- **Bare-metal worker nodes**: Worker nodes are provisioned on dedicated
-  bare-metal hosts via the HostPool mechanism described in the
-  [Bare Metal Fulfillment](/enhancements/bare-metal-fulfillment) proposal.
-  This provides tenants with full hardware access for their workloads.
-- **Node sets**: Clusters support multiple node sets, each with a different
-  host class. This allows tenants to mix hardware types (e.g., GPU and
-  non-GPU nodes) within a single cluster.
-- **Credential access**: Tenants access their clusters through the API URL
-  (OpenShift API server) and console URL (OpenShift web console). The Fulfillment
-  Service provides endpoints for retrieving the kubeconfig and admin password.
-- **Networking**: Cluster networking integrates with HostPool network
-  attachments. When a HostPool is created for a cluster, the bare-metal hosts
-  are configured with the network attachments specified in the HostPool's
-  network configuration. This includes connectivity for the cluster's control
-  plane to worker node communication, as well as any tenant-facing network
-  access. See the [Bare Metal Fulfillment](/enhancements/bare-metal-fulfillment)
-  and [Networking](/enhancements/networking) proposals for details on network
-  attachment configuration.
+CIDRs use plain string notation in CIDR format (e.g., `10.132.0.0/14`),
+consistent with the existing `VirtualNetwork` and `Subnet` proto conventions
+and Kubernetes API conventions.
 
 ### Risks and Mitigations
 
-TBD
+- **Invalid CIDR values**: Tenants may provide overlapping or malformed CIDRs.
+  Mitigated by server-side CIDR validation, consistent with VirtualNetwork
+  and Subnet validation.
+- **Backward compatibility**: Existing clusters use `template_parameters`.
+  Mitigated by retaining `template_parameters` — the new fields take
+  precedence when set, but the old path continues to work.
 
 ### Drawbacks
 
-#### Cluster creation time
-
-Cluster creation is inherently slower than VM creation due to multi-node
-bare-metal provisioning and HyperShift control plane setup. Tenants should
-expect creation times on the order of minutes rather than seconds.
-
-#### Bare metal availability
-
-Clusters cannot be created without available hosts matching the requested host
-classes. If the system cannot allocate the required number of nodes, the cluster
-will be marked as degraded, and the details will be reported in the `DEGRADED`
-condition.
-
-#### Node set constraints
-
-Node scaling is limited to changing the node count within existing host classes
-or adding new node sets. The host class of an existing node set cannot be
-changed after creation. At least one node set must remain at all times.
+- Adding explicit fields to the proto increases the API surface. Each new
+  field requires changes across multiple repos (proto, server, CLI, CR,
+  operator, AAP). However, this is the same trade-off already accepted for
+  VMaaS and the benefit of discoverability and type safety outweighs it.
 
 
 ## Alternatives (Not Implemented)

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -186,18 +186,21 @@ executed:
 3. Upon successful validation, the Fulfillment Service deletes the ClusterOrder
    custom resource (CR) from the appropriate namespace.
 
-4. The O-SAC Operator detects the deletion of the ClusterOrder CR and begins
-   the cleanup process.
+4. The O-SAC Operator detects the deletion via Kubernetes finalizers: a
+   `deletionTimestamp` is set on the ClusterOrder CR, and the Operator begins
+   the cleanup process while the finalizer prevents garbage collection.
 
 5. The Operator, using AAP, automates the following steps:
     - Deletes the HyperShift HostedCluster resource
-    - Releases all allocated bare-metal hosts back to the pool
+    - Deletes the associated HostPool, releasing all allocated bare-metal
+      hosts back to the provider's inventory
     - Performs any additional cleanup operations required by the selected
       cluster template
 
-6. The Operator updates the status of the deletion operation and ensures all
-   resources are properly cleaned up. If the deletion fails, the cluster
-   remains in a Deleting state to prevent orphaned infrastructure.
+6. Once cleanup completes successfully, the Operator removes the finalizer,
+   allowing Kubernetes to garbage-collect the CR. If the deletion fails, the
+   cluster remains in a Deleting state with the finalizer intact to prevent
+   orphaned infrastructure.
 
 7. The tenant can confirm the deletion and cleanup via the Fulfillment CLI or
    API.
@@ -330,6 +333,8 @@ The cluster can be in one of the following states:
   to determine if all requested nodes are available.
 - **Failed** (`CLUSTER_STATE_FAILED`): The cluster creation or update has
   failed.
+- **Deleting** (`CLUSTER_STATE_DELETING`): The cluster is being deleted.
+  Resources are being cleaned up (HostedCluster, HostPool, bare-metal hosts).
 
 The conditions provide additional detail:
 
@@ -383,6 +388,12 @@ Fulfillment Service. The following is the API format used for this publication:
 }
 ```
 
+The template's `node_sets` define the **default** node set configuration. Each
+node set specifies the default `host_class` and initial `size`. Tenants can
+override the `size` (and optionally add new node sets) when creating a cluster
+by including `node_sets` in the cluster creation request. If the tenant does not
+specify `node_sets`, the template defaults are used.
+
 ### Implementation Details/Notes/Constraints
 
 This proposal is built upon HyperShift, which provides hosted control planes
@@ -405,6 +416,14 @@ The key architectural decisions are:
 - **Credential access**: Tenants access their clusters through the API URL
   (OpenShift API server) and console URL (OpenShift web console). The Fulfillment
   Service provides endpoints for retrieving the kubeconfig and admin password.
+- **Networking**: Cluster networking integrates with HostPool network
+  attachments. When a HostPool is created for a cluster, the bare-metal hosts
+  are configured with the network attachments specified in the HostPool's
+  network configuration. This includes connectivity for the cluster's control
+  plane to worker node communication, as well as any tenant-facing network
+  access. See the [Bare Metal Fulfillment](/enhancements/bare-metal-fulfillment)
+  and [Networking](/enhancements/networking) proposals for details on network
+  attachment configuration.
 
 ### Risks and Mitigations
 

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -57,27 +57,25 @@ currently hidden in templates or hardcoded.
 
 ### User Stories
 
-- As a provider, I want to define cluster templates that my tenants will be
-  able to use
-- As a tenant, I want to list pre-defined cluster templates with their
-  available parameters and host classes
-- As a tenant, I want to create an OpenShift cluster based on a pre-defined
-  template
-- As a tenant, I want to scale the number of nodes in my cluster by adjusting
-  node set sizes
-- As a tenant, I want to access my cluster via kubeconfig and web console
-- As a tenant, I want to retrieve the admin password for my cluster
-- As a tenant, I want to delete my cluster and have all associated resources
-  cleaned up
+- As a tenant, I want to specify my own pull secret when creating a cluster
+  so I can use my private image registries
+- As a tenant, I want to provide my SSH public key so I can access worker
+  nodes for debugging
+- As a tenant, I want to choose the OpenShift version for my cluster
+- As a tenant, I want to configure cluster and service network CIDRs to avoid
+  conflicts with my existing infrastructure
+- As a tenant, I want to discover available cluster configuration options from
+  the API without inspecting template internals
 
 ### Goals
 
-- Provide a self-service API for tenants to create, manage, and operate
-  OpenShift clusters with minimal operational overhead
-- Support a catalog of pre-defined cluster templates
-- Enable node scaling by allowing tenants to modify node set sizes
-- Provide credential access (kubeconfig, admin password, console URL)
-- Align with the existing O-SAC fulfillment workflow used by VMaaS
+- Define explicit `ClusterSpec` fields for all tenant-configurable cluster
+  parameters, replacing the opaque `template_parameters` mechanism
+- Allow tenants to control OCP version, credentials, and networking
+  configuration through the API and CLI
+- Provide sensible defaults so that all new fields are optional
+- Align with the approach already taken for VMaaS (`ComputeInstanceSpec`
+  explicit fields)
 
 ### Non-Goals
 

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -93,18 +93,24 @@ The following are explicitly out of scope for this proposal:
 
 ## Proposal
 
-The CaaS API is based on two primary resources:
+The CaaS capability already exists with two primary resources — **Cluster**
+and **ClusterTemplate** — along with working lifecycle workflows (create,
+scale, delete). This proposal changes how cluster configuration flows through
+the system.
 
-* **Cluster**: Represents a provisioned OpenShift cluster that a tenant can
-  create and manage. Tenants can only see the clusters they created.
-* **ClusterTemplate**: Defined by the provider, this is a pre-configured
-  blueprint for clusters. Each template is identified by a unique template ID
-  and includes initial node set definitions. Templates are available to all
-  tenants to use; they cannot edit them.
+### Current state
 
-Currently, cluster configuration is passed via the generic
-`template_parameters` field, and some values are hardcoded in the Ansible
-roles:
+Today, cluster configuration reaches the provisioning layer through two
+mechanisms:
+
+1. **`template_parameters`**: An opaque `map<string, Any>` on `ClusterSpec`.
+   Tenants pass `pull_secret` and `ssh_public_key` here, but the field names
+   and types are not visible in the proto definition.
+
+2. **Hardcoded values in Ansible roles**: `release_image` is set in each
+   template's `defaults/main.yaml`. `cluster_network_cidr` and
+   `service_network_cidr` are hardcoded in the `hosted_cluster` service role.
+   Tenants cannot override these.
 
 ```json
 {
@@ -116,11 +122,15 @@ roles:
     }
   }
 }
-// release_image is hardcoded in template defaults
-// cluster_network_cidr (10.132.0.0/14) and service_network_cidr (172.31.0.0/16) are hardcoded in the hosted_cluster role
+// release_image hardcoded in template defaults/main.yaml
+// cluster_network_cidr (10.132.0.0/14) hardcoded in hosted_cluster role
+// service_network_cidr (172.31.0.0/16) hardcoded in hosted_cluster role
 ```
 
-This proposal changes the API to use explicit typed fields in `ClusterSpec`:
+### Proposed change
+
+Add five explicit fields to `ClusterSpec`. All are optional with sensible
+defaults, so existing behavior is preserved:
 
 ```json
 {
@@ -135,142 +145,53 @@ This proposal changes the API to use explicit typed fields in `ClusterSpec`:
 }
 ```
 
-To request a new Cluster, tenants provide:
+The changes span multiple components:
 
-* The ID of the desired ClusterTemplate
-* Cluster configuration via explicit fields (`pull_secret`, `ssh_public_key`)
-* Optionally, custom node requests specifying host classes and node counts
-  (defaults are provided by the template)
+* **Fulfillment Service (proto)**: Add the five fields to `ClusterSpec` in
+  both public and private proto definitions.
+* **Fulfillment Service (server)**: Validate new fields and pass them through
+  to the ClusterOrder CR.
+* **Fulfillment CLI**: Add dedicated flags (`--pull-secret`,
+  `--ssh-public-key`, `--release-image`, `--cluster-network-cidr`,
+  `--service-network-cidr`) to the `create cluster` command.
+* **Fulfillment Service (controller)**: Map new proto fields to ClusterOrder
+  CR spec fields.
+* **O-SAC Operator**: Read new fields from ClusterOrder CR and pass them to
+  AAP.
+* **O-SAC AAP**: Update `hosted_cluster` role to use new CR fields instead
+  of hardcoded values and `templateParameters`.
 
-The cluster fulfillment process aligns with the existing O-SAC fulfillment
-workflows. To support this, the following O-SAC components will be enhanced or
-updated:
+### Workflow changes
 
-* **Fulfillment Service**: Defines and exposes the APIs for managing Cluster
-  and ClusterTemplate resources.
-* **Fulfillment CLI**: Provides tenants with command-line access to the
-  Fulfillment Service APIs.
-* **O-SAC Operator**: Monitors and reconciles ClusterOrder custom resources
-  within the system.
-* **O-SAC AAP (Ansible Automation Platform)**: Executes automation tasks (via
-  Ansible playbooks) to reconcile ClusterOrder resources, including
-  interactions with HyperShift for cluster lifecycle management and ESI for
-  bare-metal host allocation.
+The cluster creation, scaling, and deletion workflows remain unchanged. The
+only difference is in step 1 of cluster creation:
 
-### Workflow Description
+**Before:** The tenant passes credentials via
+`--template-parameter pull_secret=...` and cannot control OCP version or
+networking CIDRs.
 
-#### Cluster creation
+**After:** The tenant uses explicit flags:
 
-1. The tenant initiates the creation of a new Cluster using the Fulfillment
-   CLI. The tenant must provide:
-    - The ID of the desired ClusterTemplate
-    - Cluster configuration via explicit fields (e.g., `--pull-secret`,
-      `--ssh-public-key`)
-    - Optionally, custom node requests specifying the host class and number of
-      nodes for each node set
+```
+fulfillment-cli create cluster \
+  --template hosted_cluster \
+  --pull-secret <pull-secret> \
+  --ssh-public-key "ssh-ed25519 ..." \
+  --release-image "quay.io/.../ocp-release:4.17.0-multi" \
+  --cluster-network-cidr "10.132.0.0/14" \
+  --service-network-cidr "172.31.0.0/16"
+```
 
-2. The Fulfillment Service receives this request and performs validation to
-   ensure:
-    - The specified template exists and is available
-    - Required cluster configuration fields are provided and valid
-    - The requested host classes exist
+All flags are optional. If omitted, the system uses provider defaults (for
+credentials) or template/role defaults (for release image and CIDRs).
 
-3. Upon successful validation, the Fulfillment Service creates a new
-   ClusterOrder custom resource (CR) in the appropriate Hub and namespace.
+#### Unchanged workflows
 
-4. The O-SAC Operator detects the new ClusterOrder CR and begins the
-   reconciliation process.
-
-5. The Operator, using Ansible Automation Platform (AAP), automates the
-   following steps:
-    - Creates a HostPool to allocate the required bare-metal hosts (see
-      [Bare Metal Fulfillment](/enhancements/bare-metal-fulfillment) for details)
-    - Creates a HyperShift HostedCluster with the allocated hosts as worker
-      nodes
-    - Configures the cluster according to the template parameters
-    - Performs any additional operations required by the selected template
-
-6. The Operator continuously monitors the cluster's status and updates the
-   ClusterOrder CR status to reflect the current state, including `api_url`
-   and `console_url` when the cluster is ready.
-
-7. The tenant can check the cluster's status at any time using the Fulfillment
-   CLI or API, and can access the cluster via the provided API URL and console
-   URL.
-
-#### Node scaling
-
-When a tenant requests a change to the node set sizes, the following workflow
-is executed:
-
-1. The tenant updates the node set sizes for an existing cluster using the
-   Fulfillment CLI or API.
-
-2. The Fulfillment Service validates the update:
-    - The host class for existing node sets cannot be changed
-    - New node sets can be added
-    - At least one node set must remain
-
-3. The Fulfillment Service updates the ClusterOrder CR with the new node
-   requests.
-
-4. The Operator detects the configuration change and triggers a
-   re-provisioning cycle via AAP.
-
-5. AAP adjusts the HostPool allocation and HyperShift NodePool sizes to match
-   the requested node counts.
-
-6. The cluster status is updated to reflect the new node allocation once
-   complete.
-
-#### Cluster deletion
-
-When a tenant requests the deletion of a Cluster, the following workflow is
-executed:
-
-1. The tenant initiates the deletion of a Cluster using the Fulfillment CLI or
-   API by specifying its identifier.
-
-2. The Fulfillment Service receives the deletion request and performs
-   validation to ensure:
-    - The specified Cluster resource exists
-    - The tenant has permission to delete the resource
-
-3. Upon successful validation, the Fulfillment Service deletes the ClusterOrder
-   custom resource (CR) from the appropriate namespace.
-
-4. The O-SAC Operator detects the deletion via Kubernetes finalizers: a
-   `deletionTimestamp` is set on the ClusterOrder CR, and the Operator begins
-   the cleanup process while the finalizer prevents garbage collection.
-
-5. The Operator, using AAP, automates the following steps:
-    - Deletes the HyperShift HostedCluster resource
-    - Deletes the associated HostPool, releasing all allocated bare-metal
-      hosts back to the provider's inventory
-    - Performs any additional cleanup operations required by the selected
-      cluster template
-
-6. Once cleanup completes successfully, the Operator removes the finalizer,
-   allowing Kubernetes to garbage-collect the CR. If the deletion fails, the
-   cluster retains its `deletion_timestamp` and finalizer intact to prevent
-   orphaned infrastructure.
-
-7. The tenant can confirm the deletion and cleanup via the Fulfillment CLI or
-   API.
-
-This workflow ensures that all resources associated with the Cluster are
-properly deprovisioned and that no orphaned resources remain.
-
-#### Cluster template management
-
-Cluster templates are centrally managed by the provider using a GitOps
-approach. All templates are stored in a version-controlled repository, which
-acts as the single source of truth. At regular intervals, an automated job in
-Ansible Automation Platform (AAP) synchronizes the latest templates from this
-repository to the Fulfillment Service. As a result, any changes to the
-templates are automatically and consistently reflected in the Fulfillment
-Service. This process ensures that tenants always have access to the most
-current catalog of available cluster templates.
+Node scaling, cluster deletion, and cluster template management workflows are
+not affected by this proposal. They continue to work as currently implemented.
+The only change is that the new explicit fields flow through the same pipeline
+as the existing `template_parameters` — from `ClusterSpec` to ClusterOrder CR
+to the Ansible provisioning roles.
 
 ### API Extensions
 

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -227,7 +227,6 @@ using a template with two node sets:
 ```json
 {
   "object": {
-    "id": "mycluster",
     "spec": {
       "template": "hosted_cluster",
       "template_parameters": {

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -18,23 +18,37 @@ superseded-by:
 
 ## Summary
 
-This document defines the tenant-facing API contract for the Cluster-as-a-Service
-capability. It specifies the Cluster and ClusterTemplate resources, their
-endpoints, request/response formats, status semantics, and lifecycle workflows
-(create, scale nodes, delete). Clusters are provisioned as HyperShift
-HostedClusters on bare-metal hosts managed through HostPools, following the
-existing O-SAC fulfillment workflow.
+This proposal promotes cluster configuration parameters from generic
+`template_parameters` (opaque `map<string, Any>`) to explicit typed fields in
+the `ClusterSpec` protobuf message, following the same approach already taken
+for VMaaS (where `vm_cpu_cores`, `vm_memory`, etc. were promoted to explicit
+`ComputeInstanceSpec` fields like `cores`, `memory_gib`, `boot_disk`).
+
+Currently, CaaS still uses the original `template_parameters` pattern, where
+parameters like `pull_secret` and `ssh_public_key` are passed as untyped
+template parameters. This proposal moves them to first-class proto fields,
+providing type safety, discoverability, and proto-level validation.
+
+This document also formally defines the tenant-facing API contract for the
+Cluster-as-a-Service capability, including lifecycle workflows (create, scale
+nodes, delete) and status semantics.
 
 
 ## Motivation
 
-The Cluster-as-a-Service (CaaS) capability already exists in O-SAC, enabling
-on-demand OpenShift clusters within a multi-tenant environment. However, the
-tenant-facing API has not been formally defined. This proposal specifies the
-explicit API contract — the Cluster and ClusterTemplate resources, their
-endpoints, lifecycle workflows, and status semantics — so that tenants can
-create and manage clusters through a well-defined, self-service interface
-without requiring deep infrastructure knowledge.
+The VMaaS API has already been updated to use explicit `ComputeInstanceSpec`
+fields instead of generic `template_parameters`. The CaaS API should follow
+the same pattern for consistency. Cluster configuration parameters (pull secret,
+SSH key) are:
+
+- Common across all cluster templates, not template-specific
+- Sensitive credentials that benefit from explicit field semantics
+- Discoverable from the proto definition without inspecting template metadata
+
+By promoting these to explicit `ClusterSpec` fields, the API becomes
+self-documenting and the CLI can offer dedicated flags (e.g., `--pull-secret`,
+`--ssh-public-key`) instead of the generic `--template-parameter name=value`
+syntax.
 
 ### User Stories
 
@@ -75,20 +89,52 @@ The following are explicitly out of scope for this proposal:
 
 ## Proposal
 
-The process of fulfilling cluster requests is based on two primary APIs:
+The CaaS API is based on two primary resources:
 
 * **Cluster**: Represents a provisioned OpenShift cluster that a tenant can
   create and manage. Tenants can only see the clusters they created.
 * **ClusterTemplate**: Defined by the provider, this is a pre-configured
   blueprint for clusters. Each template is identified by a unique template ID
-  and includes a set of parameters (some required, some optional) that tenants
-  can specify when creating a cluster, as well as initial node set definitions.
-  Templates are available to all tenants to use; they cannot edit them.
+  and includes initial node set definitions. Templates are available to all
+  tenants to use; they cannot edit them.
 
-To request a new Cluster, tenants must provide:
+Currently, cluster configuration is passed via the generic
+`template_parameters` field, and some values are hardcoded in the Ansible
+roles:
+
+```json
+{
+  "spec": {
+    "template": "hosted_cluster",
+    "template_parameters": {
+      "pull_secret": { "@type": "...StringValue", "value": "..." },
+      "ssh_public_key": { "@type": "...StringValue", "value": "ssh-ed25519 ..." }
+    }
+  }
+}
+// release_image is hardcoded in template defaults
+// cluster_network_cidr (10.132.0.0/14) and service_network_cidr (172.31.0.0/16) are hardcoded in the hosted_cluster role
+```
+
+This proposal changes the API to use explicit typed fields in `ClusterSpec`:
+
+```json
+{
+  "spec": {
+    "template": "hosted_cluster",
+    "pull_secret": "...",
+    "ssh_public_key": "ssh-ed25519 ...",
+    "release_image": "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
+    "cluster_network_cidr": "10.132.0.0/14",
+    "service_network_cidr": "172.31.0.0/16"
+  }
+}
+```
+
+To request a new Cluster, tenants provide:
 
 * The ID of the desired ClusterTemplate
-* Cluster configuration fields such as `pull_secret` and `ssh_public_key`
+* Cluster configuration via explicit fields (`pull_secret`, `ssh_public_key`)
 * Optionally, custom node requests specifying host classes and node counts
   (defaults are provided by the template)
 
@@ -114,14 +160,15 @@ updated:
 1. The tenant initiates the creation of a new Cluster using the Fulfillment
    CLI. The tenant must provide:
     - The ID of the desired ClusterTemplate
-    - Cluster configuration such as `pull_secret` and `ssh_public_key`
+    - Cluster configuration via explicit fields (e.g., `--pull-secret`,
+      `--ssh-public-key`)
     - Optionally, custom node requests specifying the host class and number of
       nodes for each node set
 
 2. The Fulfillment Service receives this request and performs validation to
    ensure:
     - The specified template exists and is available
-    - Required cluster configuration fields are provided
+    - Required cluster configuration fields are provided and valid
     - The requested host classes exist
 
 3. Upon successful validation, the Fulfillment Service creates a new
@@ -241,6 +288,9 @@ POST /api/fulfillment/v1/clusters (server-internal)
     "template": "hosted_cluster",
     "pull_secret": "<pull-secret-contents>",
     "ssh_public_key": "ssh-ed25519 AAAA...",
+    "release_image": "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
+    "cluster_network_cidr": "10.132.0.0/14",
+    "service_network_cidr": "172.31.0.0/16",
     "node_sets": {
       "compute": {
         "host_class": "acme_1tb",
@@ -272,6 +322,9 @@ Tenants can check the cluster's status via the Fulfillment CLI or the
     "template": "hosted_cluster",
     "pull_secret": "<pull-secret-contents>",
     "ssh_public_key": "ssh-ed25519 AAAA...",
+    "release_image": "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
+    "cluster_network_cidr": "10.132.0.0/14",
+    "service_network_cidr": "172.31.0.0/16",
     "node_sets": {
       "compute": {
         "host_class": "acme_1tb",
@@ -356,18 +409,26 @@ Tenants can retrieve cluster credentials using the Fulfillment CLI or API:
   direct access via `oc`, `kubectl`, or other Kubernetes-compatible tools.
 - **GetPassword**: Returns the admin password for the cluster console.
 
-#### ClusterSpec fields
+#### ClusterSpec changes
 
-Cluster configuration parameters such as `pull_secret` and `ssh_public_key` are
-defined as explicit typed fields in the `ClusterSpec` protobuf message, rather
-than as generic key-value template parameters. This provides type safety,
-discoverability, and validation at the proto level.
+The following fields are promoted from `template_parameters` or hardcoded
+values to explicit `ClusterSpec` fields. This gives tenants direct control over
+cluster configuration without relying on template internals.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `pull_secret` | string | No | Provider default | Credentials for authenticating to image repositories. If not provided, defaults are used from the provider's configuration. |
+| `ssh_public_key` | string | No | Provider default | SSH public key installed into `authorized_keys` on cluster worker nodes. If not provided, defaults are used from the provider's configuration. |
+| `release_image` | string | No | Template default | OCP release image URL (e.g., `quay.io/openshift-release-dev/ocp-release:4.17.0-multi`). Controls the OpenShift version. If not provided, the template default is used. |
+| `cluster_network_cidr` | string | No | `10.132.0.0/14` | CIDR range for the cluster's pod network. Tenants may need to customize this to avoid conflicts with existing infrastructure. |
+| `service_network_cidr` | string | No | `172.31.0.0/16` | CIDR range for the cluster's service network. Tenants may need to customize this to avoid conflicts with existing infrastructure. |
+
+Existing fields that remain unchanged:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `template` | string | Yes | Reference to the cluster template (immutable after creation) |
-| `pull_secret` | string | No | Credentials for authenticating to image repositories. If not provided, defaults are used from the provider's configuration. |
-| `ssh_public_key` | string | No | SSH public key installed into `authorized_keys` on cluster worker nodes. If not provided, defaults are used from the provider's configuration. |
+| `template_parameters` | map | No | Generic parameters (retained for backward compatibility) |
 | `node_sets` | map | No | Desired node sets (defaults from template if not specified) |
 
 #### ClusterTemplate

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -81,13 +81,14 @@ currently hidden in templates or hardcoded.
 
 The following are explicitly out of scope for this proposal:
 
-- Implementing multi-region cluster placement
-- Implementing cluster auto-scaling based on workload demand
-- Cluster version upgrades (will be addressed in a separate proposal)
-- Advanced networking features such as VPNs, peering, or custom network
-  topologies
-- Storage provisioning beyond the default StorageClass
-- Cluster add-ons management (monitoring, logging, etc.)
+- Promoting template-specific parameters (e.g., GitHub OAuth settings) to
+  `ClusterSpec` — these remain in `template_parameters`
+- Exposing provider-managed settings (base domain, availability policies,
+  platform type) as tenant-configurable fields
+- Changing the cluster creation workflow or operator reconciliation logic —
+  this proposal only changes how configuration is passed through the API
+- Removing the `template_parameters` field — it is retained for backward
+  compatibility and template-specific extensions
 
 
 ## Proposal

--- a/enhancements/caas/README.md
+++ b/enhancements/caas/README.md
@@ -19,41 +19,26 @@ superseded-by:
 ## Summary
 
 This proposal moves cluster configuration out of Ansible templates and into
-the tenant-facing API. Today, key cluster parameters are either buried in the
-opaque `template_parameters` map (`pull_secret`, `ssh_public_key`) or hardcoded
-in Ansible roles (`release_image`, networking CIDRs). Tenants cannot discover
-or control these without knowledge of the underlying templates.
-
-This proposal defines explicit typed fields in the `ClusterSpec` protobuf
-message for all tenant-configurable cluster parameters, following the same
-approach already taken for VMaaS (where `vm_cpu_cores`, `vm_memory`, etc. were
-promoted from `template_parameters` to explicit `ComputeInstanceSpec` fields).
-
-This document also formally defines the tenant-facing API contract for the
-Cluster-as-a-Service capability, including lifecycle workflows (create, scale
-nodes, delete) and status semantics.
+the tenant-facing API by adding explicit typed fields to the `ClusterSpec`
+protobuf message, following the same approach already taken for VMaaS.
 
 
 ## Motivation
 
-Currently, creating a cluster requires passing configuration through two
-different mechanisms that are not visible in the API:
+Today, key cluster parameters are either buried in the opaque
+`template_parameters` map or hardcoded in Ansible roles. Tenants cannot
+discover or control these without knowledge of the underlying templates:
 
-1. **`template_parameters`**: An opaque `map<string, Any>` where `pull_secret`
-   and `ssh_public_key` are passed as untyped values. Tenants must know the
-   parameter names and types by inspecting the template definition.
-2. **Hardcoded values in Ansible roles**: `release_image` (OCP version),
+1. **`template_parameters`**: `pull_secret` and `ssh_public_key` are passed as
+   untyped `Any` values. Tenants must know the parameter names and types by
+   inspecting template definitions.
+2. **Hardcoded in Ansible roles**: `release_image` (OCP version),
    `cluster_network_cidr`, and `service_network_cidr` are baked into the
-   playbooks. Tenants have no way to customize these at all.
+   playbooks. Tenants cannot customize these at all.
 
-The VMaaS API has already been updated to move parameters from
-`template_parameters` to explicit `ComputeInstanceSpec` fields (`cores`,
-`memory_gib`, `boot_disk`, etc.). The CaaS API should follow the same pattern.
-
-By defining explicit `ClusterSpec` fields, the API becomes self-documenting,
-the CLI can offer dedicated flags (e.g., `--pull-secret`, `--release-image`,
-`--cluster-network-cidr`), and tenants gain control over configuration that is
-currently hidden in templates or hardcoded.
+The VMaaS API has already moved parameters from `template_parameters` to
+explicit `ComputeInstanceSpec` fields (`cores`, `memory_gib`, `boot_disk`,
+etc.). The CaaS API should follow the same pattern.
 
 ### User Stories
 
@@ -79,8 +64,6 @@ currently hidden in templates or hardcoded.
 
 ### Non-Goals
 
-The following are explicitly out of scope for this proposal:
-
 - Promoting template-specific parameters (e.g., GitHub OAuth settings) to
   `ClusterSpec` — these remain in `template_parameters`
 - Exposing provider-managed settings (base domain, availability policies,
@@ -93,24 +76,10 @@ The following are explicitly out of scope for this proposal:
 
 ## Proposal
 
-The CaaS capability already exists with two primary resources — **Cluster**
-and **ClusterTemplate** — along with working lifecycle workflows (create,
-scale, delete). This proposal changes how cluster configuration flows through
-the system.
+Add five explicit fields to `ClusterSpec`. All are optional with sensible
+defaults, so existing behavior is preserved.
 
-### Current state
-
-Today, cluster configuration reaches the provisioning layer through two
-mechanisms:
-
-1. **`template_parameters`**: An opaque `map<string, Any>` on `ClusterSpec`.
-   Tenants pass `pull_secret` and `ssh_public_key` here, but the field names
-   and types are not visible in the proto definition.
-
-2. **Hardcoded values in Ansible roles**: `release_image` is set in each
-   template's `defaults/main.yaml`. `cluster_network_cidr` and
-   `service_network_cidr` are hardcoded in the `hosted_cluster` service role.
-   Tenants cannot override these.
+**Before** (current state):
 
 ```json
 {
@@ -127,10 +96,7 @@ mechanisms:
 // service_network_cidr (172.31.0.0/16) hardcoded in hosted_cluster role
 ```
 
-### Proposed change
-
-Add five explicit fields to `ClusterSpec`. All are optional with sensible
-defaults, so existing behavior is preserved:
+**After** (proposed):
 
 ```json
 {
@@ -145,32 +111,15 @@ defaults, so existing behavior is preserved:
 }
 ```
 
-The changes span multiple components:
+### Workflow Description
 
-* **Fulfillment Service (proto)**: Add the five fields to `ClusterSpec` in
-  both public and private proto definitions.
-* **Fulfillment Service (server)**: Validate new fields and pass them through
-  to the ClusterOrder CR.
-* **Fulfillment CLI**: Add dedicated flags (`--pull-secret`,
-  `--ssh-public-key`, `--release-image`, `--cluster-network-cidr`,
-  `--service-network-cidr`) to the `create cluster` command.
-* **Fulfillment Service (controller)**: Map new proto fields to ClusterOrder
-  CR spec fields.
-* **O-SAC Operator**: Read new fields from ClusterOrder CR and pass them to
-  AAP.
-* **O-SAC AAP**: Update `hosted_cluster` role to use new CR fields instead
-  of hardcoded values and `templateParameters`.
+The cluster creation, scaling, and deletion workflows are unchanged. The only
+difference is in cluster creation step 1:
 
-### Workflow changes
+**Before:** Tenant passes credentials via `--template-parameter pull_secret=...`
+and cannot control OCP version or networking CIDRs.
 
-The cluster creation, scaling, and deletion workflows remain unchanged. The
-only difference is in step 1 of cluster creation:
-
-**Before:** The tenant passes credentials via
-`--template-parameter pull_secret=...` and cannot control OCP version or
-networking CIDRs.
-
-**After:** The tenant uses explicit flags:
+**After:** Tenant uses explicit CLI flags:
 
 ```
 fulfillment-cli create cluster \
@@ -185,59 +134,33 @@ fulfillment-cli create cluster \
 All flags are optional. If omitted, the system uses provider defaults (for
 credentials) or template/role defaults (for release image and CIDRs).
 
-#### Unchanged workflows
+### API Extensions
 
-Node scaling, cluster deletion, and cluster template management workflows are
-not affected by this proposal. They continue to work as currently implemented.
-The only change is that the new explicit fields flow through the same pipeline
-as the existing `template_parameters` — from `ClusterSpec` to ClusterOrder CR
-to the Ansible provisioning roles.
-
-### API Changes
-
-#### ClusterSpec — new fields
-
-The following fields are promoted from `template_parameters` or hardcoded
-values to explicit `ClusterSpec` fields. This gives tenants direct control over
-cluster configuration without relying on template internals.
+Five new fields added to the `ClusterSpec` protobuf message (public and
+private):
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `pull_secret` | string | No | Provider default | Credentials for authenticating to image repositories. If not provided, defaults are used from the provider's configuration. |
-| `ssh_public_key` | string | No | Provider default | SSH public key installed into `authorized_keys` on cluster worker nodes. If not provided, defaults are used from the provider's configuration. |
-| `release_image` | string | No | Template default | OCP release image URL (e.g., `quay.io/openshift-release-dev/ocp-release:4.17.0-multi`). Controls the OpenShift version. If not provided, the template default is used. |
-| `cluster_network_cidr` | string | No | `10.132.0.0/14` | CIDR range for the cluster's pod network. Tenants may need to customize this to avoid conflicts with existing infrastructure. |
-| `service_network_cidr` | string | No | `172.31.0.0/16` | CIDR range for the cluster's service network. Tenants may need to customize this to avoid conflicts with existing infrastructure. |
+| `pull_secret` | string | No | Provider default | Credentials for authenticating to image repositories |
+| `ssh_public_key` | string | No | Provider default | SSH public key installed on cluster worker nodes |
+| `release_image` | string | No | Template default | OCP release image URL. Controls the OpenShift version |
+| `cluster_network_cidr` | string | No | `10.132.0.0/14` | CIDR for the cluster's pod network |
+| `service_network_cidr` | string | No | `172.31.0.0/16` | CIDR for the cluster's service network |
 
-Existing fields that remain unchanged:
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `template` | string | Yes | Reference to the cluster template (immutable after creation) |
-| `template_parameters` | map | No | Generic parameters (retained for backward compatibility) |
-| `node_sets` | map | No | Desired node sets (defaults from template if not specified) |
-
-#### ClusterTemplate — no changes
-
-ClusterTemplate is not modified by this proposal. Templates continue to define
-default node sets and are published from Ansible roles via the existing periodic
-job.
+CIDRs use plain string notation (e.g., `10.132.0.0/14`), consistent with the
+existing `VirtualNetwork` and `Subnet` proto conventions.
 
 ### Implementation Details/Notes/Constraints
 
-The new `ClusterSpec` fields must flow through the full stack:
+The new fields must flow through the full stack:
 
 1. **Proto → Server**: New fields added to `ClusterSpec` proto. Server
-   validates values (e.g., CIDR format) and applies defaults when not provided.
-2. **Server → Controller**: Controller maps new proto fields to the
-   ClusterOrder CR spec. The CR schema needs new fields to carry them.
+   validates values (e.g., CIDR format) and applies defaults.
+2. **Server → Controller**: Controller maps new proto fields to ClusterOrder
+   CR spec. The CR schema needs corresponding new fields.
 3. **Controller → Operator → AAP**: Operator reads new CR fields and passes
-   them to the AAP provisioning job. The `hosted_cluster` Ansible role is
-   updated to use these values instead of hardcoded defaults.
-
-CIDRs use plain string notation in CIDR format (e.g., `10.132.0.0/14`),
-consistent with the existing `VirtualNetwork` and `Subnet` proto conventions
-and Kubernetes API conventions.
+   them to the AAP provisioning job. The `hosted_cluster` Ansible role uses
+   these values instead of hardcoded defaults.
 
 ### Risks and Mitigations
 
@@ -250,16 +173,22 @@ and Kubernetes API conventions.
 
 ### Drawbacks
 
-- Adding explicit fields to the proto increases the API surface. Each new
-  field requires changes across multiple repos (proto, server, CLI, CR,
-  operator, AAP). However, this is the same trade-off already accepted for
-  VMaaS and the benefit of discoverability and type safety outweighs it.
+Adding explicit fields to the proto increases the API surface. Each new field
+requires changes across multiple repos (proto, server, CLI, CR, operator,
+AAP). However, this is the same trade-off already accepted for VMaaS and the
+benefit of discoverability and type safety outweighs it.
 
 
 ## Alternatives (Not Implemented)
 
+Keep using `template_parameters` for all configuration. Rejected because it
+provides no type safety, no discoverability, and is inconsistent with the
+VMaaS API which has already moved to explicit fields.
+
 
 ## Open Questions [optional]
+
+None.
 
 
 ## Test Plan
@@ -276,11 +205,12 @@ N/A
 
 ## Upgrade / Downgrade Strategy
 
-N/A
+N/A — new fields are optional and additive. Existing clusters continue to
+work via `template_parameters`.
 
 ## Version Skew Strategy
 
-N/A
+N/A — new fields are optional. Older clients that don't set them get defaults.
 
 ## Support Procedures
 


### PR DESCRIPTION
## Summary
Promote cluster configuration from opaque `template_parameters` and hardcoded Ansible values to explicit typed fields in `ClusterSpec`, following the same approach taken for VMaaS.

### New `ClusterSpec` fields
- `pull_secret` — image registry credentials (currently in `template_parameters`)
- `ssh_public_key` — SSH key for worker nodes (currently in `template_parameters`)
- `release_image` — OCP version (currently hardcoded in template defaults)
- `cluster_network_cidr` — pod network CIDR (currently hardcoded in Ansible role)
- `service_network_cidr` — service network CIDR (currently hardcoded in Ansible role)

All fields are optional with sensible defaults.

## Jira
[MGMT-23417](https://redhat.atlassian.net/browse/MGMT-23417)