### PR TITLE
OSAC-46: Add VM instance types enhancement proposal

### DIFF
--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -1,0 +1,586 @@
+---
+title: vm-instance-types
+authors:
+  - atraeger@redhat.com
+creation-date: 2026-05-06
+last-updated: 2026-05-06
+tracking-link:
+  - https://redhat.atlassian.net/browse/OSAC-46
+see-also:
+  - "/enhancements/vmaas"
+replaces:
+superseded-by:
+---
+
+# VM Instance Types
+
+## Summary
+
+This enhancement introduces VM instance types as pre-defined compute resource bundles (cores, memory) that can be referenced by name when creating virtual machines. Instance types simplify VM creation by providing a standardized set of compute configurations, following cloud-native patterns similar to AWS EC2 instance types, Azure VM sizes, and GCP machine types. In the initial implementation (Phase 1), all instance types are globally scoped and defined by the Cloud Service Provider, ensuring consistency and preventing configuration fragmentation. Users select an instance type by name rather than specifying individual cores and memory values. This proposal focuses on Virtual Machine-as-a-Service (VMaaS) compute instances only; Cluster-as-a-Service (CaaS) uses bare metal provisioning with a separate resource classification system (`HostType`) and is not covered by this enhancement.
+
+## Motivation
+
+The current ComputeInstance API allows users to specify compute resources (cores, memory) as individual numeric fields. While flexible, this approach creates several challenges: it complicates capacity planning and resource optimization, makes it harder to standardize VM offerings across tenants, and increases the cognitive load for users who must understand appropriate core-to-memory ratios. Instance types address these problems by providing a curated set of pre-validated compute configurations that align with infrastructure capabilities and organizational standards. This also lays the groundwork for future enhancements such as usage-based metering, capacity reservations, and custom instance type definitions (Phase 2).
+
+### User Stories
+
+* As a Organization User, I want to create a VM by selecting an instance type (e.g., 'standard-4-16') that defines the compute resources, so that I can quickly provision VMs without needing to understand appropriate core-to-memory ratios.
+* As a Organization User, I want to list available instance types with their compute specifications, so that I can choose the right size for my workload.
+* As a Cloud Provider Admin, I want to define global instance types including their compute specifications, so that I can standardize VM offerings and align them with available infrastructure capacity.
+* As a Cloud Provider Admin, I want to enforce governance by requiring instance types for all VM creation, so that I can prevent resource fragmentation and ensure efficient capacity utilization.
+* As a Cloud Provider Admin, I want to control instance type availability by enabling/disabling types globally, so that I can manage which VM sizes are available to tenants without deleting instance type definitions.
+
+### Goals
+
+* Provide a self-service API for Organization Users to list available instance types and create VMs using instance type names
+* Require all ComputeInstance creation to use instance types (strict mode), removing the ability to specify cores and memory individually
+* Support globally-scoped instance types defined and managed by Cloud Provider Admins only
+* Enable/disable instance types globally to control availability without deleting type definitions
+* Ensure instance type compute specifications (cores, memory) are immutable after creation to prevent inconsistencies
+* Maintain backward compatibility for existing VMs created before instance types are introduced
+
+### Non-Goals
+
+The following are explicitly out of scope for Phase 1:
+
+* Organization-specific instance types (Organization Admin-defined types scoped to a single organization)
+* Instance type "Series" with technical constraint ranges (min/max RAM-to-CPU ratios, supported architectures)
+* Flexible mode allowing users to specify custom cores/memory values within series constraints
+* GPU support (gpu_count, gpu_type fields) - deferred to Phase 2
+* Storage specifications as part of instance types (boot disk size remains separate, following AWS/Azure/GCP pattern)
+* Quota enforcement and capacity planning based on instance types (quota system not yet defined in OSAC)
+* Pricing or metering metadata associated with instance types
+* Network bandwidth constraints or network performance tiers
+* Per-organization instance type restrictions (all orgs see all enabled instance types in Phase 1)
+
+## Proposal
+
+This proposal introduces a new `InstanceType` resource that defines pre-configured compute bundles with immutable core and memory specifications. The Cloud Service Provider creates and manages all instance types, which are globally visible to all organizations when enabled. The `ComputeInstance` API is modified to require an `instance_type` field and remove the existing `cores` and `memory_gib` fields. Disk specifications remain separate from instance types, as storage and compute are decoupled following industry-standard cloud patterns.
+
+### Key Resources
+
+**InstanceType** - Provider-defined compute specification
+* Globally scoped, visible to all organizations when enabled
+* Immutable compute specs (cores, memory_gib)
+* Mutable metadata (description, enabled flag)
+* Cloud Provider Admin-only creation and management
+
+**ComputeInstance (modified)** - Virtual machine resource
+* Now requires `instance_type` field (string reference to InstanceType ID)
+* Removes `cores` and `memory_gib` fields from ComputeInstanceSpec
+* Retains `boot_disk` and `storage_class` as separate specifications
+
+### Scoping and Visibility
+
+All instance types in Phase 1 are globally scoped:
+* **Created by:** Cloud Provider Admin only
+* **Visible to:** All organizations (when enabled=true)
+* **Hidden from:** Organization Users when enabled=false (Admin can always see all)
+
+ListInstanceTypes API behavior:
+* Organization Users: Returns only enabled instance types
+* Cloud Provider Admin: Returns all instance types (enabled + disabled)
+
+### Workflow Description
+
+#### Instance Type Management (Cloud Provider Admin)
+
+**Creating an Instance Type**
+
+1. Cloud Provider Admin uses the OSAC CLI to create a new global instance type:
+   ```bash
+   osac create instance-type standard-4-16 \
+     --cores 4 \
+     --memory-gib 16 \
+     --description "Balanced compute: 4 cores, 16 GiB RAM"
+   ```
+2. The Fulfillment Service validates the request and creates the InstanceType resource
+3. The instance type is immediately available (enabled=true by default) to all Organization Users
+
+**Disabling an Instance Type**
+
+1. Cloud Provider Admin disables an instance type to prevent new VM creation:
+   ```bash
+   osac update instance-type standard-4-16 --enabled=false
+   ```
+2. The Fulfillment Service updates the InstanceType metadata
+3. The instance type is hidden from ListInstanceTypes for Organization Users
+4. Existing VMs using this instance type continue to run unchanged
+5. New VM creation requests with this instance type are rejected
+
+**Deleting an Instance Type**
+
+1. Cloud Provider Admin attempts to delete an instance type:
+   ```bash
+   osac delete instance-type standard-4-16
+   ```
+2. The Fulfillment Service checks if any VMs reference this instance type
+3. If in use: deletion is rejected with an error listing affected VMs
+4. If not in use: deletion succeeds
+
+#### VM Creation (Organization User)
+
+**Listing Available Instance Types**
+
+1. Organization User lists available instance types:
+   ```bash
+   osac list instance-types
+   ```
+2. The Fulfillment Service returns only enabled instance types:
+   ```json
+   {
+     "items": [
+       {
+         "id": "standard-2-4",
+         "metadata": { "name": "standard-2-4" },
+         "cores": 2,
+         "memory_gib": 4,
+         "description": "Small balanced compute",
+         "enabled": true
+       },
+       {
+         "id": "standard-4-16",
+         "metadata": { "name": "standard-4-16" },
+         "cores": 4,
+         "memory_gib": 16,
+         "description": "Medium balanced compute",
+         "enabled": true
+       }
+     ]
+   }
+   ```
+
+**Creating a VM with Instance Type**
+
+1. Organization User creates a VM specifying an instance type:
+   ```bash
+   osac create compute-instance my-vm \
+     --instance-type standard-4-16 \
+     --boot-disk-gib 50 \
+     --image quay.io/fedora/fedora:40
+   ```
+2. The Fulfillment Service validates and resolves:
+   - Instance type "standard-4-16" exists and is enabled
+   - User has appropriate permissions
+   - Resolves instance type to cores=4, memory_gib=16
+3. The Fulfillment Service creates the ComputeInstance CR with expanded values:
+   ```yaml
+   apiVersion: osac.openshift.io/v1alpha1
+   kind: ComputeInstance
+   metadata:
+     name: my-vm
+     annotations:
+       osac.io/instance-type: "standard-4-16"  # Audit trail
+   spec:
+     cores: 4              # Expanded from instance type
+     memory_gib: 16        # Expanded from instance type
+     template: "default-vm-template"
+     boot_disk:
+       size_gib: 50
+     image:
+       source_type: "registry"
+       source_ref: "quay.io/fedora/fedora:40"
+   ```
+4. The osac-operator reconciles the ComputeInstance, reading cores and memory_gib from spec
+5. The VM is provisioned via KubeVirt with 4 cores and 16 GiB RAM
+
+**Error Cases**
+
+**Non-existent instance type:**
+```bash
+$ osac create compute-instance my-vm --instance-type nonexistent
+Error: instance type "nonexistent" not found
+```
+
+**Disabled instance type:**
+```bash
+$ osac create compute-instance my-vm --instance-type old-type
+Error: instance type "old-type" is not available (disabled)
+```
+
+**Missing instance type:**
+```bash
+$ osac create compute-instance my-vm --boot-disk-gib 50
+Error: instance_type field is required
+```
+
+### API Extensions
+
+This enhancement modifies existing OSAC APIs and introduces new resources:
+
+#### New Resources
+
+**InstanceType** (proto/public/osac/public/v1/instance_type_type.proto)
+- Public API: Read-only List and Get operations for Organization Users
+- Private API: Full CRUD operations for Cloud Provider Admins
+
+**InstanceTypes Service** (proto/public/osac/public/v1/instance_types_service.proto)
+- Public API: ListInstanceTypes, GetInstanceType
+- Private API: CreateInstanceType, UpdateInstanceType, DeleteInstanceType
+
+#### Modified Resources
+
+**ComputeInstanceSpec** (proto/public/osac/public/v1/compute_instance_type.proto - API layer only)
+- Add: `instance_type` field (string, required) - reference to InstanceType ID
+- Remove: `cores` field (optional int32) - replaced by instance_type in API
+- Remove: `memory_gib` field (optional int32) - replaced by instance_type in API
+- Retain: `boot_disk`, `storage_class`, `template`, `image`, `user_data`, `ssh_key`, etc.
+
+Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-service expands instance_type to these fields when creating the CR. See "Instance Type Resolution Strategy" for details.
+
+#### Validation
+
+**Public API (Organization Users):**
+- CreateComputeInstance: Require instance_type field, reject if missing
+- CreateComputeInstance: Validate instance_type exists and is enabled
+- CreateComputeInstance: Expand instance_type to cores/memory_gib before creating CR
+- CreateComputeInstance: Add osac.io/instance-type annotation to CR
+- UpdateComputeInstance: Reject changes to instance_type field (immutable in Phase 1)
+
+**Private API (Cloud Provider Admin):**
+- CreateInstanceType: Require cores and memory_gib fields
+- CreateInstanceType: Validate cores > 0 and memory_gib > 0
+- UpdateInstanceType: Reject changes to cores or memory_gib (immutable)
+- UpdateInstanceType: Allow changes to description and enabled
+- DeleteInstanceType: Reject if any ComputeInstances reference this type
+
+#### Deletion Protection
+
+**InstanceType deletion checks:**
+- fulfillment-service queries database for ComputeInstances using this instance type
+- If any references exist, deletion is rejected with 409 Conflict
+- Returns list of affected ComputeInstance IDs in error message
+- Deletion succeeds only when no ComputeInstances reference the type
+
+### Implementation Details/Notes/Constraints
+
+#### Database Schema
+
+**instance_types table:**
+```sql
+CREATE TABLE instance_types (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    creation_timestamp TIMESTAMPTZ NOT NULL,
+    deletion_timestamp TIMESTAMPTZ,
+    finalizers TEXT[],
+    creators TEXT[],
+    tenants TEXT[],  -- Empty for global instance types
+    labels JSONB,
+    annotations JSONB,
+    data JSONB NOT NULL  -- Serialized InstanceType protobuf
+);
+```
+
+The `data` JSONB column contains:
+```json
+{
+  "cores": 4,
+  "memory_gib": 16,
+  "description": "Balanced compute: 4 cores, 16 GiB RAM",
+  "enabled": true
+}
+```
+
+#### Instance Type Resolution Strategy
+
+**Expansion at API boundary:**
+
+Instance types are resolved and expanded by fulfillment-service when creating the ComputeInstance CR. The CR spec contains the expanded compute resources (cores, memory_gib), not the instance type reference. This design choice provides:
+
+- **Zero changes to osac-operator:** Controller reads cores/memory_gib as it does today
+- **No runtime dependencies:** osac-operator doesn't need to call fulfillment-service API
+- **Enforcement at boundary:** Organization Users access only the fulfillment-service API (not k8s APIs), so instance type validation cannot be bypassed
+- **Audit trail:** Original instance_type name stored in CR annotation
+
+**fulfillment-service flow:**
+1. User creates ComputeInstance via API with `instance_type: "standard-4-16"`
+2. fulfillment-service validates instance type exists and is enabled
+3. fulfillment-service resolves cores=4, memory_gib=16 from InstanceType
+4. fulfillment-service creates ComputeInstance CR with:
+   - `spec.cores: 4`
+   - `spec.memory_gib: 16`
+   - `metadata.annotations["osac.io/instance-type"]: "standard-4-16"` (audit trail)
+
+**osac-operator reconciliation (unchanged):**
+1. Read ComputeInstance.spec.cores and spec.memory_gib
+2. Pass values to KubeVirt VM spec
+3. Update ComputeInstance.status
+
+**Future extensibility:**
+
+Changing instance types is blocked in Phase 1 (spec.cores and spec.memory_gib are immutable). In the future, we could support instance type updates by:
+1. Allowing updates to cores/memory_gib fields
+2. Updating the `osac.io/instance-type` annotation
+3. Triggering VM resize (if supported by underlying platform)
+
+Advanced OpenShift Virtualization features (NUMA topology, hugepages, CPU pinning) remain internal implementation details and are not exposed to Organization Users through the instance type API.
+
+#### Fulfillment Service Implementation
+
+**Server structure:**
+- `InstanceTypesServer` (public) - wraps `PrivateInstanceTypesServer` with tenant filtering
+- `PrivateInstanceTypesServer` (private) - full CRUD using GenericServer pattern
+- Both servers in `internal/servers/instance_types_server.go` and `private_instance_types_server.go`
+
+**Authorization:**
+- CreateInstanceType: Requires Cloud Provider Admin role
+- ListInstanceTypes (public): Filters to enabled=true, global scope only
+- GetInstanceType (public): Returns only if enabled=true
+- ListInstanceTypes (private): Returns all instance types
+- UpdateInstanceType: Requires Cloud Provider Admin role
+- DeleteInstanceType: Requires Cloud Provider Admin role, rejects if references exist
+
+#### Proto Definition Sketch
+
+```proto
+// proto/public/osac/public/v1/instance_type_type.proto
+message InstanceType {
+  string id = 1;
+  Metadata metadata = 2;
+  int32 cores = 3;
+  int32 memory_gib = 4;
+  string description = 5;
+  bool enabled = 6;
+}
+
+// proto/public/osac/public/v1/instance_types_service.proto
+service InstanceTypes {
+  rpc List(ListInstanceTypesRequest) returns (ListInstanceTypesResponse) {
+    option (google.api.http) = {
+      get: "/api/fulfillment/v1/instance_types"
+    };
+  }
+  rpc Get(GetInstanceTypeRequest) returns (InstanceType) {
+    option (google.api.http) = {
+      get: "/api/fulfillment/v1/instance_types/{id}"
+    };
+  }
+}
+
+// proto/private/osac/private/v1/instance_types_service.proto
+service InstanceTypes {
+  rpc Create(CreateInstanceTypeRequest) returns (InstanceType);
+  rpc Update(UpdateInstanceTypeRequest) returns (InstanceType);
+  rpc Delete(DeleteInstanceTypeRequest) returns (google.protobuf.Empty);
+  rpc List(ListInstanceTypesRequest) returns (ListInstanceTypesResponse);
+  rpc Get(GetInstanceTypeRequest) returns (InstanceType);
+}
+```
+
+**API vs CR Schema:**
+
+The fulfillment-service API and the Kubernetes CR have different schemas to support instance type expansion at the API boundary.
+
+**Public API Schema (proto/public/osac/public/v1/):**
+```proto
+message ComputeInstanceSpec {
+  string template = 1;
+  map<string, google.protobuf.Any> template_parameters = 2;
+  optional google.protobuf.Timestamp restart_requested_at = 3;
+  optional ComputeInstanceImage image = 4;
+
+  // NEW: Required instance type reference (API only)
+  string instance_type = 5;
+
+  // REMOVED from API: cores and memory_gib (replaced by instance_type)
+
+  optional string ssh_key = 7;
+  optional ComputeInstanceDisk boot_disk = 8;
+  repeated ComputeInstanceDisk additional_disks = 9;
+  optional string run_strategy = 10;
+  optional string user_data = 11;
+  optional string subnet = 12;
+  repeated string security_groups = 13;
+}
+```
+
+**Kubernetes CR Schema (osac-operator CRD):**
+```yaml
+# ComputeInstance CR (created by fulfillment-service)
+apiVersion: osac.openshift.io/v1alpha1
+kind: ComputeInstance
+metadata:
+  annotations:
+    osac.io/instance-type: "standard-4-16"  # Audit trail
+spec:
+  template: "..."
+  cores: 4              # Expanded from instance type
+  memory_gib: 16        # Expanded from instance type
+  boot_disk:
+    size_gib: 50
+  # ... other fields unchanged
+```
+
+The CR retains cores/memory_gib fields in spec (unchanged from today) so osac-operator requires no modifications. The instance_type field exists only in the API layer and is stored as an annotation in the CR.
+
+### Risks and Mitigations
+
+**Risk: Breaking change for existing API consumers**
+- Mitigation: Since OSAC is pre-GA, breaking changes are acceptable
+
+**Risk: Instance type reference becomes stale if type is deleted**
+- Mitigation: fulfillment-service API checks prevent deletion of InstanceTypes referenced by active VMs
+- Mitigation: Admin must explicitly disable, wait for VMs to be deleted, then delete type
+
+**Risk: Users need a specific core/memory combination not offered**
+- Mitigation: Document process for requesting new instance types from Cloud Provider Admin
+- Mitigation: Phase 2 will introduce flexible mode with custom configurations within series bounds
+- Mitigation: Admins can create arbitrary instance types to meet tenant needs
+
+**Risk: Capacity planning becomes harder without understanding actual resource allocation**
+- Mitigation: ListInstanceTypes provides full spec visibility
+- Mitigation: Future quota system will track instance type usage
+- Mitigation: Admin APIs expose compute resource consumption per tenant
+
+### Drawbacks
+
+**Reduced flexibility for Organization Users**
+- Users can no longer specify arbitrary core/memory combinations
+- Trade-off: Simplicity and standardization vs. maximum flexibility
+- Justification: Cloud providers typically constrain VM sizes for operational reasons (capacity planning, SLA guarantees, cost optimization)
+
+**Additional API resource and complexity**
+- Introduces new InstanceType resource with CRUD operations
+- Trade-off: More API surface area vs. simplified VM creation UX
+- Justification: The pattern is well-established (AWS, Azure, GCP) and familiar to users
+
+## Alternatives (Not Implemented)
+
+**Alternative 1: Keep cores/memory_gib fields alongside instance_type**
+- Allow users to either specify instance_type OR cores/memory_gib
+- Rejected: Creates API ambiguity (what if both are specified?)
+- Rejected: Doesn't achieve goal of standardization and governance
+- Rejected: Complicates capacity planning and quota enforcement
+
+**Alternative 2: Make instance types optional (flexible mode from start)**
+- Allow instance_type as a convenience but keep cores/memory_gib as primary fields
+- Rejected: Doesn't enforce standardization
+- Rejected: Deferred to Phase 2 with proper series-based constraints
+
+**Alternative 3: Use HostType instead of creating new InstanceType resource**
+- Reuse existing HostType resource for VMs
+- Rejected: HostType is intentionally opaque (only id/title/description)
+- Rejected: HostType serves bare metal inventory labeling, not VM compute specs
+- Rejected: Need structured cores/memory_gib for capacity planning and quotas
+
+**Alternative 4: Store instance type inline in ComputeInstanceSpec**
+- Embed full instance type spec (cores, memory) directly in each ComputeInstance
+- Rejected: Updates to instance type definitions wouldn't propagate to existing VMs
+- Rejected: Breaks immutability guarantees (users could modify embedded spec)
+- Rejected: Increases storage overhead and denormalization
+
+**Alternative 5: Dynamic instance type generation based on requested resources**
+- Auto-create instance types on-demand when users specify custom cores/memory
+- Rejected: Defeats purpose of governance and standardization
+- Rejected: Infinite instance type growth makes management infeasible
+- Rejected: Deferred to Phase 2 as explicit "custom instance types within series"
+
+## Test Plan
+
+**Unit Tests:**
+- InstanceType CRUD operations via GenericServer
+- ComputeInstance validation rejects missing instance_type
+- ComputeInstance validation rejects disabled instance_type
+- ComputeInstance validation rejects non-existent instance_type
+- InstanceType deletion rejected when VMs reference it
+- InstanceType cores/memory_gib immutability enforcement
+- Public API filters instance types to enabled=true only
+- Private API returns all instance types regardless of enabled status
+
+**Integration Tests (fulfillment-service/it/):**
+- Create InstanceType, verify it appears in ListInstanceTypes
+- Create ComputeInstance with valid instance_type, verify VM provisions with correct resources
+- Attempt to create ComputeInstance with disabled instance_type, verify rejection
+- Disable InstanceType, verify it disappears from org user ListInstanceTypes
+- Attempt to delete InstanceType with active VMs, verify rejection
+- Delete all VMs, then delete InstanceType, verify success
+- Create VM, update instance_type, verify rejection (immutability)
+
+**End-to-End Tests:**
+- Cloud Provider Admin creates instance type via CLI
+- Organization User lists instance types and sees new type
+- Organization User creates VM using instance type
+- osac-operator provisions KubeVirt VM with correct cores/memory
+- VM reaches Running state
+- Cloud Provider Admin disables instance type
+- Organization User no longer sees type in list
+- Attempt to create new VM with disabled type fails
+- Existing VM continues running
+
+**Migration Testing:**
+- Run migration on test database with existing ComputeInstances
+- Verify all VMs get assigned instance_type
+- Verify compute resources match pre-migration values
+- Verify new VM creation works post-migration
+
+## Graduation Criteria
+
+This enhancement is not targeting a specific OSAC release at this time. When targeting a release, graduation criteria will be defined based on production deployment feedback and user validation.
+
+Expected maturity progression:
+- **Dev Preview:** Initial implementation with basic instance type CRUD and VM creation
+- **Tech Preview:** Production deployment at pilot sites with migration tooling
+- **GA:** Full production deployment with documented migration path and operational runbooks
+
+Success signals for graduation:
+- Zero incidents related to instance type reference resolution
+- Migration tooling successfully used at 2+ pilot sites
+- Positive feedback from Cloud Provider Admins on manageability
+- Positive feedback from Organization Users on simplified VM creation UX
+- Documentation complete and validated by users
+
+## Upgrade/Downgrade Strategy
+
+Not applicable - OSAC is pre-GA. This is a breaking API change.
+
+## Version Skew Strategy
+
+Not applicable - OSAC is pre-GA. Components should be upgraded together.
+
+## Support Procedures
+
+### Operational Impact of API Extensions
+
+**New API resources:**
+- InstanceType (CRD-like resource in fulfillment-service, not a Kubernetes CRD)
+- Creates additional database table and API endpoints
+- Increases fulfillment-service memory footprint (caching layer for instance type lookups)
+
+**Modified API resources:**
+- ComputeInstance.spec.instance_type (new required field)
+- Breaking change: cores/memory_gib fields removed
+
+**Failure Modes and Troubleshooting:**
+
+**ComputeInstance stuck in Pending with invalid resource values**
+- **Detection:** `kubectl get computeinstance <name> -o yaml` shows invalid cores/memory_gib values
+- **Diagnosis:** Instance type definition was corrupted or manually modified in database
+- **Resolution:** Delete and recreate VM via API with valid instance type, or fix database corruption
+- **Prevention:** Only modify instance types via fulfillment-service API, never directly in database
+
+**ComputeInstance creation rejected: "instance type disabled"**
+- **Detection:** API returns 400 Bad Request with message about disabled instance type
+- **Diagnosis:** Cloud Provider Admin disabled the instance type
+- **Resolution:** Re-enable instance type or choose different instance type when creating VM
+- **Prevention:** Communicate instance type lifecycle changes to users before disabling
+
+**osac-operator reconciliation failures**
+- **Detection:** Controller logs show errors provisioning VM or invalid spec values
+- **Diagnosis:** ComputeInstance CR has invalid cores/memory_gib values (data corruption or manual edit)
+- **Resolution:** Check CR spec.cores and spec.memory_gib; if invalid, delete CR and recreate VM via API
+- **Prevention:** Never manually edit ComputeInstance CRs; always use fulfillment-service API
+
+**InstanceType cannot be deleted: "referenced by active VMs"**
+- **Detection:** DELETE API call returns 409 Conflict
+- **Diagnosis:** fulfillment-service database query found ComputeInstances using this instance type
+- **Resolution:** Delete all referencing VMs first, then delete instance type. Or disable instance type and delete later.
+- **Prevention:** Use List API or query database to find referencing VMs before attempting deletion
+
+### Disabling / Rollback
+
+Not supported.
+
+## Infrastructure Needed
+
+No additional infrastructure is required for this enhancement.

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -125,7 +125,7 @@ All instance types in Phase 1 are globally scoped:
 3. The instance type remains visible in ListInstanceTypes for Organization Users
 4. New VM creation requests succeed but return a warning: "Instance type 'standard-2-4' is deprecated and will become obsolete on 2026-12-31. Consider migrating to 'standard-2-8'."
 5. Existing VMs continue to run unchanged
