### PR TITLE
OSAC-1317: Add BareMetalInstanceCatalogItem in BM enhancement

### DIFF
--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -19,7 +19,7 @@ superseded-by:
 
 ## Summary
 
-This enhancement introduces `BareMetalInstance` and `BareMetalInstanceCatalogItem` resources to the OSAC fulfillment-service public API, enabling tenants to provision and manage physical bare metal servers through a self-service interface. Catalog items are provider-managed entries that expose available hardware profiles, OS base images, and network configurations to tenants; they are published by Cloud Provider Admins via `osac-aap` and back a private `BareMetalInstanceTemplate`. The design adopts a pluggable provider architecture — implemented in a dedicated baremetal fulfillment component — so that future bare metal backends can be integrated without breaking the API. This EP is scoped to the fulfillment-service API layer; operator, provisioning, UX, and E2E concerns are tracked as companion work items under OSAC-1118.
+This enhancement introduces `BareMetalInstance` and `BareMetalInstanceCatalogItem` resources to the OSAC fulfillment-service public API, enabling tenants to provision and manage physical bare metal servers through a self-service interface. Catalog items are provider-managed entries that expose available hardware profiles, OS base images, and network configurations to tenants; each is backed by a private `BareMetalInstanceTemplate` (created via `osac-aap`) and is managed by Cloud Provider Admins through the OSAC private API. The design adopts a pluggable provider architecture — implemented in a dedicated baremetal fulfillment component — so that future bare metal backends can be integrated without breaking the API. This EP is scoped to the fulfillment-service API layer; operator, provisioning, UX, and E2E concerns are tracked as companion work items under OSAC-1118.
 
 ## Motivation
 
@@ -47,10 +47,7 @@ OSAC currently provides no fulfillment path for workloads requiring direct hardw
 
 * Integration with OSAC networking resources (`VirtualNetwork`, `Subnet`, `SecurityGroup`) — deferred to a future enhancement; in this initial phase, network configuration is fixed by the Cloud Provider Admin as part of the `BareMetalInstanceCatalogItem` and tenants have no mechanism to configure networking at provision time. A dedicated networking enhancement will enable tenants to create their own `Subnet` and attach it to a `BareMetalInstance`.
 * Custom hardware profile or OS image selection by tenants at provision time — fixed by the catalog item. Tenants requiring a different profile must request the Cloud Provider Admin to publish a new catalog item.
-* AAP playbook implementation — covered in companion work.
-* BareMetal fulfillment component implementation — covered in companion work.
-* UI and UX — covered in companion work.
-* E2E test implementation — covered in companion work.
+* AAP playbook, baremetal fulfillment component, UI/UX, and E2E test implementation — covered in companion work.
 * Support for multiple bare metal backends in this initial release — the architecture is designed for future extensibility.
 * Quota enforcement for `BareMetalInstance` — deferred to a future enhancement.
 

--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -19,7 +19,7 @@ superseded-by:
 
 ## Summary
 
-This enhancement introduces `BareMetalInstance` and `BareMetalInstanceCatalogItem` resources to the OSAC fulfillment-service public API, enabling tenants to provision and manage physical bare metal servers through a self-service interface. Catalog items are provider-managed entries that expose available hardware profiles, OS base images, and network configurations to tenants; each is backed by a private `BareMetalInstanceTemplate` (created via `osac-aap`) and is managed by Cloud Provider Admins through the OSAC private API. The design adopts a pluggable provider architecture — implemented in a dedicated baremetal fulfillment component — so that future bare metal backends can be integrated without breaking the API. This EP is scoped to the fulfillment-service API layer; operator, provisioning, UX, and E2E concerns are tracked as companion work items under OSAC-1118.
+This enhancement introduces `BareMetalInstance` and `BareMetalInstanceCatalogItem` resources to the OSAC fulfillment-service public API, enabling tenants to provision and manage physical bare metal servers through a self-service interface. Catalog items are provider-managed entries that expose available hardware profiles, OS base images, and network configurations to tenants; each is backed by a `BareMetalInstanceTemplate`. The design adopts a pluggable provider architecture — implemented in a dedicated baremetal fulfillment component — so that future bare metal backends can be integrated without breaking the API. This EP is scoped to the fulfillment-service API layer; operator, provisioning, UX, and E2E concerns are tracked as companion work items under OSAC-1118.
 
 ## Motivation
 
@@ -34,13 +34,14 @@ OSAC currently provides no fulfillment path for workloads requiring direct hardw
 * As a **Tenant User**, I want to restart my bare metal server so that I can perform maintenance without deprovisioning it.
 * As a **Tenant User**, I want to deprovision my bare metal server when my workload is complete so that resources are released.
 * As a **Cloud Provider Admin**, I want to define and publish `BareMetalInstanceCatalogItem` objects so that I can control which hardware profiles and OS images are available to tenants.
+* As a **Tenant Admin**, I want to create organization-specific `BareMetalInstanceCatalogItem` objects from available templates so that I can offer tenant-specific bare metal configurations to users in my organization.
 * As a **Cloud Infrastructure Admin**, I want the OSAC stack to integrate with BCM (NVIDIA Base Command Manager) so that bare metal provisioning is automated through the existing control plane.
 
 ### Goals
 
 * Provide a self-service API for tenants to create `BareMetalInstance` resources referencing a `BareMetalInstanceCatalogItem`.
-* Define `BareMetalInstanceCatalogItem` as a provider-managed catalog resource through which tenants discover available hardware profiles, OS images, and network configurations; publishing control and optional tenant scoping follow the `ComputeInstanceCatalogItem` pattern.
-* Align the `BareMetalInstance` API shape with the existing `ComputeInstance` API (same `id`, `metadata`, `spec`, `status` envelope, same condition and state patterns, same run strategy and restart signal mechanism).
+* Define `BareMetalInstanceTemplate` as a public resource managed by Cloud Provider Admins; `BareMetalInstanceCatalogItem` as a catalog resource where Cloud Provider Admins publish global entries and Tenant Admins create tenant-scoped ones; publishing control and tenant scoping are enforced by the server.
+* Maintain API consistency with `ComputeInstance` where possible — same resource shape, service structure, template and catalog item patterns, run strategy and restart signal mechanism, and authorization model.
 * Expose the API through both gRPC and the existing REST gateway.
 
 ### Non-Goals
@@ -53,18 +54,21 @@ OSAC currently provides no fulfillment path for workloads requiring direct hardw
 
 ## Proposal
 
-The proposal introduces two new resource types to the fulfillment-service public API:
+The proposal introduces three new resource types to the fulfillment-service public API:
 
-**`BareMetalInstanceCatalogItem`** is a provider-managed catalog entry that presents an available bare metal configuration to tenants. Cloud Provider Admins create private `BareMetalInstanceTemplate` objects via `osac-aap` and expose them to tenants through catalog items. The `published` flag controls visibility and an optional `tenant` field enables scoping to a specific tenant; unpublished or out-of-scope catalog items are invisible to tenant List/Get calls. `FieldDefinition` entries on the catalog item govern which spec fields tenants may override and apply defaults for the rest. This mirrors the role of `ComputeInstanceCatalogItem` for VMs.
+**`BareMetalInstanceTemplate`** defines a bare metal hardware profile (host type, OS image, network configuration). Cloud Provider Admins create and manage templates via the public API. osac-aap is used for the actual host-level provisioning at runtime, not for template management.
 
-**`BareMetalInstance`** is a tenant-created resource representing a provisioned bare metal server. Its `spec` references a catalog item via `catalog_item` and carries provisioning parameters (SSH public key, user data, run strategy, restart signal). Its `status` exposes the lifecycle state and conditions aligned with the `ComputeInstance` pattern.
+**`BareMetalInstanceCatalogItem`** is a catalog entry that presents an available bare metal configuration to tenants. Cloud Provider Admins publish global catalog items; Tenant Admins can additionally create tenant-scoped catalog items through the public API, referencing available templates. The `published` flag controls visibility and an optional `tenant` field enables scoping to a specific tenant; unpublished or out-of-scope catalog items are invisible to tenant List/Get calls. `FieldDefinition` entries on the catalog item govern which spec fields tenants may override and apply defaults for the rest.
+
+**`BareMetalInstance`** is a tenant-created resource representing a provisioned bare metal server. Its `spec` references a catalog item via `catalog_item` and carries provisioning parameters (SSH public key, user data, run strategy, restart signal). Its `status` exposes the lifecycle state and conditions.
 
 Provisioning is driven by a chain of components: the fulfillment service creates a `HostLease` CR in the management cluster when a `BareMetalInstance` is created. The baremetal fulfillment operator picks up the `HostLease`, finds and assigns a free host from the inventory backend, and triggers `osac-aap` for host-level setup (OS image, SSH key, user data). The osac-operator watches `HostLease` CRs for status changes and pushes updates back to the fulfillment service via the `Signal` RPC. `HostLease` is an internal implementation detail; tenants never interact with it directly.
 
 ### Workflow Description
 
 **Actors:**
-- **Cloud Provider Admin** — creates `BareMetalInstanceTemplate` objects (private) via `osac-aap` and publishes them as `BareMetalInstanceCatalogItem` entries in the fulfillment service.
+- **Cloud Provider Admin** — creates and manages `BareMetalInstanceTemplate` objects via the public API and publishes them as global `BareMetalInstanceCatalogItem` entries.
+- **Tenant Admin** — creates tenant-scoped `BareMetalInstanceCatalogItem` entries via the public API, referencing available templates.
 - **Tenant User** — creates and manages `BareMetalInstance` resources via the public API.
 - **Fulfillment Service** — handles `BareMetalInstance` CRUD and creates `HostLease` CRs directly in the management cluster.
 - **osac-operator** — watches `HostLease` CRs for status changes and pushes them to the fulfillment service via the `Signal` RPC; does not create any CRs in this flow.
@@ -74,7 +78,7 @@ Provisioning is driven by a chain of components: the fulfillment service creates
 
 #### Provisioning
 