-6. (Future) Scheduled job automatically transitions to OBSOLETE when the `obsolete` timestamp is reached
+6. **Note:** Phase 1 does not include automatic state transitions - Cloud Provider Admin must manually transition to OBSOLETE on or after the obsolete date
 
 **Obsoleting an Instance Type**
 

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -285,9 +285,12 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 - CreateInstanceType: Default state to ACTIVE if not specified
 - UpdateInstanceType: Reject changes to name, cores, or memory_gib (immutable)
 - UpdateInstanceType: Allow changes to description, state, and deprecation fields
-- UpdateInstanceType: When transitioning to DEPRECATED, auto-populate deprecation.deprecated timestamp if not provided
-- UpdateInstanceType: When transitioning to OBSOLETE, auto-populate deprecation.obsolete timestamp if not provided
-- UpdateInstanceType: Validate deprecation.obsolete is in the future when transitioning to DEPRECATED
+- UpdateInstanceType: When transitioning to DEPRECATED, auto-populate deprecation.deprecated timestamp (set to current time) if not provided
+- UpdateInstanceType: When transitioning to OBSOLETE, auto-populate deprecation.obsolete timestamp (set to current time) if not provided
+- UpdateInstanceType: If deprecation.deprecated is provided explicitly, allow any timestamp (past or future) - represents when deprecation was/will be announced
+- UpdateInstanceType: If deprecation.obsolete is provided explicitly when transitioning to DEPRECATED, validate it is in the future (cannot set future DEPRECATED type to already-obsolete)
+- UpdateInstanceType: If deprecation.obsolete is provided explicitly when transitioning to OBSOLETE, allow any timestamp (past or future) - represents when it became/will become obsolete
+- UpdateInstanceType: API behavior is based on state field, not timestamps (future deprecation timestamps do not affect current behavior)
 - DeleteInstanceType: Reject if any ComputeInstances reference this instance type by name
 
 #### Deletion Protection

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -3,7 +3,7 @@ title: vm-instance-types
 authors:
   - atraeger@redhat.com
 creation-date: 2026-05-06
-last-updated: 2026-05-17
+last-updated: 2026-06-01
 tracking-link:
   - https://redhat.atlassian.net/browse/OSAC-46
 see-also:
@@ -260,7 +260,7 @@ This enhancement modifies existing OSAC APIs and introduces new resources:
 
 **InstanceTypes Service** (proto/public/osac/public/v1/instance_types_service.proto)
 - Public API: ListInstanceTypes, GetInstanceType
-- Private API: CreateInstanceType, UpdateInstanceType, DeleteInstanceType
+- Private API: ListInstanceTypes, GetInstanceType, CreateInstanceType, UpdateInstanceType, DeleteInstanceType
 
 #### Modified Resources
 
@@ -292,6 +292,7 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 - CreateInstanceType: Default state to ACTIVE if not specified
 - UpdateInstanceType: Reject changes to name, cores, or memory_gib (immutable)
 - UpdateInstanceType: Allow changes to description, state, and deprecation fields
+- UpdateInstanceType: State transitions are bidirectional (e.g., DEPRECATED → ACTIVE is allowed to "resurrect" an instance type if needed)
 - UpdateInstanceType: When transitioning to DEPRECATED, auto-populate deprecation.deprecated timestamp (set to current time) if not provided
 - UpdateInstanceType: When transitioning to OBSOLETE, auto-populate deprecation.obsolete timestamp (set to current time) if not provided
 - UpdateInstanceType: If deprecation.deprecated is provided explicitly, allow any timestamp (past or future) - represents when deprecation was/will be announced
@@ -299,13 +300,14 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 - UpdateInstanceType: If deprecation.obsolete is provided explicitly when transitioning to OBSOLETE, allow any timestamp (past or future) - represents when it became/will become obsolete
 - UpdateInstanceType: API behavior is based on state field, not timestamps (future deprecation timestamps do not affect current behavior)
 - DeleteInstanceType: Reject if any ComputeInstances reference this instance type by name
+- DeleteInstanceType: Uses soft-delete pattern (sets deletion_timestamp), consistent with OSAC resource lifecycle management
 
 #### Deletion Protection
 
 **InstanceType deletion checks:**
 - fulfillment-service queries database for ComputeInstances using this instance type name (via osac.io/instance-type-name label)
 - If any references exist, deletion is rejected with 409 Conflict
-- Returns list of affected ComputeInstance names in error message
+- Error message indicates the instance type is in use (e.g., "Cannot delete instance type 'standard-4-16': instance type is in use")
 - Deletion succeeds only when no ComputeInstances reference the instance type name
 
 ### Implementation Details/Notes/Constraints
@@ -317,12 +319,13 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 CREATE TABLE instance_types (
     name TEXT PRIMARY KEY,                  -- User-specified name (globally unique, immutable, never reusable, e.g., "standard-4-16")
     creation_timestamp TIMESTAMPTZ NOT NULL,
+    update_timestamp TIMESTAMPTZ NOT NULL,  -- Last modification time for auditing
     deletion_timestamp TIMESTAMPTZ,
     finalizers TEXT[],
     creators TEXT[],
     tenants TEXT[],                         -- Empty for global instance types in Phase 1
-    labels JSONB,
-    annotations JSONB,
+    labels JSONB,                           -- Reserved for future extensibility (not exposed in Phase 1 Create/List APIs)
+    annotations JSONB,                      -- Reserved for future extensibility (not exposed in Phase 1 Create/List APIs)
     data JSONB NOT NULL                     -- Serialized InstanceType protobuf
 );
 