-1. The Cloud Provider Admin creates `BareMetalInstanceTemplate` objects via `osac-aap` and publishes them as `BareMetalInstanceCatalogItem` entries in the fulfillment service private API, setting `published: true`.
+1. The Cloud Provider Admin creates `BareMetalInstanceTemplate` objects via the public API and publishes them as `BareMetalInstanceCatalogItem` entries, setting `published: true`.
 2. The Tenant User lists available catalog items:
    ```
    GET /api/fulfillment/v1/baremetal_instance_catalog_items
@@ -148,21 +152,30 @@ sequenceDiagram
 ### API Extensions
 
 **New gRPC services (public API):**
-- `BareMetalInstances` — CRUD for tenant-managed bare metal instances.
-- `BareMetalInstanceCatalogItems` — List/Get for published catalog items (read-only for tenants).
+- `BareMetalInstanceTemplates` — full CRUD.
+- `BareMetalInstanceCatalogItems` — full CRUD; Tenant Admins manage tenant-scoped entries, Tenant Users get read-only access to published items.
+- `BareMetalInstances` — full CRUD for tenant-managed bare metal instances.
 
 **New gRPC services (private API):**
-- `BareMetalInstances` (private) — adds the `Signal` RPC for `osac-operator` feedback, following the existing `ComputeInstances` private API pattern.
-- `BareMetalInstanceCatalogItems` (private) — full CRUD for Cloud Provider Admins to create, update, publish, and delete catalog items.
-- `BareMetalInstanceTemplates` (private) — full CRUD for Cloud Provider Admins to manage the underlying hardware profile definitions.
+- `BareMetalInstanceTemplates` (private) — full CRUD + `Signal` RPC.
+- `BareMetalInstanceCatalogItems` (private) — full CRUD + `Signal` RPC.
+- `BareMetalInstances` (private) — full CRUD + `Signal` RPC for `osac-operator` feedback.
 
 **REST gateway routes (public — tenant-facing):**
+- `GET    /api/fulfillment/v1/baremetal_instance_templates`
+- `GET    /api/fulfillment/v1/baremetal_instance_templates/{id}`
+- `POST   /api/fulfillment/v1/baremetal_instance_templates`
+- `PATCH  /api/fulfillment/v1/baremetal_instance_templates/{object.id}`
+- `DELETE /api/fulfillment/v1/baremetal_instance_templates/{id}`
 - `GET    /api/fulfillment/v1/baremetal_instance_catalog_items`
 - `GET    /api/fulfillment/v1/baremetal_instance_catalog_items/{id}`
+- `POST   /api/fulfillment/v1/baremetal_instance_catalog_items`
+- `PATCH  /api/fulfillment/v1/baremetal_instance_catalog_items/{object.id}`
+- `DELETE /api/fulfillment/v1/baremetal_instance_catalog_items/{id}`
 - `GET    /api/fulfillment/v1/baremetal_instances`
 - `GET    /api/fulfillment/v1/baremetal_instances/{id}`
 - `POST   /api/fulfillment/v1/baremetal_instances`
-- `PATCH  /api/fulfillment/v1/baremetal_instances/{object.id}` — `{object.id}` is the gRPC-gateway convention for PATCH: the request body carries the full object and the ID is bound via `object.id`, matching the `ComputeInstance` pattern.
+- `PATCH  /api/fulfillment/v1/baremetal_instances/{object.id}` — `{object.id}` is the gRPC-gateway convention for PATCH: the request body carries the full object and the ID is bound via `object.id`.
 - `DELETE /api/fulfillment/v1/baremetal_instances/{id}`
 
 **REST gateway routes (private — Cloud Provider Admin):**
@@ -183,6 +196,10 @@ sequenceDiagram
 
 #### Proto: BareMetalInstanceTemplate
 
+Public and private types share the same structure; the private type is identical but lives in `osac/private/v1/`.
+
+**Public** (`osac/public/v1/baremetal_instance_template_type.proto`):
+
 ```protobuf
 message BareMetalInstanceTemplate {
   string id = 1;
@@ -198,13 +215,16 @@ message BareMetalInstanceTemplate {
   BareMetalInstanceTemplateSpecDefaults spec_defaults = 5;
 }
 
-// BareMetalInstanceTemplateSpecDefaults follows the same convention as other OSAC template types.
-// No overridable spec fields are defined in this initial version; fields will be added in future
+// No overridable spec fields in this initial version; fields will be added in future
 // enhancements as tenant-configurable options are introduced (e.g. networking integration).
 message BareMetalInstanceTemplateSpecDefaults {}
 ```
 
 #### Proto: BareMetalInstanceCatalogItem
+
+Two variants — public type omits the `tenant` field (server-managed); private type includes it:
+
+**Public** (`osac/public/v1/baremetal_instance_catalog_item_type.proto`):
 
 ```protobuf
 message BareMetalInstanceCatalogItem {
@@ -224,9 +244,10 @@ message BareMetalInstanceCatalogItem {
   // returned by tenant-facing List/Get calls.
   bool published = 6;
 
-  // Optional tenant scope. Empty string means the item is global (visible to
-  // all tenants). When set, only the named tenant can see this catalog item.
-  string tenant = 7;
+  // Field 7 is omitted: `tenant` is an internal field managed by the server,
+  // not exposed through the public API. When a Tenant Admin creates a catalog
+  // item via the public API, the server automatically scopes it to the caller's
+  // tenant.
 
   // FieldDefinition controls which BareMetalInstanceSpec fields tenants may
   // set at provision time. Non-editable fields are always overridden by the
@@ -234,6 +255,25 @@ message BareMetalInstanceCatalogItem {
   // Schema and fall back to the default when not supplied by the tenant.
   // No overridable fields are defined in this initial version; entries will
   // be added in future enhancements (e.g. networking integration).
+  repeated FieldDefinition field_definitions = 8;
+}
+```
+
+**Private** (`osac/private/v1/baremetal_instance_catalog_item_type.proto`):
+
+```protobuf
+message BareMetalInstanceCatalogItem {
+  string id = 1;
+  Metadata metadata = 2;
+  string title = 3;
+  string description = 4;
+  string template = 5;
+  bool published = 6;
+
+  // Tenant scope for this catalog item. Empty string means the item is global
+  // and visible to all tenants.
+  string tenant = 7;
+
   repeated FieldDefinition field_definitions = 8;
 }
 ```
@@ -262,8 +302,7 @@ message BareMetalInstanceSpec {
   optional string user_data = 3;
 
   // Run strategy controls the power state of the bare metal instance (on/off).
-  // Named run_strategy for alignment with ComputeInstance; an enum is used rather
-  // than a boolean to leave room for future states (e.g. suspended backends).
+  // An enum is used rather than a boolean to leave room for future states (e.g. suspended backends).
   optional BareMetalInstanceRunStrategy run_strategy = 4;
 
   // RestartRequestedAt is a timestamp signal to request a power cycle.
@@ -324,15 +363,16 @@ enum BareMetalInstanceConditionType {
 
 #### Alignment with ComputeInstance
 
-`BareMetalInstance` intentionally mirrors `ComputeInstance`:
-- Same `id` + `Metadata` + `spec` + `status` envelope.
-- Same condition shape (`ConditionStatus`, `last_transition_time`, `reason`, `message`).
-- Same CRUD service shape and REST route pattern (`/api/fulfillment/v1/<resource>`).
-- Same private API `Signal` RPC for `osac-operator` feedback loop.
-- Same run strategy (`run_strategy`) and restart signal mechanism (`restart_requested_at`, `last_restarted_at`).
-- Same catalog item pattern (`spec.catalog_item` referencing a `BareMetalInstanceCatalogItem`, with `FieldDefinition`-based field control) mirroring `ComputeInstance` → `ComputeInstanceCatalogItem`.
+Where possible, the BareMetalInstance API is consistent with ComputeInstance:
+- `id` + `Metadata` + `spec` + `status` envelope.
+- Condition shape: `ConditionStatus`, `last_transition_time`, `reason`, `message`.
+- CRUD service shape and REST route pattern (`/api/fulfillment/v1/<resource>`).
+- Private `Signal` RPC for `osac-operator` feedback loop.
+- `run_strategy` and restart signal mechanism (`restart_requested_at`, `last_restarted_at`).
+- `spec.catalog_item` referencing a `BareMetalInstanceCatalogItem` with `FieldDefinition`-based field control.
+- `BareMetalInstanceTemplate` with `spec_defaults`, public full CRUD service.
 
-Fields specific to VMs (network attachments) are absent from `BareMetalInstance` in this initial version and may be added in future enhancements.
+Fields specific to VMs (network attachments, image, cores, memory) are absent from `BareMetalInstance` in this initial version.
 
 ### Risks and Mitigations
 
@@ -370,7 +410,7 @@ None identified.
 Test plan will be finalized during the implementation phase. Expected coverage:
 
 - **Unit tests:** Proto field validation, state machine transitions, provider interface mocking.
-- **Integration tests:** `BareMetalInstance` CRUD via gRPC, catalog item List/Get (public and private), `published` visibility enforcement, `FieldDefinition` application, Signal RPC feedback loop, OPA authorization enforcement, PATCH immutability enforcement.
+- **Integration tests:** `BareMetalInstance` CRUD via gRPC, catalog item CRUD (public and private), `published` visibility enforcement, tenant-scoping enforcement (Tenant Admin creates scoped items; Cloud Provider Admin creates global items via private API), `FieldDefinition` application, Signal RPC feedback loop, OPA authorization enforcement, PATCH immutability enforcement.
 - **E2E tests:** Full provisioning and deprovisioning workflow against BCM; CI pipeline configured to run E2E tests on merge.
 
 Tricky areas: asynchronous provisioning lifecycle (tests must handle delays or mock the provider), `catalog_item` immutability enforcement after create, `published`/`tenant` visibility boundary checks, tenant isolation boundary checks, and failure-path recovery (FAILED state → delete → recreate).

--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -40,7 +40,7 @@ OSAC currently provides no fulfillment path for workloads requiring direct hardw
 ### Goals
 
 * Provide a self-service API for tenants to create `BareMetalInstance` resources referencing a `BareMetalInstanceCatalogItem`.
-* Define `BareMetalInstanceTemplate` as a public resource managed by Cloud Provider Admins; `BareMetalInstanceCatalogItem` as a catalog resource where Cloud Provider Admins publish global entries and Tenant Admins create tenant-scoped ones; publishing control and tenant scoping are enforced by the server.
+* Define `BareMetalInstanceTemplate` as a resource managed by Cloud Provider Admins through the private API and readable by tenants through the public API (List/Get); `BareMetalInstanceCatalogItem` as a catalog resource where Cloud Provider Admins publish global entries via the private API and Tenant Admins create tenant-scoped ones via the public API; publishing control and tenant scoping are enforced by the server.
 * Maintain API consistency with `ComputeInstance` where possible — same resource shape, service structure, template and catalog item patterns, run strategy and restart signal mechanism, and authorization model.
 * Expose the API through both gRPC and the existing REST gateway.
 
@@ -56,7 +56,7 @@ OSAC currently provides no fulfillment path for workloads requiring direct hardw
 
 The proposal introduces three new resource types to the fulfillment-service public API:
 
-**`BareMetalInstanceTemplate`** defines a bare metal hardware profile (host type, OS image, network configuration). Cloud Provider Admins create and manage templates via the public API. osac-aap is used for the actual host-level provisioning at runtime, not for template management.
+**`BareMetalInstanceTemplate`** defines a bare metal hardware profile (host type, OS image, network configuration). Cloud Provider Admins create and manage templates via the private API; tenants can discover available templates via the public API (List/Get only). osac-aap is used for the actual host-level provisioning at runtime, not for template management.
 
 **`BareMetalInstanceCatalogItem`** is a catalog entry that presents an available bare metal configuration to tenants. Cloud Provider Admins publish global catalog items; Tenant Admins can additionally create tenant-scoped catalog items through the public API, referencing available templates. The `published` flag controls visibility and an optional `tenant` field enables scoping to a specific tenant; unpublished or out-of-scope catalog items are invisible to tenant List/Get calls. `FieldDefinition` entries on the catalog item govern which spec fields tenants may override and apply defaults for the rest.
 
@@ -67,7 +67,7 @@ Provisioning is driven by a chain of components: the fulfillment service creates
 ### Workflow Description
 
 **Actors:**
-- **Cloud Provider Admin** — creates and manages `BareMetalInstanceTemplate` objects via the public API and publishes them as global `BareMetalInstanceCatalogItem` entries.
+- **Cloud Provider Admin** — creates and manages `BareMetalInstanceTemplate` objects via the private API and publishes them as global `BareMetalInstanceCatalogItem` entries via the private API.
 - **Tenant Admin** — creates tenant-scoped `BareMetalInstanceCatalogItem` entries via the public API, referencing available templates.
 - **Tenant User** — creates and manages `BareMetalInstance` resources via the public API.
 - **Fulfillment Service** — handles `BareMetalInstance` CRUD and creates `HostLease` CRs directly in the management cluster.
@@ -78,7 +78,7 @@ Provisioning is driven by a chain of components: the fulfillment service creates
 
 #### Provisioning
 
-1. The Cloud Provider Admin creates `BareMetalInstanceTemplate` objects via the public API and publishes them as `BareMetalInstanceCatalogItem` entries, setting `published: true`.
+1. The Cloud Provider Admin creates `BareMetalInstanceTemplate` objects via the private API and publishes them as `BareMetalInstanceCatalogItem` entries via the private API, setting `published: true`.
 2. The Tenant User lists available catalog items:
    ```
    GET /api/fulfillment/v1/baremetal_instance_catalog_items
@@ -153,7 +153,7 @@ sequenceDiagram
 ### API Extensions
 
 **New gRPC services (public API):**
-- `BareMetalInstanceTemplates` — full CRUD.
+- `BareMetalInstanceTemplates` — List/Get only (read-only for tenants; managed through the private API).
 - `BareMetalInstanceCatalogItems` — full CRUD; Tenant Admins manage tenant-scoped entries, Tenant Users get read-only access to published items.
 - `BareMetalInstances` — full CRUD for tenant-managed bare metal instances.
 
@@ -165,9 +165,6 @@ sequenceDiagram
 **REST gateway routes (public — tenant-facing):**
 - `GET    /api/fulfillment/v1/baremetal_instance_templates`
 - `GET    /api/fulfillment/v1/baremetal_instance_templates/{id}`
-- `POST   /api/fulfillment/v1/baremetal_instance_templates`
-- `PATCH  /api/fulfillment/v1/baremetal_instance_templates/{object.id}`
-- `DELETE /api/fulfillment/v1/baremetal_instance_templates/{id}`
 - `GET    /api/fulfillment/v1/baremetal_instance_catalog_items`
 - `GET    /api/fulfillment/v1/baremetal_instance_catalog_items/{id}`
 - `POST   /api/fulfillment/v1/baremetal_instance_catalog_items`
@@ -371,7 +368,7 @@ Where possible, the BareMetalInstance API is consistent with ComputeInstance:
 - Private `Signal` RPC for `osac-operator` feedback loop.
 - `run_strategy` and restart signal mechanism (`restart_requested_at`, `last_restarted_at`).
 - `spec.catalog_item` referencing a `BareMetalInstanceCatalogItem` with `FieldDefinition`-based field control.
-- `BareMetalInstanceTemplate` with `spec_defaults`, public full CRUD service.
+- `BareMetalInstanceTemplate` with `spec_defaults`; managed via private API, readable via public List/Get.
 
 Fields specific to VMs (network attachments, image, cores, memory) are absent from `BareMetalInstance` in this initial version.
 

--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -47,7 +47,6 @@ OSAC currently provides no fulfillment path for workloads requiring direct hardw
 
 * Integration with OSAC networking resources (`VirtualNetwork`, `Subnet`, `SecurityGroup`) — deferred to a future enhancement; in this initial phase, network configuration is fixed by the Cloud Provider Admin as part of the `BareMetalInstanceCatalogItem` and tenants have no mechanism to configure networking at provision time. A dedicated networking enhancement will enable tenants to create their own `Subnet` and attach it to a `BareMetalInstance`.
 * Custom hardware profile or OS image selection by tenants at provision time — fixed by the catalog item. Tenants requiring a different profile must request the Cloud Provider Admin to publish a new catalog item.
-* Per-organization catalog item scoping — catalog items are global in this initial release; per-tenant scoping via the `tenant` field is deferred to a future enhancement.
 * AAP playbook implementation — covered in companion work.
 * BareMetal fulfillment component implementation — covered in companion work.
 * UI and UX — covered in companion work.

--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -18,7 +18,7 @@ superseded-by:
 
 ## Summary
 
-This enhancement introduces `BaremetalInstance` and `BaremetalInstanceTemplate` resources to the OSAC fulfillment-service public API, enabling tenants to provision and manage physical bare metal servers through a self-service interface. Templates encode the default instance type, OS base image, and network configuration and are published by Cloud Provider Admins via `osac-aap`. The design adopts a pluggable provider architecture — implemented in a dedicated baremetal fulfillment component — so that future bare metal backends can be integrated without breaking the API. This EP is scoped to the fulfillment-service API layer; operator, provisioning, UX, and E2E concerns are tracked as companion work items under OSAC-1118.
+This enhancement introduces `BareMetalInstance` and `BareMetalInstanceTemplate` resources to the OSAC fulfillment-service public API, enabling tenants to provision and manage physical bare metal servers through a self-service interface. Templates encode the default instance type, OS base image, and network configuration and are published by Cloud Provider Admins via `osac-aap`. The design adopts a pluggable provider architecture — implemented in a dedicated baremetal fulfillment component — so that future bare metal backends can be integrated without breaking the API. This EP is scoped to the fulfillment-service API layer; operator, provisioning, UX, and E2E concerns are tracked as companion work items under OSAC-1118.
 
 ## Motivation
 
@@ -26,50 +26,50 @@ OSAC currently provides no fulfillment path for workloads requiring direct hardw
 
 ### User Stories
 
-* As a **Tenant User**, I want to browse available `BaremetalInstanceTemplate` objects so that I can select the one that matches my workload requirements.
-* As a **Tenant User**, I want to provision a bare metal server by specifying a `BaremetalInstanceTemplate` so that I can run workloads that require direct hardware access without manual coordination with the cloud provider.
+* As a **Tenant User**, I want to browse available `BareMetalInstanceTemplate` objects so that I can select the one that matches my workload requirements.
+* As a **Tenant User**, I want to provision a bare metal server by specifying a `BareMetalInstanceTemplate` so that I can run workloads that require direct hardware access without manual coordination with the cloud provider.
 * As a **Tenant User**, I want to monitor the lifecycle state of my bare metal server (provisioning, running, failed) so that I can take corrective action if provisioning fails.
 * As a **Tenant User**, I want to control the run strategy (power on/off) of my bare metal server so that I can manage its operational state without deprovisioning it.
 * As a **Tenant User**, I want to restart my bare metal server so that I can perform maintenance without deprovisioning it.
 * As a **Tenant User**, I want to deprovision my bare metal server when my workload is complete so that resources are released.
-* As a **Cloud Provider Admin**, I want to define and publish `BaremetalInstanceTemplate` objects so that I can control which hardware profiles and OS images are available to tenants.
+* As a **Cloud Provider Admin**, I want to define and publish `BareMetalInstanceTemplate` objects so that I can control which hardware profiles and OS images are available to tenants.
 * As a **Cloud Infrastructure Admin**, I want the OSAC stack to integrate with BCM (NVIDIA Base Command Manager) so that bare metal provisioning is automated through the existing control plane.
 
 ### Goals
 
-* Provide a self-service API for tenants to create `BaremetalInstance` resources referencing a `BaremetalInstanceTemplate`.
-* Define `BaremetalInstanceTemplate` as a provider-managed global catalog resource exposing the available hardware profile, OS base image, and default network configuration.
-* Align the `BaremetalInstance` API shape with the existing `ComputeInstance` API (same `id`, `metadata`, `spec`, `status` envelope, same condition and state patterns, same run strategy and restart signal mechanism).
+* Provide a self-service API for tenants to create `BareMetalInstance` resources referencing a `BareMetalInstanceTemplate`.
+* Define `BareMetalInstanceTemplate` as a provider-managed global catalog resource exposing the available hardware profile, OS base image, and default network configuration.
+* Align the `BareMetalInstance` API shape with the existing `ComputeInstance` API (same `id`, `metadata`, `spec`, `status` envelope, same condition and state patterns, same run strategy and restart signal mechanism).
 * Expose the API through both gRPC and the existing REST gateway.
 
 ### Non-Goals
 
-* Integration with OSAC networking resources (`VirtualNetwork`, `Subnet`, `SecurityGroup`) — deferred to a future enhancement; in this initial phase, network configuration is fixed by the Cloud Provider Admin as part of the `BaremetalInstanceTemplate` and tenants have no mechanism to configure networking at provision time. A dedicated networking enhancement will enable tenants to create their own `Subnet` and attach it to a `BaremetalInstance`.
+* Integration with OSAC networking resources (`VirtualNetwork`, `Subnet`, `SecurityGroup`) — deferred to a future enhancement; in this initial phase, network configuration is fixed by the Cloud Provider Admin as part of the `BareMetalInstanceTemplate` and tenants have no mechanism to configure networking at provision time. A dedicated networking enhancement will enable tenants to create their own `Subnet` and attach it to a `BareMetalInstance`.
 * Custom hardware profile or OS image selection by tenants at provision time — fixed by the template. Tenants requiring a different profile must request the Cloud Provider Admin to publish a new template.
 * Per-organization template scoping — templates are global; a BMaaS catalog feature is deferred to a future enhancement.
 * AAP playbook implementation — covered in companion work.
-* Baremetal fulfillment component implementation — covered in companion work.
+* BareMetal fulfillment component implementation — covered in companion work.
 * UI and UX — covered in companion work.
 * E2E test implementation — covered in companion work.
 * Support for multiple bare metal backends in this initial release — the architecture is designed for future extensibility.
-* Quota enforcement for `BaremetalInstance` — deferred to a future enhancement.
+* Quota enforcement for `BareMetalInstance` — deferred to a future enhancement.
 
 ## Proposal
 
 The proposal introduces two new resource types to the fulfillment-service public API:
 
-**`BaremetalInstanceTemplate`** is a provider-defined, read-only resource that encodes a validated combination of hardware profile (instance flavor), OS base image, and default network configuration. Templates are defined by Cloud Provider Admins as Ansible roles in `osac-aap` and published to the fulfillment service via the provisioning pipeline. Tenants discover available templates via List/Get and reference one when creating a `BaremetalInstance`. This mirrors the role of `ComputeInstanceTemplate` for VMs.
+**`BareMetalInstanceTemplate`** is a provider-defined, read-only resource that encodes a validated combination of hardware profile (instance flavor), OS base image, and default network configuration. Templates are defined by Cloud Provider Admins as Ansible roles in `osac-aap` and published to the fulfillment service via the provisioning pipeline. Tenants discover available templates via List/Get and reference one when creating a `BareMetalInstance`. This mirrors the role of `ComputeInstanceTemplate` for VMs.
 
-**`BaremetalInstance`** is a tenant-created resource representing a provisioned bare metal server. Its `spec` references a template and carries provisioning parameters (SSH public key, user data, run strategy, restart signal). Its `status` exposes the lifecycle state and conditions aligned with the `ComputeInstance` pattern.
+**`BareMetalInstance`** is a tenant-created resource representing a provisioned bare metal server. Its `spec` references a template and carries provisioning parameters (SSH public key, user data, run strategy, restart signal). Its `status` exposes the lifecycle state and conditions aligned with the `ComputeInstance` pattern.
 
-Provisioning is driven by a chain of components: the fulfillment service creates a `HostLease` CR in the management cluster when a `BaremetalInstance` is created. The baremetal fulfillment operator picks up the `HostLease`, finds and assigns a free host from the inventory backend, and triggers `osac-aap` for host-level setup (OS image, SSH key, user data). The osac-operator watches `HostLease` CRs for status changes and pushes updates back to the fulfillment service via the `Signal` RPC. `HostLease` is an internal implementation detail; tenants never interact with it directly.
+Provisioning is driven by a chain of components: the fulfillment service creates a `HostLease` CR in the management cluster when a `BareMetalInstance` is created. The baremetal fulfillment operator picks up the `HostLease`, finds and assigns a free host from the inventory backend, and triggers `osac-aap` for host-level setup (OS image, SSH key, user data). The osac-operator watches `HostLease` CRs for status changes and pushes updates back to the fulfillment service via the `Signal` RPC. `HostLease` is an internal implementation detail; tenants never interact with it directly.
 
 ### Workflow Description
 
 **Actors:**
-- **Cloud Provider Admin** — defines `BaremetalInstanceTemplate` objects as Ansible roles in `osac-aap`; templates are published to the fulfillment service via the provisioning pipeline.
-- **Tenant User** — creates and manages `BaremetalInstance` resources via the public API.
-- **Fulfillment Service** — handles `BaremetalInstance` CRUD and creates `HostLease` CRs directly in the management cluster.
+- **Cloud Provider Admin** — defines `BareMetalInstanceTemplate` objects as Ansible roles in `osac-aap`; templates are published to the fulfillment service via the provisioning pipeline.
+- **Tenant User** — creates and manages `BareMetalInstance` resources via the public API.
+- **Fulfillment Service** — handles `BareMetalInstance` CRUD and creates `HostLease` CRs directly in the management cluster.
 - **osac-operator** — watches `HostLease` CRs for status changes and pushes them to the fulfillment service via the `Signal` RPC; does not create any CRs in this flow.
 - **baremetal-fulfillment-operator** — reconciles `HostLease` CRs: finds and assigns a free host from the inventory backend, then triggers `osac-aap` for host-level provisioning.
 - **osac-aap** — executes the provisioning and deprovisioning Ansible roles (OS image, SSH key, user data); triggered by the baremetal-fulfillment-operator.
@@ -77,27 +77,27 @@ Provisioning is driven by a chain of components: the fulfillment service creates
 
 #### Provisioning
 
-1. The Cloud Provider Admin defines one or more `BaremetalInstanceTemplate` objects as Ansible roles in `osac-aap`. The provisioning pipeline applies these roles and publishes the resulting templates to the fulfillment service.
+1. The Cloud Provider Admin defines one or more `BareMetalInstanceTemplate` objects as Ansible roles in `osac-aap`. The provisioning pipeline applies these roles and publishes the resulting templates to the fulfillment service.
 2. The Tenant User lists available templates:
    ```
    GET /api/fulfillment/v1/baremetal_instance_templates
    ```
-3. The Tenant User creates a `BaremetalInstance` referencing the desired template:
+3. The Tenant User creates a `BareMetalInstance` referencing the desired template:
    ```
    POST /api/fulfillment/v1/baremetal_instances
    ```
-4. The fulfillment service creates a `HostLease` CR in the management cluster; `BaremetalInstance.status.state` is set to `BAREMETAL_INSTANCE_STATE_PROVISIONING`.
+4. The fulfillment service creates a `HostLease` CR in the management cluster; `BareMetalInstance.status.state` is set to `BARE_METAL_INSTANCE_STATE_PROVISIONING`.
 5. The baremetal-fulfillment-operator picks up the `HostLease` and queries the inventory backend to find and assign a free host matching the requested host type and selector.
 6. The baremetal-fulfillment-operator triggers `osac-aap` to run the host-level provisioning template (OS image, SSH key, user data) and updates the `HostLease` status on completion.
-7. The osac-operator watches the `HostLease` CR and pushes status updates to the fulfillment service via the `Signal` RPC; the fulfillment service reflects this in `BaremetalInstance.status`.
-8. The Tenant User polls until `status.state` is `BAREMETAL_INSTANCE_STATE_RUNNING`:
+7. The osac-operator watches the `HostLease` CR and pushes status updates to the fulfillment service via the `Signal` RPC; the fulfillment service reflects this in `BareMetalInstance.status`.
+8. The Tenant User polls until `status.state` is `BARE_METAL_INSTANCE_STATE_RUNNING`:
    ```
    GET /api/fulfillment/v1/baremetal_instances/{id}
    ```
 
 #### Failure Handling
 
-If any step in the provisioning chain fails (playbook error, BCM API failure, `HostLease` stuck), the osac-operator sets `BaremetalInstance.status.state` to `BAREMETAL_INSTANCE_STATE_FAILED` via the `Signal` RPC. The tenant can inspect the `conditions` field for details. To retry, the tenant deletes and recreates the `BaremetalInstance`; note that recreating may result in a different physical host being assigned from the inventory.
+If any step in the provisioning chain fails (playbook error, BCM API failure, `HostLease` stuck), the osac-operator sets `BareMetalInstance.status.state` to `BARE_METAL_INSTANCE_STATE_FAILED` via the `Signal` RPC. The tenant can inspect the `conditions` field for details. To retry, the tenant deletes and recreates the `BareMetalInstance`; note that recreating may result in a different physical host being assigned from the inventory.
 
 #### Deprovisioning
 
@@ -105,10 +105,10 @@ If any step in the provisioning chain fails (playbook error, BCM API failure, `H
    ```
    DELETE /api/fulfillment/v1/baremetal_instances/{id}
    ```
-2. The fulfillment service deletes the `HostLease` CR; `BaremetalInstance.status.state` transitions to `BAREMETAL_INSTANCE_STATE_DELETING`.
+2. The fulfillment service deletes the `HostLease` CR; `BareMetalInstance.status.state` transitions to `BARE_METAL_INSTANCE_STATE_DELETING`.
 3. The baremetal-fulfillment-operator reconciles the `HostLease` deletion: triggers `osac-aap` for the host-level deprovisioning template, then unassigns the host from the inventory backend.
 4. The osac-operator watches the `HostLease` CR deletion and pushes final status via the `Signal` RPC.
-5. The `BaremetalInstance` resource is removed once deprovisioning completes.
+5. The `BareMetalInstance` resource is removed once deprovisioning completes.
 
 #### Provisioning Sequence
 
@@ -151,11 +151,11 @@ sequenceDiagram
 ### API Extensions
 
 **New gRPC services (public API):**
-- `BaremetalInstances` — CRUD for tenant-managed bare metal instances.
-- `BaremetalInstanceTemplates` — List/Get for provider-defined templates (read-only for tenants).
+- `BareMetalInstances` — CRUD for tenant-managed bare metal instances.
+- `BareMetalInstanceTemplates` — List/Get for provider-defined templates (read-only for tenants).
 
 **New gRPC service (private API):**
-- `BaremetalInstances` (private) — adds the `Signal` RPC for `osac-operator` feedback, following the existing `ComputeInstances` private API pattern.
+- `BareMetalInstances` (private) — adds the `Signal` RPC for `osac-operator` feedback, following the existing `ComputeInstances` private API pattern.
 
 **REST gateway routes:**
 - `GET    /api/fulfillment/v1/baremetal_instance_templates`
@@ -170,10 +170,10 @@ sequenceDiagram
 
 ### Implementation Details/Notes/Constraints
 
-#### Proto: BaremetalInstanceTemplate
+#### Proto: BareMetalInstanceTemplate
 
 ```protobuf
-message BaremetalInstanceTemplate {
+message BareMetalInstanceTemplate {
   string id = 1;
   Metadata metadata = 2;
 
@@ -183,28 +183,28 @@ message BaremetalInstanceTemplate {
   // Human-friendly long description in Markdown format.
   string description = 4;
 
-  // Default spec values applied when creating a BaremetalInstance from this template.
-  BaremetalInstanceTemplateSpecDefaults spec_defaults = 5;
+  // Default spec values applied when creating a BareMetalInstance from this template.
+  BareMetalInstanceTemplateSpecDefaults spec_defaults = 5;
 }
 
-// BaremetalInstanceTemplateSpecDefaults follows the same convention as other OSAC template types.
+// BareMetalInstanceTemplateSpecDefaults follows the same convention as other OSAC template types.
 // No overridable spec fields are defined in this initial version; fields will be added in future
 // enhancements as tenant-configurable options are introduced (e.g. networking integration).
-message BaremetalInstanceTemplateSpecDefaults {}
+message BareMetalInstanceTemplateSpecDefaults {}
 ```
 
-#### Proto: BaremetalInstance
+#### Proto: BareMetalInstance
 
 ```protobuf
-message BaremetalInstance {
+message BareMetalInstance {
   string id = 1;
   Metadata metadata = 2;
-  BaremetalInstanceSpec spec = 3;
-  BaremetalInstanceStatus status = 4;
+  BareMetalInstanceSpec spec = 3;
+  BareMetalInstanceStatus status = 4;
 }
 
-message BaremetalInstanceSpec {
-  // Reference to the BaremetalInstanceTemplate. Required on create; immutable after creation.
+message BareMetalInstanceSpec {
+  // Reference to the BareMetalInstanceTemplate. Required on create; immutable after creation.
   string template = 1;
 
   // SSH public key injected into the OS at provisioning time. Immutable after creation.
@@ -219,7 +219,7 @@ message BaremetalInstanceSpec {
   // Run strategy controls the power state of the bare metal instance (on/off).
   // Named run_strategy for alignment with ComputeInstance; an enum is used rather
   // than a boolean to leave room for future states (e.g. suspended backends).
-  optional BaremetalInstanceRunStrategy run_strategy = 4;
+  optional BareMetalInstanceRunStrategy run_strategy = 4;
 
   // RestartRequestedAt is a timestamp signal to request a power cycle.
   // Set to the current time to trigger an immediate restart.
@@ -227,66 +227,66 @@ message BaremetalInstanceSpec {
   optional google.protobuf.Timestamp restart_requested_at = 5;
 }
 
-message BaremetalInstanceStatus {
-  BaremetalInstanceState state = 1;
-  repeated BaremetalInstanceCondition conditions = 2;
+message BareMetalInstanceStatus {
+  BareMetalInstanceState state = 1;
+  repeated BareMetalInstanceCondition conditions = 2;
 
   // LastRestartedAt records when the last restart was initiated by the controller.
   optional google.protobuf.Timestamp last_restarted_at = 3;
 }
 
-enum BaremetalInstanceRunStrategy {
-  BAREMETAL_INSTANCE_RUN_STRATEGY_UNSPECIFIED = 0;
+enum BareMetalInstanceRunStrategy {
+  BARE_METAL_INSTANCE_RUN_STRATEGY_UNSPECIFIED = 0;
 
   // The instance is kept powered on.
-  BAREMETAL_INSTANCE_RUN_STRATEGY_ALWAYS      = 1;
+  BARE_METAL_INSTANCE_RUN_STRATEGY_ALWAYS      = 1;
 
   // The instance is powered off.
-  BAREMETAL_INSTANCE_RUN_STRATEGY_HALTED      = 2;
+  BARE_METAL_INSTANCE_RUN_STRATEGY_HALTED      = 2;
 }
 
-enum BaremetalInstanceState {
-  BAREMETAL_INSTANCE_STATE_UNSPECIFIED  = 0;
-  BAREMETAL_INSTANCE_STATE_PROVISIONING = 1;
-  BAREMETAL_INSTANCE_STATE_RUNNING      = 2;
-  BAREMETAL_INSTANCE_STATE_FAILED       = 3;
-  BAREMETAL_INSTANCE_STATE_DELETING     = 4;
+enum BareMetalInstanceState {
+  BARE_METAL_INSTANCE_STATE_UNSPECIFIED  = 0;
+  BARE_METAL_INSTANCE_STATE_PROVISIONING = 1;
+  BARE_METAL_INSTANCE_STATE_RUNNING      = 2;
+  BARE_METAL_INSTANCE_STATE_FAILED       = 3;
+  BARE_METAL_INSTANCE_STATE_DELETING     = 4;
 }
 
-enum BaremetalInstanceConditionType {
-  BAREMETAL_INSTANCE_CONDITION_TYPE_UNSPECIFIED           = 0;
+enum BareMetalInstanceConditionType {
+  BARE_METAL_INSTANCE_CONDITION_TYPE_UNSPECIFIED           = 0;
 
   // Infrastructure has been allocated to this instance by the baremetal fulfillment component.
-  BAREMETAL_INSTANCE_CONDITION_TYPE_PROVISIONED           = 1;
+  BARE_METAL_INSTANCE_CONDITION_TYPE_PROVISIONED           = 1;
 
   // OS image and user configuration have been applied by the provisioning provider.
-  BAREMETAL_INSTANCE_CONDITION_TYPE_CONFIGURATION_APPLIED = 2;
+  BARE_METAL_INSTANCE_CONDITION_TYPE_CONFIGURATION_APPLIED = 2;
 
   // The machine is available and assigned to the tenant (HostLease active).
   // Does not indicate OS readiness — the tenant is responsible for OS-level checks.
-  BAREMETAL_INSTANCE_CONDITION_TYPE_READY                 = 3;
+  BARE_METAL_INSTANCE_CONDITION_TYPE_READY                 = 3;
 
   // A power cycle (restart) is currently in progress.
-  BAREMETAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS   = 4;
+  BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS   = 4;
 
   // A restart request has failed.
-  BAREMETAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED        = 5;
+  BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED        = 5;
 
   // Configuration changes require a restart to take effect.
-  BAREMETAL_INSTANCE_CONDITION_TYPE_RESTART_REQUIRED      = 6;
+  BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_REQUIRED      = 6;
 }
 ```
 
 #### Alignment with ComputeInstance
 
-`BaremetalInstance` intentionally mirrors `ComputeInstance`:
+`BareMetalInstance` intentionally mirrors `ComputeInstance`:
 - Same `id` + `Metadata` + `spec` + `status` envelope.
 - Same condition shape (`ConditionStatus`, `last_transition_time`, `reason`, `message`).
 - Same CRUD service shape and REST route pattern (`/api/fulfillment/v1/<resource>`).
 - Same private API `Signal` RPC for `osac-operator` feedback loop.
 - Same run strategy (`run_strategy`) and restart signal mechanism (`restart_requested_at`, `last_restarted_at`).
 
-Fields specific to VMs (network attachments) are absent from `BaremetalInstance` in this initial version and may be added in future enhancements.
+Fields specific to VMs (network attachments) are absent from `BareMetalInstance` in this initial version and may be added in future enhancements.
 
 ### Risks and Mitigations
 
@@ -300,7 +300,7 @@ Fields specific to VMs (network attachments) are absent from `BaremetalInstance`
 **Mitigation:** Follows the same OPA-based authorization model as `ComputeInstance`. Tenant scoping is enforced at the fulfillment-service layer via existing middleware.
 
 **Risk:** Tenants provision unlimited bare metal instances, exhausting backend capacity.
-**Mitigation:** Quota enforcement for `BaremetalInstance` is deferred to a future enhancement. Until quotas are implemented, capacity limits must be managed out-of-band by the Cloud Provider Admin.
+**Mitigation:** Quota enforcement for `BareMetalInstance` is deferred to a future enhancement. Until quotas are implemented, capacity limits must be managed out-of-band by the Cloud Provider Admin.
 
 **Risk:** Compromised backend credentials expose the bare metal backend to unauthorized access.
 **Mitigation:** Credential storage and management for the baremetal backend are out of scope for this EP and will be defined in a dedicated security enhancement. The baremetal fulfillment component must not embed credentials in CRDs or API responses.
@@ -311,20 +311,20 @@ None identified.
 
 ## Alternatives (Not Implemented)
 
-**Map `BaremetalInstance` to the existing `ComputeInstance` resource with a baremetal flag.** This avoids a new resource type but conflates VM and bare metal semantics, complicates template definitions, and requires dispatching on a field value rather than resource type. A dedicated resource type provides cleaner separation of concerns and allows independent API evolution.
+**Map `BareMetalInstance` to the existing `ComputeInstance` resource with a baremetal flag.** This avoids a new resource type but conflates VM and bare metal semantics, complicates template definitions, and requires dispatching on a field value rather than resource type. A dedicated resource type provides cleaner separation of concerns and allows independent API evolution.
 
 **Expose the bare metal backend API directly to tenants.** This bypasses OSAC entirely, eliminating tenant isolation, quota enforcement, and the pluggable backend architecture. Not viable for a multi-tenant cloud platform.
 
 ## Open Questions
 
-1. ~~Should `BaremetalInstance` and `HostLease` be the same object, or remain distinct?~~ **Closed:** Distinct. The fulfillment service creates a `HostLease` as the internal backend CRD, but `HostLease` is also used by other workflows (cluster-as-a-service, agent provisioning) that bypass the fulfillment service entirely. Coupling the public API schema to `HostLease` would make future consolidation a breaking change.
+1. ~~Should `BareMetalInstance` and `HostLease` be the same object, or remain distinct?~~ **Closed:** Distinct. The fulfillment service creates a `HostLease` as the internal backend CRD, but `HostLease` is also used by other workflows (cluster-as-a-service, agent provisioning) that bypass the fulfillment service entirely. Coupling the public API schema to `HostLease` would make future consolidation a breaking change.
 
 ## Test Plan
 
 Test plan will be finalized during the implementation phase. Expected coverage:
 
 - **Unit tests:** Proto field validation, state machine transitions, provider interface mocking.
-- **Integration tests:** `BaremetalInstance` CRUD via gRPC, template List/Get, Signal RPC feedback loop, OPA authorization enforcement, PATCH immutability enforcement.
+- **Integration tests:** `BareMetalInstance` CRUD via gRPC, template List/Get, Signal RPC feedback loop, OPA authorization enforcement, PATCH immutability enforcement.
 - **E2E tests:** Full provisioning and deprovisioning workflow against BCM; CI pipeline configured to run E2E tests on merge.
 
 Tricky areas: asynchronous provisioning lifecycle (tests must handle delays or mock the provider), template immutability enforcement after create, tenant isolation boundary checks, and failure-path recovery (FAILED state → delete → recreate).
@@ -339,28 +339,28 @@ Graduation criteria will be defined when targeting a release. Expected progressi
 
 ## Upgrade / Downgrade Strategy
 
-This is a new API with no impact on existing resources. Downgrading requires deleting all `BaremetalInstance` and `BaremetalInstanceTemplate` resources and uninstalling the new CRDs from the management cluster before reverting the fulfillment-service image.
+This is a new API with no impact on existing resources. Downgrading requires deleting all `BareMetalInstance` and `BareMetalInstanceTemplate` resources and uninstalling the new CRDs from the management cluster before reverting the fulfillment-service image.
 
 ## Version Skew Strategy
 
-The fulfillment-service, baremetal-fulfillment-operator, and osac-operator must be upgraded together. If the baremetal-fulfillment-operator is not running, `HostLease` CRs will not be reconciled and new `BaremetalInstance` create requests will remain in `PROVISIONING` indefinitely. If the osac-operator baremetal controller is not running, status updates will not propagate back to the fulfillment service.
+The fulfillment-service, baremetal-fulfillment-operator, and osac-operator must be upgraded together. If the baremetal-fulfillment-operator is not running, `HostLease` CRs will not be reconciled and new `BareMetalInstance` create requests will remain in `PROVISIONING` indefinitely. If the osac-operator baremetal controller is not running, status updates will not propagate back to the fulfillment service.
 
 ## Support Procedures
 
-**Symptom:** `BaremetalInstance` stuck in `BAREMETAL_INSTANCE_STATE_PROVISIONING`.
+**Symptom:** `BareMetalInstance` stuck in `BARE_METAL_INSTANCE_STATE_PROVISIONING`.
 **Diagnosis:** Check baremetal-fulfillment-operator logs for inventory or AAP errors. Check osac-aap job logs for playbook failures. Verify the `HostLease` CR exists and that `ExternalHostID` has been set (indicates host was found in inventory).
-**Resolution:** If the host was allocated but provisioning failed, delete the `HostLease` CR manually and delete the `BaremetalInstance` to trigger a clean retry.
+**Resolution:** If the host was allocated but provisioning failed, delete the `HostLease` CR manually and delete the `BareMetalInstance` to trigger a clean retry.
 
-**Symptom:** All `BaremetalInstance` creations remain in `BAREMETAL_INSTANCE_STATE_PROVISIONING` with no `HostLease` created.
+**Symptom:** All `BareMetalInstance` creations remain in `BARE_METAL_INSTANCE_STATE_PROVISIONING` with no `HostLease` created.
 **Diagnosis:** The fulfillment service may not be able to reach the management cluster API. Check fulfillment-service logs for Kubernetes API errors.
 **Resolution:** Verify management cluster connectivity and credentials used by the fulfillment service.
 
-**Symptom:** All `BaremetalInstance` creations transition to `BAREMETAL_INSTANCE_STATE_FAILED`.
+**Symptom:** All `BareMetalInstance` creations transition to `BARE_METAL_INSTANCE_STATE_FAILED`.
 **Diagnosis:** Check baremetal-fulfillment-operator logs for inventory API or AAP errors. Validate inventory backend credentials, verify AAP availability, and confirm network connectivity.
-**Resolution:** Rotate credentials if expired, resolve network connectivity issues, then retry by deleting the failed `BaremetalInstance` and recreating it.
+**Resolution:** Rotate credentials if expired, resolve network connectivity issues, then retry by deleting the failed `BareMetalInstance` and recreating it.
 
 **Symptom:** Create returns `404 Not Found` for the template ID.
-**Diagnosis:** The `BaremetalInstanceTemplate` does not exist or is not visible to the tenant's organization.
+**Diagnosis:** The `BareMetalInstanceTemplate` does not exist or is not visible to the tenant's organization.
 **Resolution:** Cloud Provider Admin must create and publish the appropriate template via `osac-aap`.
 
 **Disabling the API:** Scale the baremetal-fulfillment-operator and the osac-operator baremetal controller to 0 replicas. Existing `HostLease` CRs persist but are not reconciled. Re-enabling both resumes reconciliation without data loss.

--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -127,7 +127,7 @@ sequenceDiagram
     FS-->>TU: list of available catalog items
 
     TU->>FS: POST /baremetal_instances {catalog_item, ssh_key, ...}
-    Note over FS: resolve catalog_item → templateID;<br/>apply field_definitions → templateParameters
+    Note over FS: resolve catalog_item → templateID, apply field_definitions → templateParameters
     FS->>MC: create HostLease CR (templateID, templateParameters, ssh_key, user_data)
     FS-->>TU: 201 Created {id, state: PROVISIONING}
 

--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -87,7 +87,7 @@ Provisioning is driven by a chain of components: the fulfillment service creates
    ```
    POST /api/fulfillment/v1/baremetal_instances
    ```
-4. The fulfillment service creates a `HostLease` CR in the management cluster; `BareMetalInstance.status.state` is set to `BARE_METAL_INSTANCE_STATE_PROVISIONING`.
+4. The fulfillment service resolves the catalog item to a `templateID` and derives `templateParameters` from the `field_definitions`, then creates a `HostLease` CR in the management cluster with those values plus `ssh_key` and `user_data`; `BareMetalInstance.status.state` is set to `BARE_METAL_INSTANCE_STATE_PROVISIONING`.
 5. The baremetal-fulfillment-operator picks up the `HostLease` and queries the inventory backend to find and assign a free host matching the requested host type and selector.
 6. The baremetal-fulfillment-operator triggers `osac-aap` to run the host-level provisioning template (OS image, SSH key, user data) and updates the `HostLease` status on completion.
 7. The osac-operator watches the `HostLease` CR and pushes status updates to the fulfillment service via the `Signal` RPC; the fulfillment service reflects this in `BareMetalInstance.status`.
@@ -127,7 +127,8 @@ sequenceDiagram
     FS-->>TU: list of available catalog items
 
     TU->>FS: POST /baremetal_instances {catalog_item, ssh_key, ...}
-    FS->>MC: create HostLease CR (hostType, profile, catalogItemID, fieldValues)
+    Note over FS: resolve catalog_item → templateID;<br/>apply field_definitions → templateParameters
+    FS->>MC: create HostLease CR (templateID, templateParameters, ssh_key, user_data)
     FS-->>TU: 201 Created {id, state: PROVISIONING}
 
     MC-->>BMF: watch: HostLease CR created (no ExternalHostID yet)

--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -8,6 +8,7 @@ tracking-link:
   - https://redhat.atlassian.net/browse/OSAC-1118
 see-also:
   - /enhancements/bare-metal-fulfillment
+  - /enhancements/catalog-items
 replaces:
   - N/A
 superseded-by:
@@ -18,7 +19,7 @@ superseded-by:
 
 ## Summary
 
-This enhancement introduces `BareMetalInstance` and `BareMetalInstanceTemplate` resources to the OSAC fulfillment-service public API, enabling tenants to provision and manage physical bare metal servers through a self-service interface. Templates encode the default instance type, OS base image, and network configuration and are published by Cloud Provider Admins via `osac-aap`. The design adopts a pluggable provider architecture — implemented in a dedicated baremetal fulfillment component — so that future bare metal backends can be integrated without breaking the API. This EP is scoped to the fulfillment-service API layer; operator, provisioning, UX, and E2E concerns are tracked as companion work items under OSAC-1118.
+This enhancement introduces `BareMetalInstance` and `BareMetalInstanceCatalogItem` resources to the OSAC fulfillment-service public API, enabling tenants to provision and manage physical bare metal servers through a self-service interface. Catalog items are provider-managed entries that expose available hardware profiles, OS base images, and network configurations to tenants; they are published by Cloud Provider Admins via `osac-aap` and back a private `BareMetalInstanceTemplate`. The design adopts a pluggable provider architecture — implemented in a dedicated baremetal fulfillment component — so that future bare metal backends can be integrated without breaking the API. This EP is scoped to the fulfillment-service API layer; operator, provisioning, UX, and E2E concerns are tracked as companion work items under OSAC-1118.
 
 ## Motivation
 
@@ -26,27 +27,27 @@ OSAC currently provides no fulfillment path for workloads requiring direct hardw
 
 ### User Stories
 
-* As a **Tenant User**, I want to browse available `BareMetalInstanceTemplate` objects so that I can select the one that matches my workload requirements.
-* As a **Tenant User**, I want to provision a bare metal server by specifying a `BareMetalInstanceTemplate` so that I can run workloads that require direct hardware access without manual coordination with the cloud provider.
+* As a **Tenant User**, I want to browse available `BareMetalInstanceCatalogItem` objects so that I can select the one that matches my workload requirements.
+* As a **Tenant User**, I want to provision a bare metal server by specifying a `BareMetalInstanceCatalogItem` so that I can run workloads that require direct hardware access without manual coordination with the cloud provider.
 * As a **Tenant User**, I want to monitor the lifecycle state of my bare metal server (provisioning, running, failed) so that I can take corrective action if provisioning fails.
 * As a **Tenant User**, I want to control the run strategy (power on/off) of my bare metal server so that I can manage its operational state without deprovisioning it.
 * As a **Tenant User**, I want to restart my bare metal server so that I can perform maintenance without deprovisioning it.
 * As a **Tenant User**, I want to deprovision my bare metal server when my workload is complete so that resources are released.
-* As a **Cloud Provider Admin**, I want to define and publish `BareMetalInstanceTemplate` objects so that I can control which hardware profiles and OS images are available to tenants.
+* As a **Cloud Provider Admin**, I want to define and publish `BareMetalInstanceCatalogItem` objects so that I can control which hardware profiles and OS images are available to tenants.
 * As a **Cloud Infrastructure Admin**, I want the OSAC stack to integrate with BCM (NVIDIA Base Command Manager) so that bare metal provisioning is automated through the existing control plane.
 
 ### Goals
 
-* Provide a self-service API for tenants to create `BareMetalInstance` resources referencing a `BareMetalInstanceTemplate`.
-* Define `BareMetalInstanceTemplate` as a provider-managed global catalog resource exposing the available hardware profile, OS base image, and default network configuration.
+* Provide a self-service API for tenants to create `BareMetalInstance` resources referencing a `BareMetalInstanceCatalogItem`.
+* Define `BareMetalInstanceCatalogItem` as a provider-managed catalog resource through which tenants discover available hardware profiles, OS images, and network configurations; publishing control and optional tenant scoping follow the `ComputeInstanceCatalogItem` pattern.
 * Align the `BareMetalInstance` API shape with the existing `ComputeInstance` API (same `id`, `metadata`, `spec`, `status` envelope, same condition and state patterns, same run strategy and restart signal mechanism).
 * Expose the API through both gRPC and the existing REST gateway.
 
 ### Non-Goals
 
-* Integration with OSAC networking resources (`VirtualNetwork`, `Subnet`, `SecurityGroup`) — deferred to a future enhancement; in this initial phase, network configuration is fixed by the Cloud Provider Admin as part of the `BareMetalInstanceTemplate` and tenants have no mechanism to configure networking at provision time. A dedicated networking enhancement will enable tenants to create their own `Subnet` and attach it to a `BareMetalInstance`.
-* Custom hardware profile or OS image selection by tenants at provision time — fixed by the template. Tenants requiring a different profile must request the Cloud Provider Admin to publish a new template.
-* Per-organization template scoping — templates are global; a BMaaS catalog feature is deferred to a future enhancement.
+* Integration with OSAC networking resources (`VirtualNetwork`, `Subnet`, `SecurityGroup`) — deferred to a future enhancement; in this initial phase, network configuration is fixed by the Cloud Provider Admin as part of the `BareMetalInstanceCatalogItem` and tenants have no mechanism to configure networking at provision time. A dedicated networking enhancement will enable tenants to create their own `Subnet` and attach it to a `BareMetalInstance`.
+* Custom hardware profile or OS image selection by tenants at provision time — fixed by the catalog item. Tenants requiring a different profile must request the Cloud Provider Admin to publish a new catalog item.
+* Per-organization catalog item scoping — catalog items are global in this initial release; per-tenant scoping via the `tenant` field is deferred to a future enhancement.
 * AAP playbook implementation — covered in companion work.
 * BareMetal fulfillment component implementation — covered in companion work.
 * UI and UX — covered in companion work.
@@ -58,16 +59,16 @@ OSAC currently provides no fulfillment path for workloads requiring direct hardw
 
 The proposal introduces two new resource types to the fulfillment-service public API:
 
-**`BareMetalInstanceTemplate`** is a provider-defined, read-only resource that encodes a validated combination of hardware profile (instance flavor), OS base image, and default network configuration. Templates are defined by Cloud Provider Admins as Ansible roles in `osac-aap` and published to the fulfillment service via the provisioning pipeline. Tenants discover available templates via List/Get and reference one when creating a `BareMetalInstance`. This mirrors the role of `ComputeInstanceTemplate` for VMs.
+**`BareMetalInstanceCatalogItem`** is a provider-managed catalog entry that presents an available bare metal configuration to tenants. Cloud Provider Admins create private `BareMetalInstanceTemplate` objects via `osac-aap` and expose them to tenants through catalog items. The `published` flag controls visibility and an optional `tenant` field enables scoping to a specific tenant; unpublished or out-of-scope catalog items are invisible to tenant List/Get calls. `FieldDefinition` entries on the catalog item govern which spec fields tenants may override and apply defaults for the rest. This mirrors the role of `ComputeInstanceCatalogItem` for VMs.
 
-**`BareMetalInstance`** is a tenant-created resource representing a provisioned bare metal server. Its `spec` references a template and carries provisioning parameters (SSH public key, user data, run strategy, restart signal). Its `status` exposes the lifecycle state and conditions aligned with the `ComputeInstance` pattern.
+**`BareMetalInstance`** is a tenant-created resource representing a provisioned bare metal server. Its `spec` references a catalog item via `catalog_item` and carries provisioning parameters (SSH public key, user data, run strategy, restart signal). Its `status` exposes the lifecycle state and conditions aligned with the `ComputeInstance` pattern.
 
 Provisioning is driven by a chain of components: the fulfillment service creates a `HostLease` CR in the management cluster when a `BareMetalInstance` is created. The baremetal fulfillment operator picks up the `HostLease`, finds and assigns a free host from the inventory backend, and triggers `osac-aap` for host-level setup (OS image, SSH key, user data). The osac-operator watches `HostLease` CRs for status changes and pushes updates back to the fulfillment service via the `Signal` RPC. `HostLease` is an internal implementation detail; tenants never interact with it directly.
 
 ### Workflow Description
 
 **Actors:**
-- **Cloud Provider Admin** — defines `BareMetalInstanceTemplate` objects as Ansible roles in `osac-aap`; templates are published to the fulfillment service via the provisioning pipeline.
+- **Cloud Provider Admin** — creates `BareMetalInstanceTemplate` objects (private) via `osac-aap` and publishes them as `BareMetalInstanceCatalogItem` entries in the fulfillment service.
 - **Tenant User** — creates and manages `BareMetalInstance` resources via the public API.
 - **Fulfillment Service** — handles `BareMetalInstance` CRUD and creates `HostLease` CRs directly in the management cluster.
 - **osac-operator** — watches `HostLease` CRs for status changes and pushes them to the fulfillment service via the `Signal` RPC; does not create any CRs in this flow.
@@ -77,12 +78,12 @@ Provisioning is driven by a chain of components: the fulfillment service creates
 
 #### Provisioning
 
-1. The Cloud Provider Admin defines one or more `BareMetalInstanceTemplate` objects as Ansible roles in `osac-aap`. The provisioning pipeline applies these roles and publishes the resulting templates to the fulfillment service.
-2. The Tenant User lists available templates:
+1. The Cloud Provider Admin creates `BareMetalInstanceTemplate` objects via `osac-aap` and publishes them as `BareMetalInstanceCatalogItem` entries in the fulfillment service private API, setting `published: true`.
+2. The Tenant User lists available catalog items:
    ```
-   GET /api/fulfillment/v1/baremetal_instance_templates
+   GET /api/fulfillment/v1/baremetal_instance_catalog_items
    ```
-3. The Tenant User creates a `BareMetalInstance` referencing the desired template:
+3. The Tenant User creates a `BareMetalInstance` referencing the desired catalog item:
    ```
    POST /api/fulfillment/v1/baremetal_instances
    ```
@@ -122,11 +123,11 @@ sequenceDiagram
     participant AAP as osac-aap
     participant INV as Inventory Backend
 
-    TU->>FS: GET /baremetal_instance_templates
-    FS-->>TU: list of available templates
+    TU->>FS: GET /baremetal_instance_catalog_items
+    FS-->>TU: list of available catalog items
 
-    TU->>FS: POST /baremetal_instances {template_id, ssh_key, ...}
-    FS->>MC: create HostLease CR (hostType, profile, templateID, templateParameters)
+    TU->>FS: POST /baremetal_instances {catalog_item, ssh_key, ...}
+    FS->>MC: create HostLease CR (hostType, profile, catalogItemID, fieldValues)
     FS-->>TU: 201 Created {id, state: PROVISIONING}
 
     MC-->>BMF: watch: HostLease CR created (no ExternalHostID yet)
@@ -152,28 +153,36 @@ sequenceDiagram
 
 **New gRPC services (public API):**
 - `BareMetalInstances` — CRUD for tenant-managed bare metal instances.
-- `BareMetalInstanceTemplates` — List/Get for provider-defined templates (read-only for tenants).
+- `BareMetalInstanceCatalogItems` — List/Get for published catalog items (read-only for tenants).
 
-**New gRPC service (private API):**
+**New gRPC services (private API):**
 - `BareMetalInstances` (private) — adds the `Signal` RPC for `osac-operator` feedback, following the existing `ComputeInstances` private API pattern.
+- `BareMetalInstanceCatalogItems` (private) — full CRUD for Cloud Provider Admins to create, update, publish, and delete catalog items.
 
-**REST gateway routes:**
-- `GET    /api/fulfillment/v1/baremetal_instance_templates`
-- `GET    /api/fulfillment/v1/baremetal_instance_templates/{id}`
+**REST gateway routes (public — tenant-facing):**
+- `GET    /api/fulfillment/v1/baremetal_instance_catalog_items`
+- `GET    /api/fulfillment/v1/baremetal_instance_catalog_items/{id}`
 - `GET    /api/fulfillment/v1/baremetal_instances`
 - `GET    /api/fulfillment/v1/baremetal_instances/{id}`
 - `POST   /api/fulfillment/v1/baremetal_instances`
 - `PATCH  /api/fulfillment/v1/baremetal_instances/{object.id}` — `{object.id}` is the gRPC-gateway convention for PATCH: the request body carries the full object and the ID is bound via `object.id`, matching the `ComputeInstance` pattern.
 - `DELETE /api/fulfillment/v1/baremetal_instances/{id}`
 
-**PATCH semantics:** The `PATCH` endpoint supports partial updates to mutable fields only: `run_strategy` and `restart_requested_at`. The `template`, `ssh_key`, and `user_data` fields are immutable after creation; requests that attempt to modify them are rejected with `400 Bad Request`. A `FieldMask` is applied automatically from the fields present in the request body.
+**REST gateway routes (private — Cloud Provider Admin):**
+- `GET    /api/private/v1/baremetal_instance_catalog_items`
+- `GET    /api/private/v1/baremetal_instance_catalog_items/{id}`
+- `POST   /api/private/v1/baremetal_instance_catalog_items`
+- `PATCH  /api/private/v1/baremetal_instance_catalog_items/{object.id}`
+- `DELETE /api/private/v1/baremetal_instance_catalog_items/{id}`
+
+**PATCH semantics:** The `PATCH` endpoint supports partial updates to mutable fields only: `run_strategy` and `restart_requested_at`. The `catalog_item`, `ssh_key`, and `user_data` fields are immutable after creation; requests that attempt to modify them are rejected with `400 Bad Request`. A `FieldMask` is applied automatically from the fields present in the request body.
 
 ### Implementation Details/Notes/Constraints
 
-#### Proto: BareMetalInstanceTemplate
+#### Proto: BareMetalInstanceCatalogItem
 
 ```protobuf
-message BareMetalInstanceTemplate {
+message BareMetalInstanceCatalogItem {
   string id = 1;
   Metadata metadata = 2;
 
@@ -183,14 +192,25 @@ message BareMetalInstanceTemplate {
   // Human-friendly long description in Markdown format.
   string description = 4;
 
-  // Default spec values applied when creating a BareMetalInstance from this template.
-  BareMetalInstanceTemplateSpecDefaults spec_defaults = 5;
-}
+  // Reference to the underlying BareMetalInstanceTemplate (private resource).
+  string template = 5;
 
-// BareMetalInstanceTemplateSpecDefaults follows the same convention as other OSAC template types.
-// No overridable spec fields are defined in this initial version; fields will be added in future
-// enhancements as tenant-configurable options are introduced (e.g. networking integration).
-message BareMetalInstanceTemplateSpecDefaults {}
+  // Whether this catalog item is visible to tenants. Only published items are
+  // returned by tenant-facing List/Get calls.
+  bool published = 6;
+
+  // Optional tenant scope. Empty string means the item is global (visible to
+  // all tenants). When set, only the named tenant can see this catalog item.
+  string tenant = 7;
+
+  // FieldDefinition controls which BareMetalInstanceSpec fields tenants may
+  // set at provision time. Non-editable fields are always overridden by the
+  // catalog default; editable fields are validated against the provided JSON
+  // Schema and fall back to the default when not supplied by the tenant.
+  // No overridable fields are defined in this initial version; entries will
+  // be added in future enhancements (e.g. networking integration).
+  repeated FieldDefinition field_definitions = 8;
+}
 ```
 
 #### Proto: BareMetalInstance
@@ -204,8 +224,8 @@ message BareMetalInstance {
 }
 
 message BareMetalInstanceSpec {
-  // Reference to the BareMetalInstanceTemplate. Required on create; immutable after creation.
-  string template = 1;
+  // Reference to the BareMetalInstanceCatalogItem. Required on create; immutable after creation.
+  string catalog_item = 1;
 
   // SSH public key injected into the OS at provisioning time. Immutable after creation.
   // Must be a valid SSH public key in OpenSSH format (ssh-rsa, ssh-ed25519, etc.).
@@ -285,6 +305,7 @@ enum BareMetalInstanceConditionType {
 - Same CRUD service shape and REST route pattern (`/api/fulfillment/v1/<resource>`).
 - Same private API `Signal` RPC for `osac-operator` feedback loop.
 - Same run strategy (`run_strategy`) and restart signal mechanism (`restart_requested_at`, `last_restarted_at`).
+- Same catalog item pattern (`spec.catalog_item` referencing a `BareMetalInstanceCatalogItem`, with `FieldDefinition`-based field control) mirroring `ComputeInstance` → `ComputeInstanceCatalogItem`.
 
 Fields specific to VMs (network attachments) are absent from `BareMetalInstance` in this initial version and may be added in future enhancements.
 
@@ -311,7 +332,7 @@ None identified.
 
 ## Alternatives (Not Implemented)
 
-**Map `BareMetalInstance` to the existing `ComputeInstance` resource with a baremetal flag.** This avoids a new resource type but conflates VM and bare metal semantics, complicates template definitions, and requires dispatching on a field value rather than resource type. A dedicated resource type provides cleaner separation of concerns and allows independent API evolution.
+**Map `BareMetalInstance` to the existing `ComputeInstance` resource with a baremetal flag.** This avoids a new resource type but conflates VM and bare metal semantics, complicates catalog item definitions, and requires dispatching on a field value rather than resource type. A dedicated resource type provides cleaner separation of concerns and allows independent API evolution.
 
 **Expose the bare metal backend API directly to tenants.** This bypasses OSAC entirely, eliminating tenant isolation, quota enforcement, and the pluggable backend architecture. Not viable for a multi-tenant cloud platform.
 
@@ -324,10 +345,10 @@ None identified.
 Test plan will be finalized during the implementation phase. Expected coverage:
 
 - **Unit tests:** Proto field validation, state machine transitions, provider interface mocking.
-- **Integration tests:** `BareMetalInstance` CRUD via gRPC, template List/Get, Signal RPC feedback loop, OPA authorization enforcement, PATCH immutability enforcement.
+- **Integration tests:** `BareMetalInstance` CRUD via gRPC, catalog item List/Get (public and private), `published` visibility enforcement, `FieldDefinition` application, Signal RPC feedback loop, OPA authorization enforcement, PATCH immutability enforcement.
 - **E2E tests:** Full provisioning and deprovisioning workflow against BCM; CI pipeline configured to run E2E tests on merge.
 
-Tricky areas: asynchronous provisioning lifecycle (tests must handle delays or mock the provider), template immutability enforcement after create, tenant isolation boundary checks, and failure-path recovery (FAILED state → delete → recreate).
+Tricky areas: asynchronous provisioning lifecycle (tests must handle delays or mock the provider), `catalog_item` immutability enforcement after create, `published`/`tenant` visibility boundary checks, tenant isolation boundary checks, and failure-path recovery (FAILED state → delete → recreate).
 
 ## Graduation Criteria
 
@@ -339,7 +360,7 @@ Graduation criteria will be defined when targeting a release. Expected progressi
 
 ## Upgrade / Downgrade Strategy
 
-This is a new API with no impact on existing resources. Downgrading requires deleting all `BareMetalInstance` and `BareMetalInstanceTemplate` resources and uninstalling the new CRDs from the management cluster before reverting the fulfillment-service image.
+This is a new API with no impact on existing resources. Downgrading requires deleting all `BareMetalInstance` and `BareMetalInstanceCatalogItem` resources and uninstalling the new CRDs from the management cluster before reverting the fulfillment-service image.
 
 ## Version Skew Strategy
 
@@ -359,9 +380,9 @@ The fulfillment-service, baremetal-fulfillment-operator, and osac-operator must 
 **Diagnosis:** Check baremetal-fulfillment-operator logs for inventory API or AAP errors. Validate inventory backend credentials, verify AAP availability, and confirm network connectivity.
 **Resolution:** Rotate credentials if expired, resolve network connectivity issues, then retry by deleting the failed `BareMetalInstance` and recreating it.
 
-**Symptom:** Create returns `404 Not Found` for the template ID.
-**Diagnosis:** The `BareMetalInstanceTemplate` does not exist or is not visible to the tenant's organization.
-**Resolution:** Cloud Provider Admin must create and publish the appropriate template via `osac-aap`.
+**Symptom:** Create returns `404 Not Found` for the catalog item ID.
+**Diagnosis:** The `BareMetalInstanceCatalogItem` does not exist, is not published, or is scoped to a different tenant.
+**Resolution:** Cloud Provider Admin must create the catalog item via the private API, set `published: true`, and verify the `tenant` field matches the requesting tenant (or is empty for global visibility).
 
 **Disabling the API:** Scale the baremetal-fulfillment-operator and the osac-operator baremetal controller to 0 replicas. Existing `HostLease` CRs persist but are not reconciled. Re-enabling both resumes reconciliation without data loss.
 

--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -368,6 +368,8 @@ The fulfillment-service, baremetal-fulfillment-operator, and osac-operator must 
 
 ## Support Procedures
 
+> **Log hygiene:** Before sharing or inspecting logs, operators must verify that `ssh_key`, `user_data`, and backend credentials (inventory API tokens, AAP credentials) are redacted. These values must never appear in fulfillment-service or operator logs; if they do, treat it as a security incident and rotate the affected credentials immediately.
+
 **Symptom:** `BareMetalInstance` stuck in `BARE_METAL_INSTANCE_STATE_PROVISIONING`.
 **Diagnosis:** Check baremetal-fulfillment-operator logs for inventory or AAP errors. Check osac-aap job logs for playbook failures. Verify the `HostLease` CR exists and that `ExternalHostID` has been set (indicates host was found in inventory).
 **Resolution:** If the host was allocated but provisioning failed, delete the `HostLease` CR manually and delete the `BareMetalInstance` to trigger a clean retry.

--- a/enhancements/baremetal-instance-api/README.md
+++ b/enhancements/baremetal-instance-api/README.md
@@ -157,6 +157,7 @@ sequenceDiagram
 **New gRPC services (private API):**
 - `BareMetalInstances` (private) — adds the `Signal` RPC for `osac-operator` feedback, following the existing `ComputeInstances` private API pattern.
 - `BareMetalInstanceCatalogItems` (private) — full CRUD for Cloud Provider Admins to create, update, publish, and delete catalog items.
+- `BareMetalInstanceTemplates` (private) — full CRUD for Cloud Provider Admins to manage the underlying hardware profile definitions.
 
 **REST gateway routes (public — tenant-facing):**
 - `GET    /api/fulfillment/v1/baremetal_instance_catalog_items`
@@ -168,6 +169,11 @@ sequenceDiagram
 - `DELETE /api/fulfillment/v1/baremetal_instances/{id}`
 
 **REST gateway routes (private — Cloud Provider Admin):**
+- `GET    /api/private/v1/baremetal_instance_templates`
+- `GET    /api/private/v1/baremetal_instance_templates/{id}`
+- `POST   /api/private/v1/baremetal_instance_templates`
+- `PATCH  /api/private/v1/baremetal_instance_templates/{object.id}`
+- `DELETE /api/private/v1/baremetal_instance_templates/{id}`
 - `GET    /api/private/v1/baremetal_instance_catalog_items`
 - `GET    /api/private/v1/baremetal_instance_catalog_items/{id}`
 - `POST   /api/private/v1/baremetal_instance_catalog_items`
@@ -177,6 +183,29 @@ sequenceDiagram
 **PATCH semantics:** The `PATCH` endpoint supports partial updates to mutable fields only: `run_strategy` and `restart_requested_at`. The `catalog_item`, `ssh_key`, and `user_data` fields are immutable after creation; requests that attempt to modify them are rejected with `400 Bad Request`. A `FieldMask` is applied automatically from the fields present in the request body.
 
 ### Implementation Details/Notes/Constraints
+
+#### Proto: BareMetalInstanceTemplate
+
+```protobuf
+message BareMetalInstanceTemplate {
+  string id = 1;
+  Metadata metadata = 2;
+
+  // Human-friendly short description (CLI/UI single-line display).
+  string title = 3;
+
+  // Human-friendly long description in Markdown format.
+  string description = 4;
+
+  // Default spec values applied when creating a BareMetalInstance from this template.
+  BareMetalInstanceTemplateSpecDefaults spec_defaults = 5;
+}
+
+// BareMetalInstanceTemplateSpecDefaults follows the same convention as other OSAC template types.
+// No overridable spec fields are defined in this initial version; fields will be added in future
+// enhancements as tenant-configurable options are introduced (e.g. networking integration).
+message BareMetalInstanceTemplateSpecDefaults {}
+```
 
 #### Proto: BareMetalInstanceCatalogItem
 


### PR DESCRIPTION
## Summary

- Rename `BaremetalInstance` → `BareMetalInstance` throughout the EP
- Align the full API surface with the `ComputeInstance` pattern:
  - `BareMetalInstanceTemplate` — public full CRUD service (was private-only)
  - `BareMetalInstanceCatalogItem` — public full CRUD (was List/Get only); public type omits `tenant` field (server-managed)
  - `BareMetalInstance` — public full CRUD + private Signal RPC
- Add Tenant Admin user story: create organization-specific catalog items from available templates
- Add explicit consistency goal: maintain API consistency with `ComputeInstance` where possible
- Clarify two-tier catalog item governance: Cloud Provider Admins publish global items via private API; Tenant Admins create tenant-scoped items via public API
- Clarify osac-aap role: used for host-level provisioning at runtime, not template management
- Update provisioning sequence diagram to show catalog item resolution (catalogItemID → templateID + templateParameters) happening inside the fulfillment service before HostLease CR creation
- Add log hygiene note to Support Procedures
- Add `/enhancements/catalog-items` to `see-also` in frontmatter

## Jira

https://redhat.atlassian.net/browse/OSAC-1317

## Test plan

- [ ] EP reviewed for consistency with `ComputeInstance` API pattern (template, catalog item, instance resources)
- [ ] Tenant Admin catalog item governance clearly described
- [ ] Provisioning sequence diagram reflects internal catalog item resolution
- [ ] No stale `Baremetal` (lowercase m) or `private-only template` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)