@@ -330,7 +333,7 @@ CREATE TABLE instance_types (
 -- Instance type names are never reusable, even after soft deletion
 ```
 
-The `data` JSONB column contains the serialized InstanceType protobuf.
+The `data` JSONB column contains the serialized InstanceType protobuf. This follows OSAC's standard database pattern of storing proto messages as JSONB for schema flexibility and consistency across resources.
 
 Example of an ACTIVE instance type:
 ```json

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -86,7 +86,7 @@ All instance types in Phase 1 are globally scoped:
 **API behavior by state:**
 * ListInstanceTypes: Returns ACTIVE and DEPRECATED by default; supports filter parameter to include OBSOLETE (e.g., `filter: "state IN (ACTIVE, DEPRECATED, OBSOLETE)"`)
 * GetInstanceType: Returns any instance type regardless of state (for viewing details by name)
-* CreateComputeInstance: ACTIVE succeeds, DEPRECATED succeeds with warning, OBSOLETE is rejected with 409 Conflict
+* CreateComputeInstance: ACTIVE succeeds, DEPRECATED succeeds with warning in `CreateComputeInstanceResponse.warnings` field, OBSOLETE is rejected with 409 Conflict
 
 ### Naming and Uniqueness
 
@@ -199,8 +199,15 @@ All instance types in Phase 1 are globally scoped:
    - Instance type "standard-4-16" exists and state is ACTIVE or DEPRECATED
    - User has appropriate permissions
    - Resolves instance type to cores=4, memory_gib=16
-   - If state is DEPRECATED, includes warning in response
-3. The Fulfillment Service creates the ComputeInstance CR with expanded values:
+   - If state is DEPRECATED, includes warning in `CreateComputeInstanceResponse.warnings` field
+3. The API returns `CreateComputeInstanceResponse`:
+   ```json
+   {
+     "compute_instance": { /* ComputeInstance resource */ },
+     "warnings": []  // Empty for ACTIVE instance types; contains deprecation message for DEPRECATED types
+   }
+   ```
+4. The Fulfillment Service creates the ComputeInstance CR with expanded values:
    ```yaml
    apiVersion: osac.openshift.io/v1alpha1
    kind: ComputeInstance
@@ -218,8 +225,8 @@ All instance types in Phase 1 are globally scoped:
        source_type: "registry"
        source_ref: "quay.io/fedora/fedora:40"
    ```
-4. The osac-operator reconciles the ComputeInstance, reading cores and memory_gib from spec
-5. The VM is provisioned via KubeVirt with 4 cores and 16 GiB RAM
+5. The osac-operator reconciles the ComputeInstance, reading cores and memory_gib from spec
+6. The VM is provisioned via KubeVirt with 4 cores and 16 GiB RAM
 
 **Error Cases**
 
@@ -271,7 +278,7 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 **Public API (Organization Users):**
 - CreateComputeInstance: Require instance_type field (string name), reject if missing
 - CreateComputeInstance: Validate instance_type name exists and state is ACTIVE or DEPRECATED
-- CreateComputeInstance: If state is DEPRECATED, return warning with replacement suggestion (if set)
+- CreateComputeInstance: If state is DEPRECATED, include warning in `CreateComputeInstanceResponse.warnings` field with replacement suggestion (if set) and obsolete timestamp (if set)
 - CreateComputeInstance: If state is OBSOLETE, reject with HTTP 409 Conflict ("instance type is obsolete")
 - CreateComputeInstance: If instance_type name not found, reject with HTTP 404 Not Found
 - CreateComputeInstance: Expand instance_type name to cores/memory_gib before creating CR
@@ -499,6 +506,12 @@ message ComputeInstanceSpec {
   optional string user_data = 11;
   optional string subnet = 12;
   repeated string security_groups = 13;
+}
+
+// CreateComputeInstanceResponse includes warnings for DEPRECATED instance types
+message CreateComputeInstanceResponse {
+  ComputeInstance compute_instance = 1;
+  repeated string warnings = 2;  // Warning messages (e.g., "Instance type 'standard-2-4' is deprecated and will become obsolete on 2026-12-31. Consider migrating to 'standard-2-8'.")
 }
 ```
 

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -36,7 +36,8 @@ The current ComputeInstance API allows users to specify compute resources (cores
 * Require all ComputeInstance creation to use instance types (strict mode), removing the ability to specify cores and memory individually
 * Support globally-scoped instance types defined and managed by Cloud Provider Admins only
 * Support instance type lifecycle states (ACTIVE → DEPRECATED → OBSOLETE) following GCP deprecation model, allowing graceful migration without deleting type definitions
-* Ensure instance type compute specifications (cores, memory) are immutable after creation to prevent inconsistencies
+* Provide deprecation metadata (timestamps, replacement suggestions) to communicate migration timelines to users
+* Ensure instance type compute specifications (cores, memory, name) are immutable after creation to prevent inconsistencies
 
 ### Non-Goals
 
@@ -51,6 +52,7 @@ The following are explicitly out of scope for Phase 1:
 * Pricing or metering metadata associated with instance types
 * Network bandwidth constraints or network performance tiers
 * Per-organization instance type restrictions
+* Automatic state transitions based on deprecation timestamps (scheduled job to transition DEPRECATED → OBSOLETE)
 
 ## Proposal
 
@@ -62,8 +64,9 @@ This proposal introduces a new `InstanceType` resource that defines pre-configur
 * Globally scoped, visible to all organizations
 * Identified by name (globally unique, user-specified, e.g., "standard-4-16")
 * Immutable compute specs (cores, memory_gib, name)
-* Mutable metadata (description, state)
+* Mutable metadata (description, state, deprecation)
 * State lifecycle: ACTIVE → DEPRECATED → OBSOLETE (following GCP deprecation model)
+* Deprecation metadata includes timestamps and replacement suggestions for migration planning
 * Cloud Provider Admin-only creation and management
 
 **ComputeInstance (modified)** - Virtual machine resource
@@ -111,14 +114,18 @@ All instance types in Phase 1 are globally scoped:
 
 **Deprecating an Instance Type**
 
-1. Cloud Provider Admin marks an instance type as deprecated:
+1. Cloud Provider Admin marks an instance type as deprecated with optional transition timeline:
    ```bash
-   osac-admin update instance-type standard-2-4 --state DEPRECATED --replacement standard-2-8
+   osac-admin update instance-type standard-2-4 \
+     --state DEPRECATED \
+     --replacement standard-2-8 \
+     --obsolete-at 2026-12-31T23:59:59Z
    ```
-2. The Fulfillment Service updates the InstanceType state
+2. The Fulfillment Service updates the InstanceType state and records deprecation metadata (current timestamp as `deprecated`, future timestamp as `obsolete`)
 3. The instance type remains visible in ListInstanceTypes for Organization Users
-4. New VM creation requests succeed but return a warning: "Instance type 'standard-2-4' is deprecated. Consider using 'standard-2-8' instead."
+4. New VM creation requests succeed but return a warning: "Instance type 'standard-2-4' is deprecated and will become obsolete on 2026-12-31. Consider migrating to 'standard-2-8'."
 5. Existing VMs continue to run unchanged
+6. (Future) Scheduled job automatically transitions to OBSOLETE when the `obsolete` timestamp is reached
 
 **Obsoleting an Instance Type**
 
@@ -126,10 +133,10 @@ All instance types in Phase 1 are globally scoped:
    ```bash
    osac-admin update instance-type standard-2-4 --state OBSOLETE
    ```
-2. The Fulfillment Service updates the InstanceType state
-3. The instance type is hidden from ListInstanceTypes for Organization Users
+2. The Fulfillment Service updates the InstanceType state and records obsolete timestamp
+3. The instance type is hidden from ListInstanceTypes for Organization Users (unless explicitly filtered)
 4. Existing VMs using this instance type continue to run unchanged
-5. New VM creation requests with this instance type are rejected
+5. New VM creation requests with this instance type are rejected with 409 Conflict
 
 **Deleting an Instance Type**
 
@@ -160,7 +167,12 @@ All instance types in Phase 1 are globally scoped:
          "memory_gib": 4,
          "description": "Small balanced compute",
          "state": "DEPRECATED",
-         "replacement": "standard-2-8"
+         "deprecation": {
+           "state": "DEPRECATED",
+           "replacement": "standard-2-8",
+           "deprecated": "2026-03-15T10:00:00Z",
+           "obsolete": "2026-12-31T23:59:59Z"
+         }
        },
        {
          "name": "standard-4-16",
@@ -272,7 +284,10 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 - CreateInstanceType: Validate cores > 0 and memory_gib > 0
 - CreateInstanceType: Default state to ACTIVE if not specified
 - UpdateInstanceType: Reject changes to name, cores, or memory_gib (immutable)
-- UpdateInstanceType: Allow changes to description, state, and replacement fields
+- UpdateInstanceType: Allow changes to description, state, and deprecation fields
+- UpdateInstanceType: When transitioning to DEPRECATED, auto-populate deprecation.deprecated timestamp if not provided
+- UpdateInstanceType: When transitioning to OBSOLETE, auto-populate deprecation.obsolete timestamp if not provided
+- UpdateInstanceType: Validate deprecation.obsolete is in the future when transitioning to DEPRECATED
 - DeleteInstanceType: Reject if any ComputeInstances reference this instance type by name
 
 #### Deletion Protection
@@ -305,7 +320,9 @@ CREATE TABLE instance_types (
 CREATE UNIQUE INDEX instance_types_active_name_idx ON instance_types(name) WHERE deletion_timestamp IS NULL;
 ```
 
-The `data` JSONB column contains the serialized InstanceType protobuf:
+The `data` JSONB column contains the serialized InstanceType protobuf.
+
+Example of an ACTIVE instance type:
 ```json
 {
   "name": "standard-4-16",
@@ -315,8 +332,27 @@ The `data` JSONB column contains the serialized InstanceType protobuf:
   "cores": 4,
   "memory_gib": 16,
   "description": "Balanced compute: 4 cores, 16 GiB RAM",
-  "state": "ACTIVE",
-  "replacement": ""
+  "state": "ACTIVE"
+}
+```
+
+Example of a DEPRECATED instance type with deprecation metadata:
+```json
+{
+  "name": "standard-2-4",
+  "metadata": {
+    "name": "standard-2-4"
+  },
+  "cores": 2,
+  "memory_gib": 4,
+  "description": "Small balanced compute",
+  "state": "DEPRECATED",
+  "deprecation": {
+    "state": "DEPRECATED",
+    "replacement": "standard-2-8",
+    "deprecated": "2026-03-15T10:00:00Z",
+    "obsolete": "2026-12-31T23:59:59Z"
+  }
 }
 ```
 
@@ -385,14 +421,21 @@ enum InstanceTypeState {
   OBSOLETE = 3;     // Not available for new VMs, visible for lookups only
 }
 
+message InstanceTypeDeprecation {
+  InstanceTypeState state = 1;                   // DEPRECATED or OBSOLETE (matches parent InstanceType.state)
+  string replacement = 2;                        // Optional: suggested replacement instance type name
+  google.protobuf.Timestamp deprecated = 3;      // Optional: when deprecation was announced (auto-set on DEPRECATED transition)
+  google.protobuf.Timestamp obsolete = 4;        // Optional: when it becomes/became obsolete (admin-specified or auto-set)
+}
+
 message InstanceType {
-  string name = 1;                        // Primary identifier (globally unique, immutable, e.g., "standard-4-16")
-  Metadata metadata = 2;                  // Standard metadata (name field matches top-level name)
-  int32 cores = 3;                        // Immutable compute specification
-  int32 memory_gib = 4;                   // Immutable compute specification
-  string description = 5;                 // Mutable descriptive text
-  InstanceTypeState state = 6;            // Mutable lifecycle state
-  string replacement = 7;                 // Optional: suggested replacement instance type name (when DEPRECATED)
+  string name = 1;                               // Primary identifier (globally unique, immutable, e.g., "standard-4-16")
+  Metadata metadata = 2;                         // Standard metadata (name field matches top-level name)
+  int32 cores = 3;                               // Immutable compute specification
+  int32 memory_gib = 4;                          // Immutable compute specification
+  string description = 5;                        // Mutable descriptive text
+  InstanceTypeState state = 6;                   // Mutable lifecycle state
+  InstanceTypeDeprecation deprecation = 7;       // Optional: only set when state is DEPRECATED or OBSOLETE
 }
 
 // proto/public/osac/public/v1/instance_types_service.proto
@@ -544,17 +587,24 @@ The CR retains cores/memory_gib fields in spec (unchanged from today) so osac-op
 - ComputeInstance validation rejects missing instance_type
 - ComputeInstance validation rejects OBSOLETE instance_type
 - ComputeInstance validation rejects non-existent instance_type
-- ComputeInstance with DEPRECATED instance_type succeeds with warning
+- ComputeInstance with DEPRECATED instance_type succeeds with warning (includes obsolete timestamp in warning)
 - InstanceType state transitions (ACTIVE → DEPRECATED → OBSOLETE)
+- InstanceType deprecation metadata auto-population (deprecated timestamp on DEPRECATED transition, obsolete timestamp on OBSOLETE transition)
+- InstanceType validation rejects obsolete timestamp in the past when transitioning to DEPRECATED
 - InstanceType deletion rejected when VMs reference it
-- InstanceType cores/memory_gib immutability enforcement
+- InstanceType cores/memory_gib/name immutability enforcement
+- InstanceType deprecation field mutability (replacement, timestamps)
 - ListInstanceTypes filter behavior (default excludes OBSOLETE, filter includes it)
+- ListInstanceTypes returns deprecation metadata for DEPRECATED/OBSOLETE types
 
 **Integration Tests (fulfillment-service/it/):**
 - Create InstanceType, verify it appears in ListInstanceTypes
 - Create ComputeInstance with valid instance_type, verify VM provisions with correct resources
 - Attempt to create ComputeInstance with OBSOLETE instance_type, verify 409 Conflict
+- Set InstanceType to DEPRECATED with future obsolete timestamp, verify warning includes obsolete date
+- Create VM with DEPRECATED instance_type, verify warning message includes deprecation timeline
 - Set InstanceType to OBSOLETE, verify it disappears from org user ListInstanceTypes
+- Verify GetInstanceType returns deprecation metadata for DEPRECATED and OBSOLETE types
 - Attempt to delete InstanceType with active VMs, verify rejection
 - Delete all VMs, then delete InstanceType, verify success
 - Create VM, update instance_type, verify rejection (immutability)
@@ -565,8 +615,11 @@ The CR retains cores/memory_gib fields in spec (unchanged from today) so osac-op
 - Organization User creates VM using instance type
 - osac-operator provisions KubeVirt VM with correct cores/memory
 - VM reaches Running state
+- Cloud Provider Admin sets instance type to DEPRECATED with replacement and future obsolete timestamp
+- Organization User lists instance types and sees DEPRECATED status with deprecation metadata
+- Organization User creates new VM with DEPRECATED type, receives warning with obsolete date
 - Cloud Provider Admin sets instance type to OBSOLETE
-- Organization User no longer sees type in list
+- Organization User no longer sees type in list (unless filtered)
 - Attempt to create new VM with OBSOLETE type fails with 409 Conflict
 - Existing VM continues running
 

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -16,7 +16,7 @@ superseded-by:
 
 ## Summary
 
-This enhancement introduces VM instance types as pre-defined compute resource bundles (cores, memory) that can be referenced by name when creating virtual machines. Instance types simplify VM creation by providing a standardized set of compute configurations, following cloud-native patterns similar to AWS EC2 instance types, Azure VM sizes, and GCP machine types. In the initial implementation (Phase 1), all instance types are globally scoped and defined by the Cloud Service Provider, ensuring consistency and preventing configuration fragmentation. Users select an instance type by name rather than specifying individual cores and memory values. This proposal focuses on Virtual Machine-as-a-Service (VMaaS) compute instances only; Cluster-as-a-Service (CaaS) uses bare metal provisioning with a separate resource classification system (`HostType`) and is not covered by this enhancement.
+This enhancement introduces VM instance types as pre-defined compute resource bundles (cores, memory) that can be referenced by name when creating virtual machines. Instance types simplify VM creation by providing a standardized set of compute configurations, following cloud-native patterns similar to AWS EC2 instance types, Azure VM sizes, and GCP machine types. All instance types are global. The instance type concept exists only at the gRPC API layer (fulfillment-service); at the Kubernetes CR level, instance types are expanded to cores/memory_gib fields. Users select an instance type by name rather than specifying individual cores and memory values. This proposal focuses on Virtual Machine-as-a-Service (VMaaS) compute instances only; Cluster-as-a-Service (CaaS) uses bare metal provisioning with a separate resource classification system (`HostType`) and is not covered by this enhancement.
 
 ## Motivation
 
@@ -35,9 +35,8 @@ The current ComputeInstance API allows users to specify compute resources (cores
 * Provide a self-service API for Organization Users to list available instance types and create VMs using instance type names
 * Require all ComputeInstance creation to use instance types (strict mode), removing the ability to specify cores and memory individually
 * Support globally-scoped instance types defined and managed by Cloud Provider Admins only
-* Enable/disable instance types globally to control availability without deleting type definitions
+* Support instance type lifecycle states (ACTIVE → DEPRECATED → OBSOLETE) following GCP deprecation model, allowing graceful migration without deleting type definitions
 * Ensure instance type compute specifications (cores, memory) are immutable after creation to prevent inconsistencies
-* Maintain backward compatibility for existing VMs created before instance types are introduced
 
 ### Non-Goals
 
@@ -51,22 +50,23 @@ The following are explicitly out of scope for Phase 1:
 * Quota enforcement and capacity planning based on instance types (quota system not yet defined in OSAC)
 * Pricing or metering metadata associated with instance types
 * Network bandwidth constraints or network performance tiers
-* Per-organization instance type restrictions (all orgs see all enabled instance types in Phase 1)
+* Per-organization instance type restrictions
 
 ## Proposal
 
-This proposal introduces a new `InstanceType` resource that defines pre-configured compute bundles with immutable core and memory specifications. The Cloud Service Provider creates and manages all instance types, which are globally visible to all organizations when enabled. The `ComputeInstance` API is modified to require an `instance_type` field and remove the existing `cores` and `memory_gib` fields. Disk specifications remain separate from instance types, as storage and compute are decoupled following industry-standard cloud patterns.
+This proposal introduces a new `InstanceType` resource that defines pre-configured compute bundles with immutable core and memory specifications. The Cloud Service Provider creates and manages all instance types, which are globally visible to all organizations. The `ComputeInstance` gRPC API is modified to require an `instance_type` field and remove the existing `cores` and `memory_gib` fields (the Kubernetes CR retains these fields, populated by fulfillment-service). Disk specifications remain separate from instance types, as storage and compute are decoupled following industry-standard cloud patterns. Instance types include a deprecation mechanism to manage lifecycle transitions.
 
 ### Key Resources
 
 **InstanceType** - Provider-defined compute specification
-* Globally scoped, visible to all organizations when enabled
+* Globally scoped, visible to all organizations
 * Immutable compute specs (cores, memory_gib)
-* Mutable metadata (description, enabled flag)
+* Mutable metadata (description, state)
+* State lifecycle: ACTIVE → DEPRECATED → OBSOLETE (following GCP deprecation model)
 * Cloud Provider Admin-only creation and management
 
 **ComputeInstance (modified)** - Virtual machine resource
-* Now requires `instance_type` field (string reference to InstanceType ID)
+* Now requires `instance_type` field (string reference to InstanceType name)
 * Removes `cores` and `memory_gib` fields from ComputeInstanceSpec
 * Retains `boot_disk` and `storage_class` as separate specifications
 
@@ -74,12 +74,15 @@ This proposal introduces a new `InstanceType` resource that defines pre-configur
 
 All instance types in Phase 1 are globally scoped:
 * **Created by:** Cloud Provider Admin only
-* **Visible to:** All organizations (when enabled=true)
-* **Hidden from:** Organization Users when enabled=false (Admin can always see all)
+* **Lifecycle states:**
+  - **ACTIVE**: Fully available for new VM creation, no warnings
+  - **DEPRECATED**: Available with warnings on VM creation (e.g., "Instance type 'standard-2-4' is deprecated. Consider using 'standard-2-8' instead.")
+  - **OBSOLETE**: Not available for new VM creation (rejected), still visible for lookups
 
-ListInstanceTypes API behavior:
-* Organization Users: Returns only enabled instance types
-* Cloud Provider Admin: Returns all instance types (enabled + disabled)
+**API behavior by state:**
+* ListInstanceTypes: Returns ACTIVE and DEPRECATED by default; supports filter parameter to include OBSOLETE (e.g., `filter: "state IN (ACTIVE, DEPRECATED, OBSOLETE)"`)
+* GetInstanceType: Returns any instance type regardless of state (for viewing details by name)
+* CreateComputeInstance: ACTIVE succeeds, DEPRECATED succeeds with warning, OBSOLETE is rejected with 409 Conflict
 
 ### Workflow Description
 
@@ -89,21 +92,32 @@ ListInstanceTypes API behavior:
 
 1. Cloud Provider Admin uses the OSAC CLI to create a new global instance type:
    ```bash
-   osac create instance-type standard-4-16 \
+   osac-admin create instance-type standard-4-16 \
      --cores 4 \
      --memory-gib 16 \
      --description "Balanced compute: 4 cores, 16 GiB RAM"
    ```
 2. The Fulfillment Service validates the request and creates the InstanceType resource
-3. The instance type is immediately available (enabled=true by default) to all Organization Users
+3. The instance type is immediately available (state=ACTIVE by default) to all Organization Users
 
-**Disabling an Instance Type**
+**Deprecating an Instance Type**
 
-1. Cloud Provider Admin disables an instance type to prevent new VM creation:
+1. Cloud Provider Admin marks an instance type as deprecated:
    ```bash
-   osac update instance-type standard-4-16 --enabled=false
+   osac-admin update instance-type standard-2-4 --state DEPRECATED --replacement standard-2-8
    ```
-2. The Fulfillment Service updates the InstanceType metadata
+2. The Fulfillment Service updates the InstanceType state
+3. The instance type remains visible in ListInstanceTypes for Organization Users
+4. New VM creation requests succeed but return a warning: "Instance type 'standard-2-4' is deprecated. Consider using 'standard-2-8' instead."
+5. Existing VMs continue to run unchanged
+
+**Obsoleting an Instance Type**
+
+1. Cloud Provider Admin marks an instance type as obsolete to prevent new VM creation:
+   ```bash
+   osac-admin update instance-type standard-2-4 --state OBSOLETE
+   ```
+2. The Fulfillment Service updates the InstanceType state
 3. The instance type is hidden from ListInstanceTypes for Organization Users
 4. Existing VMs using this instance type continue to run unchanged
 5. New VM creation requests with this instance type are rejected
@@ -112,10 +126,10 @@ ListInstanceTypes API behavior:
 
 1. Cloud Provider Admin attempts to delete an instance type:
    ```bash
-   osac delete instance-type standard-4-16
+   osac-admin delete instance-type standard-4-16
    ```
 2. The Fulfillment Service checks if any VMs reference this instance type
-3. If in use: deletion is rejected with an error listing affected VMs
+3. If in use: deletion is rejected with error "instance type is in use by at least one VM"
 4. If not in use: deletion succeeds
 
 #### VM Creation (Organization User)
@@ -126,7 +140,7 @@ ListInstanceTypes API behavior:
    ```bash
    osac list instance-types
    ```
-2. The Fulfillment Service returns only enabled instance types:
+2. The Fulfillment Service returns ACTIVE and DEPRECATED instance types (OBSOLETE types can be included via filter parameter):
    ```json
    {
      "items": [
@@ -136,7 +150,8 @@ ListInstanceTypes API behavior:
          "cores": 2,
          "memory_gib": 4,
          "description": "Small balanced compute",
-         "enabled": true
+         "state": "DEPRECATED",
+         "replacement": "standard-2-8"
        },
        {
          "id": "standard-4-16",
@@ -144,7 +159,7 @@ ListInstanceTypes API behavior:
          "cores": 4,
          "memory_gib": 16,
          "description": "Medium balanced compute",
-         "enabled": true
+         "state": "ACTIVE"
        }
      ]
    }
@@ -160,17 +175,18 @@ ListInstanceTypes API behavior:
      --image quay.io/fedora/fedora:40
    ```
 2. The Fulfillment Service validates and resolves:
-   - Instance type "standard-4-16" exists and is enabled
+   - Instance type "standard-4-16" exists and state is ACTIVE or DEPRECATED
    - User has appropriate permissions
    - Resolves instance type to cores=4, memory_gib=16
+   - If state is DEPRECATED, includes warning in response
 3. The Fulfillment Service creates the ComputeInstance CR with expanded values:
    ```yaml
    apiVersion: osac.openshift.io/v1alpha1
    kind: ComputeInstance
    metadata:
      name: my-vm
-     annotations:
-       osac.io/instance-type: "standard-4-16"  # Audit trail
+     labels:
+       osac.io/instance-type-name: "standard-4-16"  # Audit trail
    spec:
      cores: 4              # Expanded from instance type
      memory_gib: 16        # Expanded from instance type
@@ -192,10 +208,10 @@ $ osac create compute-instance my-vm --instance-type nonexistent
 Error: instance type "nonexistent" not found
 ```
 
-**Disabled instance type:**
+**OBSOLETE instance type:**
 ```bash
 $ osac create compute-instance my-vm --instance-type old-type
-Error: instance type "old-type" is not available (disabled)
+Error: instance type "old-type" is obsolete and cannot be used for new VMs
 ```
 
 **Missing instance type:**
@@ -221,9 +237,10 @@ This enhancement modifies existing OSAC APIs and introduces new resources:
 #### Modified Resources
 
 **ComputeInstanceSpec** (proto/public/osac/public/v1/compute_instance_type.proto - API layer only)
-- Add: `instance_type` field (string, required) - reference to InstanceType ID
+- Add: `instance_type` field (string, required) - reference to InstanceType name
 - Remove: `cores` field (optional int32) - replaced by instance_type in API
 - Remove: `memory_gib` field (optional int32) - replaced by instance_type in API
+- Note: fulfillment-service resolves instance_type name to cores/memory_gib when creating the CR
 - Retain: `boot_disk`, `storage_class`, `template`, `image`, `user_data`, `ssh_key`, etc.
 
 Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-service expands instance_type to these fields when creating the CR. See "Instance Type Resolution Strategy" for details.
@@ -232,16 +249,20 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 
 **Public API (Organization Users):**
 - CreateComputeInstance: Require instance_type field, reject if missing
-- CreateComputeInstance: Validate instance_type exists and is enabled
+- CreateComputeInstance: Validate instance_type exists and state is ACTIVE or DEPRECATED
+- CreateComputeInstance: If state is DEPRECATED, return warning with replacement suggestion (if set)
+- CreateComputeInstance: If state is OBSOLETE, reject with HTTP 409 Conflict ("instance type is obsolete")
+- CreateComputeInstance: If instance_type not found, reject with HTTP 404 Not Found
 - CreateComputeInstance: Expand instance_type to cores/memory_gib before creating CR
-- CreateComputeInstance: Add osac.io/instance-type annotation to CR
+- CreateComputeInstance: Add osac.io/instance-type-name label to CR
 - UpdateComputeInstance: Reject changes to instance_type field (immutable in Phase 1)
 
 **Private API (Cloud Provider Admin):**
 - CreateInstanceType: Require cores and memory_gib fields
 - CreateInstanceType: Validate cores > 0 and memory_gib > 0
+- CreateInstanceType: Default state to ACTIVE if not specified
 - UpdateInstanceType: Reject changes to cores or memory_gib (immutable)
-- UpdateInstanceType: Allow changes to description and enabled
+- UpdateInstanceType: Allow changes to description, state, and replacement fields
 - DeleteInstanceType: Reject if any ComputeInstances reference this type
 
 #### Deletion Protection
@@ -272,13 +293,14 @@ CREATE TABLE instance_types (
 );
 ```
 
-The `data` JSONB column contains:
+The `data` JSONB column contains the serialized InstanceType protobuf:
 ```json
 {
   "cores": 4,
   "memory_gib": 16,
   "description": "Balanced compute: 4 cores, 16 GiB RAM",
-  "enabled": true
+  "state": "ACTIVE",
+  "replacement": ""
 }
 ```
 
@@ -291,16 +313,17 @@ Instance types are resolved and expanded by fulfillment-service when creating th
 - **Zero changes to osac-operator:** Controller reads cores/memory_gib as it does today
 - **No runtime dependencies:** osac-operator doesn't need to call fulfillment-service API
 - **Enforcement at boundary:** Organization Users access only the fulfillment-service API (not k8s APIs), so instance type validation cannot be bypassed
-- **Audit trail:** Original instance_type name stored in CR annotation
+- **Audit trail:** Original instance_type name stored in CR label
 
 **fulfillment-service flow:**
 1. User creates ComputeInstance via API with `instance_type: "standard-4-16"`
-2. fulfillment-service validates instance type exists and is enabled
-3. fulfillment-service resolves cores=4, memory_gib=16 from InstanceType
-4. fulfillment-service creates ComputeInstance CR with:
+2. fulfillment-service validates instance type exists and state is ACTIVE or DEPRECATED
+3. If state is DEPRECATED, add warning to response
+4. fulfillment-service resolves cores=4, memory_gib=16 from InstanceType
+5. fulfillment-service creates ComputeInstance CR with:
    - `spec.cores: 4`
    - `spec.memory_gib: 16`
-   - `metadata.annotations["osac.io/instance-type"]: "standard-4-16"` (audit trail)
+   - `metadata.labels["osac.io/instance-type-name"]: "standard-4-16"` (audit trail)
 
 **osac-operator reconciliation (unchanged):**
 1. Read ComputeInstance.spec.cores and spec.memory_gib
@@ -311,7 +334,7 @@ Instance types are resolved and expanded by fulfillment-service when creating th
 
 Changing instance types is blocked in Phase 1 (spec.cores and spec.memory_gib are immutable). In the future, we could support instance type updates by:
 1. Allowing updates to cores/memory_gib fields
-2. Updating the `osac.io/instance-type` annotation
+2. Updating the `osac.io/instance-type-name` label
 3. Triggering VM resize (if supported by underlying platform)
 
 Advanced OpenShift Virtualization features (NUMA topology, hugepages, CPU pinning) remain internal implementation details and are not exposed to Organization Users through the instance type API.
@@ -323,25 +346,34 @@ Advanced OpenShift Virtualization features (NUMA topology, hugepages, CPU pinnin
 - `PrivateInstanceTypesServer` (private) - full CRUD using GenericServer pattern
 - Both servers in `internal/servers/instance_types_server.go` and `private_instance_types_server.go`
 
-**Authorization:**
-- CreateInstanceType: Requires Cloud Provider Admin role
-- ListInstanceTypes (public): Filters to enabled=true, global scope only
-- GetInstanceType (public): Returns only if enabled=true
-- ListInstanceTypes (private): Returns all instance types
-- UpdateInstanceType: Requires Cloud Provider Admin role
-- DeleteInstanceType: Requires Cloud Provider Admin role, rejects if references exist
+**Authorization and scoping:**
+
+Instance type APIs follow the standard fulfillment-service authentication, authorization, and tenant-scoping policy. Instance-type-specific deltas:
+
+- **Global scope:** All instance types are globally scoped (no tenant filtering)
+- **Admin-only write:** CreateInstanceType, UpdateInstanceType, DeleteInstanceType require Cloud Provider Admin role
+- **State-based filtering:** ListInstanceTypes returns ACTIVE and DEPRECATED by default (use filter parameter for OBSOLETE)
+- **Deletion protection:** DeleteInstanceType rejects if any ComputeInstances reference the type (API-layer query check)
 
 #### Proto Definition Sketch
 
 ```proto
 // proto/public/osac/public/v1/instance_type_type.proto
+enum InstanceTypeState {
+  INSTANCE_TYPE_STATE_UNSPECIFIED = 0;
+  ACTIVE = 1;       // Fully available for new VM creation
+  DEPRECATED = 2;   // Available with warnings, migration recommended
+  OBSOLETE = 3;     // Not available for new VMs, visible for lookups only
+}
+
 message InstanceType {
   string id = 1;
   Metadata metadata = 2;
   int32 cores = 3;
   int32 memory_gib = 4;
   string description = 5;
-  bool enabled = 6;
+  InstanceTypeState state = 6;
+  string replacement = 7;  // Optional: suggested replacement instance type (when DEPRECATED)
 }
 
 // proto/public/osac/public/v1/instance_types_service.proto
@@ -401,8 +433,8 @@ message ComputeInstanceSpec {
 apiVersion: osac.openshift.io/v1alpha1
 kind: ComputeInstance
 metadata:
-  annotations:
-    osac.io/instance-type: "standard-4-16"  # Audit trail
+  labels:
+    osac.io/instance-type-name: "standard-4-16"  # Audit trail
 spec:
   template: "..."
   cores: 4              # Expanded from instance type
@@ -412,7 +444,7 @@ spec:
   # ... other fields unchanged
 ```
 
-The CR retains cores/memory_gib fields in spec (unchanged from today) so osac-operator requires no modifications. The instance_type field exists only in the API layer and is stored as an annotation in the CR.
+The CR retains cores/memory_gib fields in spec (unchanged from today) so osac-operator requires no modifications. The instance_type field exists only in the API layer and is stored as a label in the CR.
 
 ### Risks and Mitigations
 
@@ -481,18 +513,19 @@ The CR retains cores/memory_gib fields in spec (unchanged from today) so osac-op
 **Unit Tests:**
 - InstanceType CRUD operations via GenericServer
 - ComputeInstance validation rejects missing instance_type
-- ComputeInstance validation rejects disabled instance_type
+- ComputeInstance validation rejects OBSOLETE instance_type
 - ComputeInstance validation rejects non-existent instance_type
+- ComputeInstance with DEPRECATED instance_type succeeds with warning
+- InstanceType state transitions (ACTIVE → DEPRECATED → OBSOLETE)
 - InstanceType deletion rejected when VMs reference it
 - InstanceType cores/memory_gib immutability enforcement
-- Public API filters instance types to enabled=true only
-- Private API returns all instance types regardless of enabled status
+- ListInstanceTypes filter behavior (default excludes OBSOLETE, filter includes it)
 
 **Integration Tests (fulfillment-service/it/):**
 - Create InstanceType, verify it appears in ListInstanceTypes
 - Create ComputeInstance with valid instance_type, verify VM provisions with correct resources
-- Attempt to create ComputeInstance with disabled instance_type, verify rejection
-- Disable InstanceType, verify it disappears from org user ListInstanceTypes
+- Attempt to create ComputeInstance with OBSOLETE instance_type, verify 409 Conflict
+- Set InstanceType to OBSOLETE, verify it disappears from org user ListInstanceTypes
 - Attempt to delete InstanceType with active VMs, verify rejection
 - Delete all VMs, then delete InstanceType, verify success
 - Create VM, update instance_type, verify rejection (immutability)
@@ -503,9 +536,9 @@ The CR retains cores/memory_gib fields in spec (unchanged from today) so osac-op
 - Organization User creates VM using instance type
 - osac-operator provisions KubeVirt VM with correct cores/memory
 - VM reaches Running state
-- Cloud Provider Admin disables instance type
+- Cloud Provider Admin sets instance type to OBSOLETE
 - Organization User no longer sees type in list
-- Attempt to create new VM with disabled type fails
+- Attempt to create new VM with OBSOLETE type fails with 409 Conflict
 - Existing VM continues running
 
 **Migration Testing:**

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -35,7 +35,7 @@ The current ComputeInstance API allows users to specify compute resources (cores
 * Provide a self-service API for Organization Users to list available instance types and create VMs using instance type names
 * Require all ComputeInstance creation to use instance types (strict mode), removing the ability to specify cores and memory individually
 * Support globally-scoped instance types defined and managed by Cloud Provider Admins only
-* Support instance type lifecycle states (ACTIVE → DEPRECATED → OBSOLETE) following GCP deprecation model, allowing graceful migration without deleting type definitions
+* Support instance type lifecycle states (ACTIVE ↔ DEPRECATED ↔ OBSOLETE) with bidirectional transitions, allowing graceful deprecation and reactivation
 * Provide deprecation metadata (timestamps, replacement suggestions) to communicate migration timelines to users
 * Ensure instance type compute specifications (cores, memory, name) are immutable after creation to prevent inconsistencies
 
@@ -65,7 +65,7 @@ This proposal introduces a new `InstanceType` resource that defines pre-configur
 * Identified by name (globally unique, user-specified, e.g., "standard-4-16")
 * Immutable compute specs (cores, memory_gib, name)
 * Mutable metadata (description, state, deprecation)
-* State lifecycle: ACTIVE → DEPRECATED → OBSOLETE (following GCP deprecation model)
+* State lifecycle: ACTIVE ↔ DEPRECATED ↔ OBSOLETE (bidirectional transitions supported)
 * Deprecation metadata includes timestamps and replacement suggestions for migration planning
 * Cloud Provider Admin-only creation and management
 
@@ -137,6 +137,16 @@ All instance types in Phase 1 are globally scoped:
 3. The instance type is hidden from ListInstanceTypes for Organization Users (unless explicitly filtered)
 4. Existing VMs using this instance type continue to run unchanged
 5. New VM creation requests with this instance type are rejected with 409 Conflict
+
+**Reactivating an Instance Type**
+
+1. Cloud Provider Admin restores a deprecated or obsolete instance type:
+   ```bash
+   osac-admin update instance-type standard-2-4 --state ACTIVE
+   ```
+2. The Fulfillment Service updates the InstanceType state to ACTIVE
+3. The instance type becomes available for new VM creation again without warnings
+4. Deprecation metadata (timestamps, replacement) is retained for historical reference
 
 **Deleting an Instance Type**
 
@@ -607,7 +617,7 @@ The CR retains cores/memory_gib fields in spec (unchanged from today) so osac-op
 - ComputeInstance validation rejects OBSOLETE instance_type
 - ComputeInstance validation rejects non-existent instance_type
 - ComputeInstance with DEPRECATED instance_type succeeds with warning (includes obsolete timestamp in warning)
-- InstanceType state transitions (ACTIVE → DEPRECATED → OBSOLETE)
+- InstanceType state transitions (ACTIVE ↔ DEPRECATED ↔ OBSOLETE, including reactivation)
 - InstanceType deprecation metadata auto-population (deprecated timestamp on DEPRECATED transition, obsolete timestamp on OBSOLETE transition)
 - InstanceType validation rejects obsolete timestamp in the past when transitioning to DEPRECATED
 - InstanceType deletion rejected when VMs reference it

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -3,7 +3,7 @@ title: vm-instance-types
 authors:
   - atraeger@redhat.com
 creation-date: 2026-05-06
-last-updated: 2026-05-06
+last-updated: 2026-05-17
 tracking-link:
   - https://redhat.atlassian.net/browse/OSAC-46
 see-also:

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -28,7 +28,7 @@ The current ComputeInstance API allows users to specify compute resources (cores
 * As a Organization User, I want to list available instance types with their compute specifications, so that I can choose the right size for my workload.
 * As a Cloud Provider Admin, I want to define global instance types including their compute specifications, so that I can standardize VM offerings and align them with available infrastructure capacity.
 * As a Cloud Provider Admin, I want to enforce governance by requiring instance types for all VM creation, so that I can prevent resource fragmentation and ensure efficient capacity utilization.
-* As a Cloud Provider Admin, I want to control instance type availability by enabling/disabling types globally, so that I can manage which VM sizes are available to tenants without deleting instance type definitions.
+* As a Cloud Provider Admin, I want to control instance type availability by managing lifecycle states (ACTIVE/DEPRECATED/OBSOLETE), so that I can manage which VM sizes are available to tenants without deleting instance type definitions.
 
 ### Goals
 
@@ -482,7 +482,7 @@ The CR retains cores/memory_gib fields in spec (unchanged from today) so osac-op
 
 **Risk: Instance type reference becomes stale if type is deleted**
 - Mitigation: fulfillment-service API checks prevent deletion of InstanceTypes referenced by active VMs
-- Mitigation: Admin must explicitly disable, wait for VMs to be deleted, then delete type
+- Mitigation: Admin must set type to OBSOLETE, wait for VMs to be deleted, then delete type
 
 **Risk: Users need a specific core/memory combination not offered**
 - Mitigation: Document process for requesting new instance types from Cloud Provider Admin
@@ -621,11 +621,11 @@ Not applicable - OSAC is pre-GA. Components should be upgraded together.
 - **Resolution:** Delete and recreate VM via API with valid instance type, or fix database corruption
 - **Prevention:** Only modify instance types via fulfillment-service API, never directly in database
 
-**ComputeInstance creation rejected: "instance type disabled"**
-- **Detection:** API returns 400 Bad Request with message about disabled instance type
-- **Diagnosis:** Cloud Provider Admin disabled the instance type
-- **Resolution:** Re-enable instance type or choose different instance type when creating VM
-- **Prevention:** Communicate instance type lifecycle changes to users before disabling
+**ComputeInstance creation rejected: "instance type is obsolete"**
+- **Detection:** API returns 409 Conflict with message indicating instance type is OBSOLETE
+- **Diagnosis:** Cloud Provider Admin marked the instance type as OBSOLETE
+- **Resolution:** Choose a different instance type (check replacement suggestion if available) or ask admin to change state back to ACTIVE/DEPRECATED
+- **Prevention:** Communicate instance type lifecycle changes (OBSOLETE transitions) to users before making the change
 
 **osac-operator reconciliation failures**
 - **Detection:** Controller logs show errors provisioning VM or invalid spec values
@@ -635,8 +635,8 @@ Not applicable - OSAC is pre-GA. Components should be upgraded together.
 
 **InstanceType cannot be deleted: "referenced by active VMs"**
 - **Detection:** DELETE API call returns 409 Conflict
-- **Diagnosis:** fulfillment-service database query found ComputeInstances using this instance type
-- **Resolution:** Delete all referencing VMs first, then delete instance type. Or disable instance type and delete later.
+- **Diagnosis:** fulfillment-service database query found ComputeInstances using this instance type name
+- **Resolution:** Delete all referencing VMs first, then delete instance type. Or set instance type to OBSOLETE and delete later.
 - **Prevention:** Use List API or query database to find referencing VMs before attempting deletion
 
 ### Disabling / Rollback

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -60,14 +60,15 @@ This proposal introduces a new `InstanceType` resource that defines pre-configur
 
 **InstanceType** - Provider-defined compute specification
 * Globally scoped, visible to all organizations
-* Immutable compute specs (cores, memory_gib)
+* Identified by name (globally unique, user-specified, e.g., "standard-4-16")
+* Immutable compute specs (cores, memory_gib, name)
 * Mutable metadata (description, state)
 * State lifecycle: ACTIVE → DEPRECATED → OBSOLETE (following GCP deprecation model)
 * Cloud Provider Admin-only creation and management
 
 **ComputeInstance (modified)** - Virtual machine resource
 * Now requires `instance_type` field (string reference to InstanceType name)
-* Removes `cores` and `memory_gib` fields from ComputeInstanceSpec
+* Removes `cores` and `memory_gib` fields from ComputeInstanceSpec (API layer only)
 * Retains `boot_disk` and `storage_class` as separate specifications
 
 ### Scoping and Visibility
@@ -83,6 +84,14 @@ All instance types in Phase 1 are globally scoped:
 * ListInstanceTypes: Returns ACTIVE and DEPRECATED by default; supports filter parameter to include OBSOLETE (e.g., `filter: "state IN (ACTIVE, DEPRECATED, OBSOLETE)"`)
 * GetInstanceType: Returns any instance type regardless of state (for viewing details by name)
 * CreateComputeInstance: ACTIVE succeeds, DEPRECATED succeeds with warning, OBSOLETE is rejected with 409 Conflict
+
+### Naming and Uniqueness
+
+* Instance type names are globally unique across the entire platform
+* Name is the primary identifier for referencing instance types (not an opaque ID)
+* ComputeInstance.spec.instance_type holds the name as a string (e.g., "standard-4-16")
+* Names are immutable after creation to prevent reference breakage
+* Database uses `name` as the primary key
 
 ### Workflow Description
 
@@ -145,7 +154,7 @@ All instance types in Phase 1 are globally scoped:
    {
      "items": [
        {
-         "id": "standard-2-4",
+         "name": "standard-2-4",
          "metadata": { "name": "standard-2-4" },
          "cores": 2,
          "memory_gib": 4,
@@ -154,7 +163,7 @@ All instance types in Phase 1 are globally scoped:
          "replacement": "standard-2-8"
        },
        {
-         "id": "standard-4-16",
+         "name": "standard-4-16",
          "metadata": { "name": "standard-4-16" },
          "cores": 4,
          "memory_gib": 16,
@@ -248,30 +257,31 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 #### Validation
 
 **Public API (Organization Users):**
-- CreateComputeInstance: Require instance_type field, reject if missing
-- CreateComputeInstance: Validate instance_type exists and state is ACTIVE or DEPRECATED
+- CreateComputeInstance: Require instance_type field (string name), reject if missing
+- CreateComputeInstance: Validate instance_type name exists and state is ACTIVE or DEPRECATED
 - CreateComputeInstance: If state is DEPRECATED, return warning with replacement suggestion (if set)
 - CreateComputeInstance: If state is OBSOLETE, reject with HTTP 409 Conflict ("instance type is obsolete")
-- CreateComputeInstance: If instance_type not found, reject with HTTP 404 Not Found
-- CreateComputeInstance: Expand instance_type to cores/memory_gib before creating CR
+- CreateComputeInstance: If instance_type name not found, reject with HTTP 404 Not Found
+- CreateComputeInstance: Expand instance_type name to cores/memory_gib before creating CR
 - CreateComputeInstance: Add osac.io/instance-type-name label to CR
 - UpdateComputeInstance: Reject changes to instance_type field (immutable in Phase 1)
 
 **Private API (Cloud Provider Admin):**
-- CreateInstanceType: Require cores and memory_gib fields
+- CreateInstanceType: Require name, cores, and memory_gib fields
+- CreateInstanceType: Validate name uniqueness (globally unique across all instance types)
 - CreateInstanceType: Validate cores > 0 and memory_gib > 0
 - CreateInstanceType: Default state to ACTIVE if not specified
-- UpdateInstanceType: Reject changes to cores or memory_gib (immutable)
+- UpdateInstanceType: Reject changes to name, cores, or memory_gib (immutable)
 - UpdateInstanceType: Allow changes to description, state, and replacement fields
-- DeleteInstanceType: Reject if any ComputeInstances reference this type
+- DeleteInstanceType: Reject if any ComputeInstances reference this instance type by name
 
 #### Deletion Protection
 
 **InstanceType deletion checks:**
-- fulfillment-service queries database for ComputeInstances using this instance type
+- fulfillment-service queries database for ComputeInstances using this instance type name (via osac.io/instance-type-name label)
 - If any references exist, deletion is rejected with 409 Conflict
-- Returns list of affected ComputeInstance IDs in error message
-- Deletion succeeds only when no ComputeInstances reference the type
+- Returns list of affected ComputeInstance names in error message
+- Deletion succeeds only when no ComputeInstances reference the instance type name
 
 ### Implementation Details/Notes/Constraints
 
@@ -280,22 +290,28 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 **instance_types table:**
 ```sql
 CREATE TABLE instance_types (
-    id TEXT PRIMARY KEY,
-    name TEXT NOT NULL,
+    name TEXT PRIMARY KEY,                  -- User-specified name (globally unique, immutable, e.g., "standard-4-16")
     creation_timestamp TIMESTAMPTZ NOT NULL,
     deletion_timestamp TIMESTAMPTZ,
     finalizers TEXT[],
     creators TEXT[],
-    tenants TEXT[],  -- Empty for global instance types
+    tenants TEXT[],                         -- Empty for global instance types in Phase 1
     labels JSONB,
     annotations JSONB,
-    data JSONB NOT NULL  -- Serialized InstanceType protobuf
+    data JSONB NOT NULL                     -- Serialized InstanceType protobuf
 );
+
+-- Soft-delete support: prevent name reuse while deletion_timestamp is set
+CREATE UNIQUE INDEX instance_types_active_name_idx ON instance_types(name) WHERE deletion_timestamp IS NULL;
 ```
 
 The `data` JSONB column contains the serialized InstanceType protobuf:
 ```json
 {
+  "name": "standard-4-16",
+  "metadata": {
+    "name": "standard-4-16"
+  },
   "cores": 4,
   "memory_gib": 16,
   "description": "Balanced compute: 4 cores, 16 GiB RAM",
@@ -303,6 +319,8 @@ The `data` JSONB column contains the serialized InstanceType protobuf:
   "replacement": ""
 }
 ```
+
+**Note:** The top-level database `name` column (PRIMARY KEY) mirrors `data.name` and `data.metadata.name` for efficient querying and indexing. All three values must be identical for a given InstanceType record.
 
 #### Instance Type Resolution Strategy
 
@@ -316,14 +334,15 @@ Instance types are resolved and expanded by fulfillment-service when creating th
 - **Audit trail:** Original instance_type name stored in CR label
 
 **fulfillment-service flow:**
-1. User creates ComputeInstance via API with `instance_type: "standard-4-16"`
-2. fulfillment-service validates instance type exists and state is ACTIVE or DEPRECATED
-3. If state is DEPRECATED, add warning to response
-4. fulfillment-service resolves cores=4, memory_gib=16 from InstanceType
-5. fulfillment-service creates ComputeInstance CR with:
+1. User creates ComputeInstance via API with `instance_type: "standard-4-16"` (name reference)
+2. fulfillment-service queries database for InstanceType with `name = "standard-4-16"`
+3. fulfillment-service validates instance type exists and state is ACTIVE or DEPRECATED
+4. If state is DEPRECATED, add warning to response
+5. fulfillment-service resolves cores=4, memory_gib=16 from InstanceType record
+6. fulfillment-service creates ComputeInstance CR with:
    - `spec.cores: 4`
    - `spec.memory_gib: 16`
-   - `metadata.labels["osac.io/instance-type-name"]: "standard-4-16"` (audit trail)
+   - `metadata.labels["osac.io/instance-type-name"]: "standard-4-16"` (audit trail and deletion protection lookup)
 
 **osac-operator reconciliation (unchanged):**
 1. Read ComputeInstance.spec.cores and spec.memory_gib
@@ -367,13 +386,13 @@ enum InstanceTypeState {
 }
 
 message InstanceType {
-  string id = 1;
-  Metadata metadata = 2;
-  int32 cores = 3;
-  int32 memory_gib = 4;
-  string description = 5;
-  InstanceTypeState state = 6;
-  string replacement = 7;  // Optional: suggested replacement instance type (when DEPRECATED)
+  string name = 1;                        // Primary identifier (globally unique, immutable, e.g., "standard-4-16")
+  Metadata metadata = 2;                  // Standard metadata (name field matches top-level name)
+  int32 cores = 3;                        // Immutable compute specification
+  int32 memory_gib = 4;                   // Immutable compute specification
+  string description = 5;                 // Mutable descriptive text
+  InstanceTypeState state = 6;            // Mutable lifecycle state
+  string replacement = 7;                 // Optional: suggested replacement instance type name (when DEPRECATED)
 }
 
 // proto/public/osac/public/v1/instance_types_service.proto
@@ -385,7 +404,7 @@ service InstanceTypes {
   }
   rpc Get(GetInstanceTypeRequest) returns (InstanceType) {
     option (google.api.http) = {
-      get: "/api/fulfillment/v1/instance_types/{id}"
+      get: "/api/fulfillment/v1/instance_types/{name}"
     };
   }
 }
@@ -397,6 +416,16 @@ service InstanceTypes {
   rpc Delete(DeleteInstanceTypeRequest) returns (google.protobuf.Empty);
   rpc List(ListInstanceTypesRequest) returns (ListInstanceTypesResponse);
   rpc Get(GetInstanceTypeRequest) returns (InstanceType);
+}
+
+// GetInstanceTypeRequest references by name
+message GetInstanceTypeRequest {
+  string name = 1;  // Instance type name (e.g., "standard-4-16")
+}
+
+// DeleteInstanceTypeRequest references by name
+message DeleteInstanceTypeRequest {
+  string name = 1;  // Instance type name (e.g., "standard-4-16")
 }
 ```
 

--- a/enhancements/vm-instance-types/README.md
+++ b/enhancements/vm-instance-types/README.md
@@ -305,7 +305,7 @@ Note: The Kubernetes CR schema retains cores/memory_gib fields. The fulfillment-
 **instance_types table:**
 ```sql
 CREATE TABLE instance_types (
-    name TEXT PRIMARY KEY,                  -- User-specified name (globally unique, immutable, e.g., "standard-4-16")
+    name TEXT PRIMARY KEY,                  -- User-specified name (globally unique, immutable, never reusable, e.g., "standard-4-16")
     creation_timestamp TIMESTAMPTZ NOT NULL,
     deletion_timestamp TIMESTAMPTZ,
     finalizers TEXT[],
@@ -316,8 +316,8 @@ CREATE TABLE instance_types (
     data JSONB NOT NULL                     -- Serialized InstanceType protobuf
 );
 
--- Soft-delete support: prevent name reuse while deletion_timestamp is set
-CREATE UNIQUE INDEX instance_types_active_name_idx ON instance_types(name) WHERE deletion_timestamp IS NULL;
+-- No additional unique index needed: PRIMARY KEY on name enforces uniqueness for all rows (active and soft-deleted)
+-- Instance type names are never reusable, even after soft deletion
 ```
 
 The `data` JSONB column contains the serialized InstanceType protobuf.


### PR DESCRIPTION
## Summary
This enhancement introduces VM instance types as pre-defined compute resource bundles (cores, memory) that can be referenced by name when creating virtual machines. Phase 1 provides provider-controlled global instance types in strict mode, standardizing VM offerings and simplifying capacity planning.

## Motivation
Instance types replace individual cores/memory_gib fields with curated compute configurations, aligning with cloud-native patterns (AWS EC2, Azure VM sizes, GCP machine types). This enables standardization, simplifies user experience, and lays groundwork for future quota enforcement and custom instance types (Phase 2).

## Tracking
https://redhat.atlassian.net/browse/OSAC-46