### PR TITLE
OSAC-1111: StorageBackend API design document

### DIFF
--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -52,7 +52,7 @@ StorageBackend is a new entity in the fulfillment-service with two API surfaces:
 
 **Private API** (`osac.private.v1.StorageBackends`): Full CRUD (Create, Get, List, Update, Delete). Used by Cloud Provider Admins and internal systems (e.g., future tenant onboarding controller that needs credentials to pass to AAP). No Signal RPC — StorageBackend has no reconciler or controller. No public API — tenants interact with storage through StorageTier, not directly with backends.
 
-The database schema follows the standard JSONB `data` column pattern with `storage_backends` and `archived_storage_backends` tables. A unique partial index on `name` enforces FR-9 (name uniqueness among active records). **[OPEN: The deletion strategy (soft-delete vs hard-delete) is under review — see Open Questions.]**
+The database schema follows the standard JSONB `data` column pattern with `storage_backends` and `archived_storage_backends` tables. A unique partial index on `name` enforces FR-9 (name uniqueness among active records). **[OPEN: see OQ-1]**
 
 The generic server's `setPayload()` switch statement requires a new case for `StorageBackend`, and the Event proto requires a new `storage_backend` payload field.
 
@@ -84,7 +84,7 @@ The diagram shows the registration path. The admin registers the backend via the
 
 **Credential rotation:** The admin calls `UpdateStorageBackend` with new `credentials` fields. No redeployment is required.
 
-**Decommission:** The admin calls `DeleteStorageBackend`. The backend is soft-deleted using the standard DAO pattern (sets `deletion_timestamp`, archives the record). Delete is rejected with `FAILED_PRECONDITION` if any StorageTier references the backend — the admin must remove all tier associations first. **[OPEN: The deletion strategy (soft-delete vs hard-delete) is under review — see Open Questions.]**
+**Decommission:** The admin calls `DeleteStorageBackend`. By default the backend is soft-deleted (standard DAO pattern — sets `deletion_timestamp`, archives the record). When `purge=true` is set on the request, the backend is permanently removed from the database. Both modes reject the delete with `FAILED_PRECONDITION` if any StorageTier references the backend — the admin must remove all tier associations first. **[OPEN: see OQ-1]**
 
 **Error cases:**
 - Duplicate name on active backend: Create returns `ALREADY_EXISTS` (enforced by the unique partial index).
@@ -169,7 +169,7 @@ No Signal RPC is defined. Signal exists on other entities to wake up a reconcile
 - Builder pattern: `NewPrivateStorageBackendsServer()` returns a builder with `SetLogger`, `SetNotifier`, `SetAttributionLogic`, `SetTenancyLogic`, `SetMetricsRegisterer`, `Build()`
 - `Create`: validates required fields (`metadata.name`, `provider`, `endpoint`, `credentials.username`, `credentials.password`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID. The generic server's `validateName()` enforces RFC 1035 DNS label format (1–63 chars, lowercase alphanumeric + hyphens, no leading/trailing hyphens). Name uniqueness among active backends is enforced by the `storage_backends_unique_active_name` partial index.
 - `Update`: fetches existing object, merges via `applyStorageBackendUpdate`, validates immutability of `provider` and `metadata.name` fields, delegates to generic server
-- `Delete`: checks for referencing StorageTier records; rejects with `FAILED_PRECONDITION` if any exist, otherwise delegates to generic server (soft delete via standard DAO pattern). **[OPEN: soft-delete vs hard-delete — see Open Questions]**
+- `Delete`: checks for referencing StorageTier records; rejects with `FAILED_PRECONDITION` if any exist. Default: soft-delete via standard DAO. When `purge=true`: hard-delete, permanently removing the record. **[OPEN: see OQ-1]**
 
 **Immutable fields on update:** `provider` and `metadata.name` are immutable after creation. Changing the storage provider would invalidate the endpoint, credentials, and any downstream StorageTier references. Name immutability ensures stable human-readable identifiers for operational use and prevents confusion when backends are referenced by name in logs and configurations.
 
@@ -224,7 +224,7 @@ create unique index storage_backends_unique_active_name
   where deletion_timestamp = 'epoch';
 ```
 
-This partial index permits name reuse after soft deletion while preventing duplicate names among active records. The DAO's unique violation error maps to gRPC `ALREADY_EXISTS`. **[OPEN: If hard-delete is chosen, this becomes a plain unique index without the partial condition.]**
+This partial index permits name reuse after soft deletion while preventing duplicate names among active records. The DAO's unique violation error maps to gRPC `ALREADY_EXISTS`. **[OPEN: see OQ-1 — the partial condition is needed for soft-delete; hard-delete via `purge` removes the row entirely so the partial index still works correctly.]**
 
 #### Generic Server Changes
 
@@ -316,19 +316,22 @@ Instead of storing credentials inline, the fulfillment-service could store a `cr
 
 *Cons:* Introduces a new credential pattern that no existing OSAC entity uses — all current entities (break_glass_credentials, identity_provider, user, cluster_template, hub) store credentials inline. Adds operational complexity (Secret must exist, namespace resolution, lifecycle management). Creates an inconsistency in the codebase.
 
-*Rejection:* Consistency with existing OSAC patterns outweighs the security benefit for phase 1. All other entities store credentials inline, and introducing a divergent pattern without an OSAC-core decision on unified credential management would create unnecessary complexity. This can be revisited when OSAC establishes a platform-wide credential storage strategy.
+*Rejection:* OSAC core are aware of the need for a credentials solution for the system(this is not a specific to storage backends) - see this ticket https://redhat.atlassian.net/browse/OSAC-1567 . Also, consistency with existing OSAC patterns outweighs the security benefit for phase 1. All other entities store credentials inline, and introducing a divergent pattern without an OSAC-core decision on unified credential management would create unnecessary complexity. This can be revisited when OSAC establishes a platform-wide credential storage strategy.
 
 ## Open Questions
 
-**OQ-1: Soft-delete vs hard-delete for StorageBackend decommission.**
+**OQ-1: Deletion strategy — soft-delete by default, optional hard-delete with `purge` flag.**
 
-The generic DAO uses soft-delete by default (sets `deletion_timestamp`, archives the record to `archived_storage_backends`). All existing OSAC entities follow this pattern. However, StorageBackend may not need the archived record — audit can be handled by the existing observability infrastructure (structured logging, PostgreSQL NOTIFY events), and referential integrity (rejecting delete when StorageTiers reference the backend) prevents orphaned references.
+**Proposed resolution:** Support both modes. `DeleteStorageBackend` performs a soft-delete by default (standard DAO pattern — sets `deletion_timestamp`, archives to `archived_storage_backends`). When `purge=true` is set on the request, the backend is permanently removed from the database.
 
-Options:
-- **Keep soft-delete (current DAO default):** No DAO changes needed. Archived records are preserved. Name reuse is allowed via the partial index. Follows the established pattern.
-- **Switch to hard-delete:** Requires extending the generic DAO with a hard-delete option or implementing custom delete logic in the StorageBackend server. Simpler schema (no archived table, plain unique index on name). Aligns with AWS/GCP patterns where infrastructure resources are hard-deleted and audit relies on external logs.
+Both modes enforce referential integrity — delete is rejected with `FAILED_PRECONDITION` if any StorageTier references the backend, regardless of soft vs hard delete.
 
-**Owner:** Storage architect. **Impact:** Database schema, DAO usage, FR-6, FR-9.
+This requires:
+- A `bool purge` field on the `DeleteStorageBackendRequest` message.
+- Extending the generic DAO or adding custom delete logic in `PrivateStorageBackendsServer.Delete()` to bypass the archive step when `purge=true`.
+- The `archived_storage_backends` table and partial unique index are still needed for the soft-delete path.
+
+**Owner:** Storage architect. **Impact:** Proto schema (`DeleteStorageBackendRequest`), DAO usage, FR-6.
 
 ## Test Plan
 

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -1,0 +1,429 @@
+---
+title: storage-backend-api
+authors:
+  - rgolan@redhat.com
+creation-date: 2026-06-15
+last-updated: 2026-06-15
+tracking-link:
+  - https://redhat.atlassian.net/browse/OSAC-1111
+prd:
+  - "prd.md"
+see-also:
+  - "/enhancements/storage-tier (OSAC-1110, future)"
+replaces:
+  - N/A
+superseded-by:
+  - N/A
+---
+
+# StorageBackend API
+
+## Summary
+
+This enhancement adds a `StorageBackend` entity to the fulfillment-service, providing a private gRPC API (CRUD) and a public read-only API for managing storage array registrations. StorageBackend follows the NetworkClass pattern: DB-backed with no Kubernetes CRD and no reconciler. See [PRD](prd.md) for detailed requirements.
+
+## Motivation
+
+OSAC manages networking infrastructure through first-class API entities (NetworkClass, VirtualNetwork, Subnet) but has no equivalent for storage. Storage backend configuration is embedded in Ansible extra vars (`VAST_ENDPOINT`, `VAST_USERNAME`, `VAST_PASSWORD`), making backends invisible to the OSAC data model. Cloud Provider Admins cannot discover registered backends, rotate credentials, or inspect backend health through the API.
+
+This gap blocks two capabilities: (1) composing tiered storage offerings where StorageTier entities (OSAC-1110) reference registered backends by ID, and (2) credential rotation without redeploying the fulfillment-service. Three prior enhancements addressed tenant-to-StorageClass resolution but left the infrastructure layer unmanaged.
+
+StorageBackend introduces the infrastructure registration layer. It stores the provider type, management endpoint, and a reference to a Kubernetes Secret containing credentials. The entity is platform-scoped (not tenant-scoped), managed exclusively by Cloud Provider Admins through the private API, and exposed read-only through the public API with credential references stripped.
+
+### Goals
+
+- Reuse the NetworkClass DB-backed server pattern (generic server, generic DAO, builder construction) with no reconciler or CRD. [Codebase: internal/servers/private_network_classes_server.go]
+- Expose both private (full CRUD) and public (read-only) API layers following the established dual-API pattern.
+- Store credentials as opaque Kubernetes Secret references — no credential content touches the fulfillment-service database.
+- Keep the StorageBackend schema provider-agnostic so that non-VAST backends (Ceph, Pure) use the same entity without schema changes.
+- Provide the foundation entity for StorageTier (OSAC-1110) composition without introducing StorageTier dependencies.
+
+### Non-Goals
+
+- Kubernetes CRD for StorageBackend — the entity is DB-backed only, like NetworkClass.
+- Reconciler or controller registration — no backend provisioning occurs on create; the initial state is `READY`.
+- Provider-specific credential validation — credential content is opaque per NFR-2.
+- CSI driver installation or StorageClass creation on target clusters — these are part of the tenant onboarding reconciliation flow, which depends on both StorageBackend and StorageTier.
+- StorageTier or StorageTierBackend entities — covered by OSAC-1110.
+
+## Proposal
+
+StorageBackend is a new entity in the fulfillment-service with two API surfaces:
+
+1. **Private API** (`osac.private.v1.StorageBackends`): Full CRUD (Create, Get, List, Update, Delete). Used by Cloud Provider Admins. No Signal RPC — StorageBackend has no reconciler or controller, so there is nothing to signal.
+
+2. **Public API** (`osac.public.v1.StorageBackends`): Read-only (List, Get). Delegates to the private server with field mapping. The `credentials_ref` field is excluded from the public API via `AddIgnoredFields()`.
+
+The database schema follows the standard JSONB `data` column pattern with `storage_backends` and `archived_storage_backends` tables. A unique partial index on `name` enforces FR-9 (name uniqueness among active records).
+
+The generic server's `setPayload()` switch statement requires a new case for `StorageBackend`, and the Event proto requires a new `storage_backend` payload field.
+
+### Workflow Description
+
+**Actors:**
+- Cloud Provider Admin — registers and manages storage backends via the private API
+- Tenant — discovers available backends (provider, endpoint, status) via the public API; cannot see credentials
+
+**Starting state:** The fulfillment-service is deployed with no StorageBackend records. Storage configuration exists only in Ansible extra vars.
+
+**Registration flow:**
+
+```mermaid
+sequenceDiagram
+    participant Admin as Cloud Provider Admin
+    participant K8s as Kubernetes API
+    participant FS as fulfillment-service (private)
+    participant DB as PostgreSQL
+
+    Admin->>K8s: Create Secret with storage credentials
+    Admin->>FS: CreateStorageBackend(provider, endpoint, credentials_ref, description)
+    FS->>FS: Validate required fields (provider, endpoint.host, credentials_ref)
+    FS->>FS: Set state = READY, clear caller-provided ID
+    FS->>DB: Insert into storage_backends (JSONB data column)
+    DB-->>FS: Return with generated UUID
+    FS-->>Admin: StorageBackend with id, state=READY
+```
+
+The diagram shows the registration path. The admin first creates a Kubernetes Secret containing provider-specific credentials, then registers the backend via the private API. The fulfillment-service validates required fields, sets the initial state to `READY`, generates a UUID, and persists the entity.
+
+**Credential rotation:** The admin calls `UpdateStorageBackend` with a new `credentials_ref` pointing to a rotated Secret. No redeployment is required.
+
+**Decommission:** The admin calls `DeleteStorageBackend`. The backend is soft-deleted: excluded from List results but preserved in the `archived_storage_backends` table for audit. Name reuse is allowed after soft deletion.
+
+**Error cases:**
+- Duplicate name on active backend: Create returns `ALREADY_EXISTS` (enforced by the unique partial index).
+- Missing required fields (provider, endpoint.host, credentials_ref): Create/Update returns `INVALID_ARGUMENT`.
+- Update with stale version and `lock=true`: returns `FAILED_PRECONDITION` (optimistic concurrency control).
+- Delete of non-existent backend: returns `NOT_FOUND`.
+
+### API Extensions
+
+This enhancement adds the following API extensions:
+
+- **Private gRPC service** `osac.private.v1.StorageBackends` — CRUD, registered in the gRPC server startup alongside `NetworkClasses`.
+- **Public gRPC service** `osac.public.v1.StorageBackends` — List + Get only, registered alongside the public `NetworkClasses` server.
+- **Event payload field** `storage_backend` added to `osac.private.v1.Event` — enables event-driven notifications for StorageBackend changes.
+
+No CRDs, webhooks, or finalizers are introduced. No existing resources are modified. If the fulfillment-service is unavailable, StorageBackend operations fail but no other OSAC resources are affected — StorageBackend has no controller loop that could leave resources in an inconsistent state.
+
+### Implementation Details/Notes/Constraints
+
+#### Proto Schema — Private API
+
+**`storage_backend_type.proto`** (`osac.private.v1`):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Generated | UUID assigned by the DAO on create |
+| `metadata` | `Metadata` | Yes | Standard OSAC metadata (name, labels, annotations, version) |
+| `provider` | `string` | Yes | Storage provider identifier (e.g., `"vast"`, `"ceph"`, `"pure"`) |
+| `description` | `string` | No | Human-readable description of the backend |
+| `endpoint` | `StorageBackendEndpoint` | Yes | Management endpoint for the storage array |
+| `credentials_ref` | `string` | Yes | Reference to a Kubernetes Secret (`namespace/secret-name` or `secret-name`). **Temporary** — the credential storage mechanism will be revisited when OSAC core establishes a unified credential management pattern. |
+| `status` | `StorageBackendStatus` | System | Operational status, set on create |
+
+**`StorageBackendEndpoint` message:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `host` | `string` | Yes | Hostname or IP of the storage management API |
+| `port` | `int32` | No | Port number; provider-specific default if omitted |
+
+**`StorageBackendStatus` message:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `state` | `StorageBackendState` | Yes | Current lifecycle state |
+| `message` | `string` | No | Human-readable status detail |
+| `model` | `string` | No | Storage array model (e.g., `"VAST C-100"`) |
+| `firmware_version` | `string` | No | Reported firmware version |
+
+**`StorageBackendState` enum:**
+
+| Value | Number | Description |
+|-------|--------|-------------|
+| `STORAGE_BACKEND_STATE_UNSPECIFIED` | 0 | Default zero value |
+| `STORAGE_BACKEND_STATE_READY` | 1 | Backend registered and available |
+
+The enum starts with `READY` as the only operational state. Additional states (e.g., `PENDING`, `FAILED`, `DEGRADED`) are added when health probing or reconciliation capabilities are introduced. The `UNSPECIFIED` sentinel follows proto3 convention.
+
+**`storage_backends_service.proto`** (`osac.private.v1`):
+
+The service defines five RPCs following the NetworkClass service pattern (without Signal, since StorageBackend has no reconciler):
+
+| RPC | HTTP Method | Path | Notes |
+|-----|-------------|------|-------|
+| `List` | `GET` | `/api/private/v1/storage_backends` | Pagination, CEL filter, ordering |
+| `Get` | `GET` | `/api/private/v1/storage_backends/{id}` | `response_body: "object"` |
+| `Create` | `POST` | `/api/private/v1/storage_backends` | `body: "object"`, `response_body: "object"` |
+| `Update` | `PATCH` | `/api/private/v1/storage_backends/{object.id}` | `body: "object"`, `response_body: "object"` |
+| `Delete` | `DELETE` | `/api/private/v1/storage_backends/{id}` | |
+
+No Signal RPC is defined. Signal exists on other entities to wake up a reconciler when external state changes — StorageBackend has no reconciler, so Signal would have no consumer. Status fields (model, firmware_version) can be updated via the standard `Update` RPC if needed in the future.
+
+#### Proto Schema — Public API
+
+**`storage_backend_type.proto`** (`osac.public.v1`):
+
+The public message mirrors the private message with these differences:
+- `credentials_ref` is excluded entirely (not present in the message definition)
+- `endpoint.host` is included (tenants need to know which array serves their storage)
+- `status` is included (tenants need to see backend availability)
+- All fields are effectively `OUTPUT_ONLY` since the public API is read-only
+
+**`storage_backends_service.proto`** (`osac.public.v1`):
+
+| RPC | HTTP Method | Path |
+|-----|-------------|------|
+| `List` | `GET` | `/api/fulfillment/v1/storage_backends` |
+| `Get` | `GET` | `/api/fulfillment/v1/storage_backends/{id}` |
+
+No Create, Update, or Delete RPCs in the public API.
+
+#### Server Implementation
+
+**`private_storage_backends_server.go`**: Follows the `PrivateNetworkClassesServer` pattern:
+
+- Struct wraps `GenericServer[*privatev1.StorageBackend]`
+- Builder pattern: `NewPrivateStorageBackendsServer()` returns a builder with `SetLogger`, `SetNotifier`, `SetAttributionLogic`, `SetTenancyLogic`, `SetMetricsRegisterer`, `Build()`
+- `Create`: validates required fields (`provider`, `endpoint.host`, `credentials_ref`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID
+- `Update`: fetches existing object, merges via `applyStorageBackendUpdate`, validates immutability of `provider` field, delegates to generic server
+- `Delete`: delegates directly to generic server (soft delete)
+
+**Immutable fields on update:** `provider` is immutable after creation. Changing the storage provider would invalidate the endpoint, credentials, and any downstream StorageTier references.
+
+**`storage_backends_server.go`** (public): Follows the `NetworkClassesServer` pattern:
+
+- Composes a `PrivateStorageBackendsServer` delegate + `GenericMapper` pair
+- `inMapper` is not needed (no write RPCs on public API), but the pattern requires it for consistency with the builder; unused mapper fields can be nil
+- `outMapper` maps private StorageBackend to public StorageBackend, skipping `credentials_ref`
+- Exposes only `List` and `Get`
+
+#### Database Migration
+
+Migration file: `54_create_storage_backends_tables.up.sql` (next available sequence number)
+
+The migration creates two tables following the standard schema:
+
+```sql
+create table storage_backends (
+  id text not null primary key,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null default now(),
+  deletion_timestamp timestamp with time zone not null default 'epoch',
+  finalizers text[] not null default '{}',
+  creators text[] not null default '{}',
+  tenants text[] not null default '{}',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  data jsonb not null
+);
+
+create table archived_storage_backends (
+  id text not null,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null,
+  deletion_timestamp timestamp with time zone not null,
+  archival_timestamp timestamp with time zone not null default now(),
+  creators text[] not null default '{}',
+  tenants text[] not null default '{}',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  data jsonb not null
+);
+```
+
+Indexes:
+
+```sql
+create index storage_backends_by_name on storage_backends (name);
+create index storage_backends_by_owner on storage_backends using gin (creators);
+create index storage_backends_by_tenant on storage_backends using gin (tenants);
+create index storage_backends_by_label on storage_backends using gin (labels);
+```
+
+Name uniqueness among active backends (FR-9):
+
+```sql
+create unique index storage_backends_unique_active_name
+  on storage_backends (name)
+  where deletion_timestamp = 'epoch';
+```
+
+This partial index permits name reuse after soft deletion while preventing duplicate names among active records. The DAO's unique violation error maps to gRPC `ALREADY_EXISTS`.
+
+#### Generic Server Changes
+
+**`generic_server.go`** — `setPayload()` switch: Add a case for `*privatev1.StorageBackend` that calls `event.SetStorageBackend(object)`.
+
+**`event_type.proto`** — Add a `StorageBackend storage_backend` field to the `Event` message's oneof payload (next available field number).
+
+#### gRPC Server Registration
+
+In `start_grpc_server_cmd.go`, add registration blocks for both servers following the NetworkClass pattern:
+
+```go
+// Public StorageBackends server
+storageBackendsServer, err := servers.NewStorageBackendsServer().
+    SetLogger(logger).
+    SetNotifier(notifier).
+    SetAttributionLogic(attributionLogic).
+    SetTenancyLogic(tenancyLogic).
+    SetMetricsRegisterer(metricsRegisterer).
+    Build()
+publicv1.RegisterStorageBackendsServer(grpcServer, storageBackendsServer)
+
+// Private StorageBackends server
+privateStorageBackendsServer, err := servers.NewPrivateStorageBackendsServer().
+    SetLogger(logger).
+    SetNotifier(notifier).
+    SetAttributionLogic(attributionLogic).
+    SetTenancyLogic(tenancyLogic).
+    SetMetricsRegisterer(metricsRegisterer).
+    Build()
+privatev1.RegisterStorageBackendsServer(grpcServer, privateStorageBackendsServer)
+```
+
+### Security Considerations
+
+StorageBackend inherits the existing fulfillment-service security model:
+
+- **Authentication:** JWT validation via the gRPC interceptor chain. No changes to the authentication flow.
+- **Authorization:** OPA policies control access to private vs. public API endpoints. Cloud Provider Admins have access to private CRUD. Tenants have access to public List + Get only.
+- **Credential isolation:** The `credentials_ref` field stores a Secret reference string, not credential content. The fulfillment-service never reads, decrypts, or forwards the Secret's data. The public API excludes `credentials_ref` entirely — tenants cannot discover Secret names. This mechanism is temporary — it will be revisited when OSAC core establishes a unified credential management pattern across all entities.
+- **Input validation:** The server validates required fields (`provider`, `endpoint.host`, `credentials_ref`) and provider immutability. The `endpoint.host` field is a string stored as-is; no DNS resolution or connection attempt is made during registration. The `credentials_ref` format is validated syntactically (non-empty string) but not resolved against the Kubernetes API.
+
+No new authentication, authorization, or encryption mechanisms are introduced.
+
+### Failure Handling and Recovery
+
+| Failure Mode | Behavior | User Observation | Recovery |
+|---|---|---|---|
+| Database unavailable during Create | gRPC interceptor rolls back the transaction | `UNAVAILABLE` error | Retry the request; the operation is idempotent (name uniqueness check prevents duplicates) |
+| Duplicate active name on Create | Unique partial index violation | `ALREADY_EXISTS` with the conflicting name | Choose a different name or delete the existing backend first |
+| Stale version on Update with `lock=true` | DAO rejects the write | `FAILED_PRECONDITION` | Re-fetch the current version and retry |
+All operations are transactional (wrapped by the gRPC database transaction interceptor) and idempotent. There is no reconciliation loop that could leave resources in a partially updated state.
+
+### RBAC / Tenancy
+
+StorageBackend is platform-scoped, not tenant-scoped. It follows the same access model as NetworkClass:
+
+- **Private API:** Accessible to Cloud Provider Admins. OPA policies enforce role-based access. No Signal RPC. The `tenants` column in the database is empty (platform-scoped resources have no tenant owner).
+- **Public API:** Accessible to all authenticated users (tenants). List and Get return all active backends (no tenant filtering). The `credentials_ref` field is stripped by the public server's output mapper.
+
+No `osac.openshift.io/tenant` or `osac.openshift.io/owner-reference` annotations are set on StorageBackend. This is consistent with NetworkClass, which is also platform-scoped. Tenant isolation applies at the StorageTier level (OSAC-1110), where tiers are assigned to tenants.
+
+### Observability and Monitoring
+
+No new observability changes. Existing monitoring mechanisms apply:
+
+- The gRPC Prometheus interceptor records request counts, latencies, and error rates for all StorageBackend RPCs automatically (same as all other gRPC services).
+- PostgreSQL NOTIFY events for StorageBackend CRUD operations are published through the existing event infrastructure.
+- Structured logging via `slog` in the server implementation covers validation failures, Signal updates, and DAO errors.
+
+### Risks and Mitigations
+
+**Credential reference format ambiguity:** The `credentials_ref` format (namespace-scoped `namespace/secret-name` vs. implicit namespace) is deferred to implementation. Choosing the wrong format creates a breaking API change later.
+
+*Mitigation:* The `credentials_ref` is an opaque string. Namespace-scoped format (`namespace/secret-name`) is the safer default because it avoids ambiguity when backends span namespaces. The format is documented in the proto field comments and validated syntactically (must contain `/`).
+
+**Soft-delete name reuse and StorageTier references:** When a backend is soft-deleted and its name is reused for a new backend, a StorageTier referencing the old backend by ID continues to resolve correctly (references use ID, not name). However, confusion may arise if operators expect name-based lookup to return the latest backend.
+
+*Mitigation:* StorageTier references backends by ID. The API documentation explicitly states that List excludes soft-deleted backends and that name reuse is permitted after decommission.
+
+### Drawbacks
+
+**Platform-scoped entity with credentials.** StorageBackend stores a reference to a Kubernetes Secret. Although the fulfillment-service never reads the Secret, the reference itself (namespace + name) is sensitive metadata. The public API strips it, but the private API exposes it to all Cloud Provider Admins regardless of which backend they manage. In a multi-admin scenario, this provides full visibility of all credential Secret names. This is consistent with NetworkClass, where all admins see all configuration, but worth noting as the attack surface grows with the number of backends.
+
+## Alternatives (Not Implemented)
+
+### Kubernetes CRD instead of DB-backed entity
+
+StorageBackend could be a Kubernetes Custom Resource (like VirtualNetwork or Subnet) with a reconciler.
+
+*Pros:* Native kubectl access, standard RBAC, built-in watch semantics, controller reconciliation loop for health checks.
+
+*Cons:* Requires CRD definition in osac-operator, reconciler registration, cross-process coordination between the operator and fulfillment-service. NetworkClass established the DB-backed pattern for platform infrastructure entities, and deviating from it fragments the architecture without clear benefit — StorageBackend has no cluster-side state to reconcile.
+
+*Rejection:* The DB-backed pattern is simpler, already proven for this use case, and aligns with the NetworkClass precedent. A CRD can be introduced later if reconciliation requirements emerge.
+
+### Credentials stored in the database
+
+Instead of referencing a Kubernetes Secret, the fulfillment-service could store credentials directly in the JSONB `data` column (encrypted at rest).
+
+*Pros:* Self-contained entity — no dependency on Kubernetes Secret management. Simpler operational model for credential rotation.
+
+*Cons:* Credential content in PostgreSQL requires application-level encryption, key rotation, and access auditing. The fulfillment-service becomes a credential store, expanding its attack surface. Kubernetes Secrets already provide encryption at rest (via etcd encryption), RBAC-controlled access, and integration with external secret managers (e.g., Vault via External Secrets Operator).
+
+*Rejection:* Storing credential references delegates security responsibility to the Kubernetes Secret infrastructure, which is purpose-built for this function. However, this is a temporary approach — all existing OSAC entities currently store credentials inline. The credential storage mechanism will be revisited when OSAC core establishes a unified pattern, and StorageBackend will adopt whatever pattern is chosen.
+
+## Open Questions
+
+1. **credentials_ref format and longevity.** Should the format be `namespace/secret-name` (explicit namespace) or `secret-name` (implicit `osac-system` namespace)? Explicit namespace is more flexible but requires the admin to know the Secret's namespace. Implicit namespace is simpler but constrains all credential Secrets to a single namespace. Note: existing OSAC entities (break_glass_credentials, identity_provider, user, cluster_template, hub) all store credentials inline in the JSONB data column. The `credentials_ref` approach is a temporary divergence — the credential storage mechanism will be revisited when OSAC core establishes a unified pattern.
+
+## Test Plan
+
+Testing follows the fulfillment-service's established Ginkgo v2 test patterns:
+
+**Unit/integration tests** (co-located in `internal/servers/`):
+
+- `private_storage_backends_server_test.go`:
+  - CRUD lifecycle: Create with all fields, Get by ID, List with pagination, Update with field mask, Delete (soft-delete)
+  - Validation: missing `provider`, missing `endpoint.host`, missing `credentials_ref` return `INVALID_ARGUMENT`
+  - Immutability: Update with changed `provider` returns `INVALID_ARGUMENT`
+  - Name uniqueness: Create with duplicate active name returns `ALREADY_EXISTS`; Create after soft-delete of same name succeeds
+  - Optimistic locking: Update with stale version and `lock=true` returns `FAILED_PRECONDITION`
+  - CEL filtering: List with `this.provider == "vast"` returns matching backends
+  - Ordering: List with `metadata.name asc` returns sorted results
+- `storage_backends_server_test.go` (public API):
+  - List and Get delegate correctly to private server
+  - `credentials_ref` is absent from public responses
+  - Create/Update/Delete are not exposed
+
+**Integration tests** (`it/`): StorageBackend CRUD via gRPC and REST endpoints against a kind cluster deployment, covering authentication and authorization.
+
+**E2E tests** (deferred to StorageTier integration): End-to-end tests covering the StorageBackend -> StorageTier -> tenant onboarding flow are scoped to OSAC-1110.
+
+## Graduation Criteria
+
+Graduation criteria will be defined when targeting a release. Expected stages: Dev Preview -> Tech Preview -> GA based on production deployment feedback.
+
+For initial merge:
+
+- All integration tests pass
+- `buf lint` passes with no warnings
+- Private and public API endpoints are accessible via both gRPC and REST
+- `credentials_ref` is confirmed absent from public API responses
+
+## Upgrade / Downgrade Strategy
+
+This is a new API with no upgrade impact. The database migration (`54_create_storage_backends_tables.up.sql`) is additive — it creates new tables and indexes without modifying existing schema.
+
+**Downgrade:** Requires deleting all StorageBackend records and then reverting the database migration (dropping the `storage_backends` and `archived_storage_backends` tables). No other OSAC entities reference StorageBackend in this phase, so deletion has no cascading effects.
+
+## Version Skew Strategy
+
+StorageBackend exists entirely within the fulfillment-service. There is no CRD in osac-operator and no cross-component API dependency. Version skew between fulfillment-service and osac-operator does not affect StorageBackend.
+
+When StorageTier (OSAC-1110) is implemented, it will reference StorageBackend by ID. At that point, the StorageTier implementation must handle the case where a referenced StorageBackend does not exist (fulfillment-service upgraded with StorageTier before StorageBackend records are created, or downgrade removes StorageBackend). This is scoped to OSAC-1110.
+
+## Support Procedures
+
+**Failure detection:**
+
+- Missing or inaccessible backends: `grpc_server_handled_total{grpc_service="osac.private.v1.StorageBackends", grpc_code!="OK"}` metric shows elevated error rates.
+- Database migration failure: `fulfillment-service` fails to start with migration error in logs.
+
+**Disabling the feature:**
+
+StorageBackend can be disabled by removing the server registration from `start_grpc_server_cmd.go` and reverting the database migration. Consequences:
+
+- No impact on cluster health — StorageBackend has no reconciler or controller.
+- No impact on existing workloads — no OSAC entity currently references StorageBackend.
+- New StorageBackend API calls return `UNIMPLEMENTED`.
+
+**Recovery:** Re-enable by restoring the server registration and re-running the migration. Data in the `storage_backends` table is preserved if only the server registration was removed. Consistency is maintained because all operations are transactional.
+
+## Infrastructure Needed
+
+None.

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -52,7 +52,7 @@ StorageBackend is a new entity in the fulfillment-service with two API surfaces:
 
 **Private API** (`osac.private.v1.StorageBackends`): Full CRUD (Create, Get, List, Update, Delete). Used by Cloud Provider Admins and internal systems (e.g., future tenant onboarding controller that needs credentials to pass to AAP). No Signal RPC — StorageBackend has no reconciler or controller. No public API — tenants interact with storage through StorageTier, not directly with backends.
 
-The database schema follows the standard JSONB `data` column pattern with `storage_backends` and `archived_storage_backends` tables. A unique partial index on `name` enforces FR-9 (name uniqueness among active records). **[OPEN: see OQ-1]**
+The database schema follows the standard JSONB `data` column pattern with `storage_backends` and `archived_storage_backends` tables (the archived table is required by the generic DAO, not user-facing). A unique partial index on `name` enforces FR-9 (name uniqueness among active records).
 
 The generic server's `setPayload()` switch statement requires a new case for `StorageBackend`, and the Event proto requires a new `storage_backend` payload field.
 
@@ -84,7 +84,9 @@ The diagram shows the registration path. The admin registers the backend via the
 
 **Credential rotation:** The admin calls `UpdateStorageBackend` with new `credentials` fields. No redeployment is required.
 
-**Decommission:** The admin calls `DeleteStorageBackend`. By default the backend is soft-deleted (standard DAO pattern — sets `deletion_timestamp`, archives the record). When `purge=true` is set on the request, the backend is permanently removed from the database. Both modes reject the delete with `FAILED_PRECONDITION` if any StorageTier references the backend — the admin must remove all tier associations first. **[OPEN: see OQ-1]**
+**Decommission (phase 0.2):** The admin transitions the backend to `DECOMMISSIONED` state via `UpdateStorageBackend`. The record remains in the database and is visible via Get and List, but the backend is no longer available for new StorageTier associations. This is a terminal state — the backend cannot return to `READY`. An intermediate `MAINTENANCE` state is available for temporary unavailability (e.g., firmware upgrade) and can be reversed back to `READY`.
+
+**Permanent removal:** The admin calls `DeleteStorageBackend`. Delete is only allowed on `DECOMMISSIONED` backends (phase 0.2) or any backend with no StorageTier references (phase 1). The DAO performs the standard archive-and-delete internally, but the archived table is an infrastructure detail, not a user-facing feature.
 
 **Error cases:**
 - Duplicate name on active backend: Create returns `ALREADY_EXISTS` (enforced by the unique partial index).
@@ -144,8 +146,22 @@ Credentials are stored inline in the JSONB `data` column, following the same pat
 |-------|--------|-------------|
 | `STORAGE_BACKEND_STATE_UNSPECIFIED` | 0 | Default zero value |
 | `STORAGE_BACKEND_STATE_READY` | 1 | Backend registered and available |
+| `STORAGE_BACKEND_STATE_MAINTENANCE` | 2 | Backend temporarily unavailable (reversible — can return to `READY`) |
+| `STORAGE_BACKEND_STATE_DECOMMISSIONED` | 3 | Backend permanently retired (terminal — cannot return to `READY`) |
 
-The enum starts with `READY` as the only operational state. Additional states (e.g., `PENDING`, `FAILED`, `DEGRADED`) are added when health probing or reconciliation capabilities are introduced. The `UNSPECIFIED` sentinel follows proto3 convention.
+**Phase 1** implements only `READY`. The `MAINTENANCE` and `DECOMMISSIONED` states are defined in the proto enum from the start but rejected by the server until phase 0.2.
+
+**State transitions (phase 0.2):**
+
+```
+READY ⇄ MAINTENANCE    (reversible)
+READY → DECOMMISSIONED (terminal, one-way)
+MAINTENANCE → DECOMMISSIONED (terminal, one-way)
+```
+
+`DECOMMISSIONED` replaces the traditional soft-delete pattern — the record stays in the database and remains visible via Get and List (filterable by state), but the backend is no longer available for new StorageTier associations. Delete (permanent removal) is only allowed on `DECOMMISSIONED` backends with no remaining StorageTier references.
+
+The `UNSPECIFIED` sentinel follows proto3 convention.
 
 **`storage_backends_service.proto`** (`osac.private.v1`):
 
@@ -169,9 +185,11 @@ No Signal RPC is defined. Signal exists on other entities to wake up a reconcile
 - Builder pattern: `NewPrivateStorageBackendsServer()` returns a builder with `SetLogger`, `SetNotifier`, `SetAttributionLogic`, `SetTenancyLogic`, `SetMetricsRegisterer`, `Build()`
 - `Create`: validates required fields (`metadata.name`, `provider`, `endpoint`, `credentials.username`, `credentials.password`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID. The generic server's `validateName()` enforces RFC 1035 DNS label format (1–63 chars, lowercase alphanumeric + hyphens, no leading/trailing hyphens). Name uniqueness among active backends is enforced by the `storage_backends_unique_active_name` partial index.
 - `Update`: fetches existing object, merges via `applyStorageBackendUpdate`, validates immutability of `provider` and `metadata.name` fields, delegates to generic server
-- `Delete`: checks for referencing StorageTier records; rejects with `FAILED_PRECONDITION` if any exist. Default: soft-delete via standard DAO. When `purge=true`: hard-delete, permanently removing the record. **[OPEN: see OQ-1]**
+- `Delete`: checks for referencing StorageTier records; rejects with `FAILED_PRECONDITION` if any exist. In phase 0.2, also rejects unless the backend is in `DECOMMISSIONED` state. Delegates to the generic server (standard DAO archive-and-delete)
 
 **Immutable fields on update:** `provider` and `metadata.name` are immutable after creation. Changing the storage provider would invalidate the endpoint, credentials, and any downstream StorageTier references. Name immutability ensures stable human-readable identifiers for operational use and prevents confusion when backends are referenced by name in logs and configurations.
+
+**State transition validation (phase 0.2):** The server enforces the state machine — `READY ⇄ MAINTENANCE` (reversible), `READY → DECOMMISSIONED` and `MAINTENANCE → DECOMMISSIONED` (terminal). Any other transition returns `INVALID_ARGUMENT`.
 
 #### Database Migration
 
@@ -224,7 +242,7 @@ create unique index storage_backends_unique_active_name
   where deletion_timestamp = 'epoch';
 ```
 
-This partial index permits name reuse after soft deletion while preventing duplicate names among active records. The DAO's unique violation error maps to gRPC `ALREADY_EXISTS`. **[OPEN: see OQ-1 — the partial condition is needed for soft-delete; hard-delete via `purge` removes the row entirely so the partial index still works correctly.]**
+This partial index permits name reuse after deletion while preventing duplicate names among active records. The DAO's unique violation error maps to gRPC `ALREADY_EXISTS`.
 
 #### Generic Server Changes
 
@@ -288,9 +306,9 @@ No new observability changes. Existing monitoring mechanisms apply:
 
 ### Risks and Mitigations
 
-**Referential integrity on delete:** Delete is rejected if any StorageTier references the backend. This prevents orphaned tier-to-backend references but requires the admin to manually remove all tier associations before decommissioning a backend.
+**Referential integrity on delete:** Delete is rejected if any StorageTier references the backend. This prevents orphaned tier-to-backend references but requires the admin to decommission the backend and remove all tier associations before permanent removal.
 
-*Mitigation:* The `FAILED_PRECONDITION` error message lists the referencing StorageTier IDs so the admin knows exactly what to clean up.
+*Mitigation:* The `FAILED_PRECONDITION` error message lists the referencing StorageTier IDs so the admin knows exactly what to clean up. The `DECOMMISSIONED` state (phase 0.2) provides a safe intermediate step — the backend is visible but no longer available for new associations.
 
 ### Drawbacks
 
@@ -316,22 +334,18 @@ Instead of storing credentials inline, the fulfillment-service could store a `cr
 
 *Cons:* Introduces a new credential pattern that no existing OSAC entity uses — all current entities (break_glass_credentials, identity_provider, user, cluster_template, hub) store credentials inline. Adds operational complexity (Secret must exist, namespace resolution, lifecycle management). Creates an inconsistency in the codebase.
 
-*Rejection:* OSAC core are aware of the need for a credentials solution for the system(this is not a specific to storage backends) - see this ticket https://redhat.atlassian.net/browse/OSAC-1567 . Also, consistency with existing OSAC patterns outweighs the security benefit for phase 1. All other entities store credentials inline, and introducing a divergent pattern without an OSAC-core decision on unified credential management would create unnecessary complexity. This can be revisited when OSAC establishes a platform-wide credential storage strategy.
+*Rejection:* Consistency with existing OSAC patterns outweighs the security benefit for phase 1. All other entities store credentials inline, and introducing a divergent pattern without an OSAC-core decision on unified credential management would create unnecessary complexity. This can be revisited when OSAC establishes a platform-wide credential storage strategy.
 
 ## Open Questions
 
-**OQ-1: Deletion strategy — soft-delete by default, optional hard-delete with `purge` flag.**
+**OQ-1 (resolved): Deletion strategy — state-based lifecycle replaces soft-delete.**
 
-**Proposed resolution:** Support both modes. `DeleteStorageBackend` performs a soft-delete by default (standard DAO pattern — sets `deletion_timestamp`, archives to `archived_storage_backends`). When `purge=true` is set on the request, the backend is permanently removed from the database.
+Decommissioning is modeled as a state transition rather than the DAO's archive pattern:
+- `MAINTENANCE` (phase 0.2): temporary unavailability, reversible to `READY`.
+- `DECOMMISSIONED` (phase 0.2): terminal state, backend is retired but remains visible via Get/List.
+- `Delete` RPC: permanent removal via the standard DAO (archive-and-delete). In phase 0.2, only allowed on `DECOMMISSIONED` backends with no StorageTier references. In phase 1, allowed on any backend with no StorageTier references.
 
-Both modes enforce referential integrity — delete is rejected with `FAILED_PRECONDITION` if any StorageTier references the backend, regardless of soft vs hard delete.
-
-This requires:
-- A `bool purge` field on the `DeleteStorageBackendRequest` message.
-- Extending the generic DAO or adding custom delete logic in `PrivateStorageBackendsServer.Delete()` to bypass the archive step when `purge=true`.
-- The `archived_storage_backends` table and partial unique index are still needed for the soft-delete path.
-
-**Owner:** Storage architect. **Impact:** Proto schema (`DeleteStorageBackendRequest`), DAO usage, FR-6.
+The `archived_storage_backends` table is required by the generic DAO infrastructure but is not exposed as a user-facing feature.
 
 ## Test Plan
 

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -389,6 +389,8 @@ This is a new API with no upgrade impact. The database migration (`54_create_sto
 
 StorageBackend exists entirely within the fulfillment-service. There is no CRD in osac-operator and no cross-component API dependency. Version skew between fulfillment-service and osac-operator does not affect StorageBackend.
 
+**Intra-component skew (rolling upgrades):** During a rolling upgrade from phase 1 to phase 0.2, a phase 1 instance may read backends from PostgreSQL with state values it does not recognize (`MAINTENANCE` = 2, `DECOMMISSIONED` = 3). Proto3 preserves unknown enum values as their integer representation, so the data is not corrupted. The phase 1 instance will serve these backends with the numeric state value in API responses. This is acceptable for the brief duration of a rolling upgrade. Downgrades from phase 0.2 to phase 1 require all backends in `MAINTENANCE` or `DECOMMISSIONED` state to be transitioned back to `READY` or deleted before the rollback (see Upgrade / Downgrade Strategy above).
+
 When StorageTier (OSAC-1110) is implemented, it will reference StorageBackend by ID. At that point, the StorageTier implementation must handle the case where a referenced StorageBackend does not exist (fulfillment-service upgraded with StorageTier before StorageBackend records are created, or downgrade removes StorageBackend). This is scoped to OSAC-1110.
 
 ## Support Procedures

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -230,7 +230,6 @@ Indexes:
 ```sql
 create index storage_backends_by_name on storage_backends (name);
 create index storage_backends_by_creator on storage_backends (creator);
-create index storage_backends_by_tenant on storage_backends (tenant);
 create index storage_backends_by_label on storage_backends using gin (labels);
 ```
 

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -52,7 +52,7 @@ StorageBackend is a new entity in the fulfillment-service with two API surfaces:
 
 **Private API** (`osac.private.v1.StorageBackends`): Full CRUD (Create, Get, List, Update, Delete). Used by Cloud Provider Admins and internal systems (e.g., future tenant onboarding controller that needs credentials to pass to AAP). No Signal RPC — StorageBackend has no reconciler or controller. No public API — tenants interact with storage through StorageTier, not directly with backends.
 
-The database schema follows the standard JSONB `data` column pattern with `storage_backends` and `archived_storage_backends` tables. A unique partial index on `name` enforces FR-9 (name uniqueness among active records).
+The database schema follows the standard JSONB `data` column pattern with `storage_backends` and `archived_storage_backends` tables. A unique partial index on `name` enforces FR-9 (name uniqueness among active records). **[OPEN: The deletion strategy (soft-delete vs hard-delete) is under review — see Open Questions.]**
 
 The generic server's `setPayload()` switch statement requires a new case for `StorageBackend`, and the Event proto requires a new `storage_backend` payload field.
 
@@ -84,7 +84,7 @@ The diagram shows the registration path. The admin registers the backend via the
 
 **Credential rotation:** The admin calls `UpdateStorageBackend` with new `credentials` fields. No redeployment is required.
 
-**Decommission:** The admin calls `DeleteStorageBackend`. The backend is soft-deleted: excluded from List results but preserved in the `archived_storage_backends` table for audit. Name reuse is allowed after soft deletion.
+**Decommission:** The admin calls `DeleteStorageBackend`. The backend is soft-deleted using the standard DAO pattern (sets `deletion_timestamp`, archives the record). Delete is rejected with `FAILED_PRECONDITION` if any StorageTier references the backend — the admin must remove all tier associations first. **[OPEN: The deletion strategy (soft-delete vs hard-delete) is under review — see Open Questions.]**
 
 **Error cases:**
 - Duplicate name on active backend: Create returns `ALREADY_EXISTS` (enforced by the unique partial index).
@@ -169,7 +169,7 @@ No Signal RPC is defined. Signal exists on other entities to wake up a reconcile
 - Builder pattern: `NewPrivateStorageBackendsServer()` returns a builder with `SetLogger`, `SetNotifier`, `SetAttributionLogic`, `SetTenancyLogic`, `SetMetricsRegisterer`, `Build()`
 - `Create`: validates required fields (`metadata.name`, `provider`, `endpoint`, `credentials.username`, `credentials.password`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID. The generic server's `validateName()` enforces RFC 1035 DNS label format (1–63 chars, lowercase alphanumeric + hyphens, no leading/trailing hyphens). Name uniqueness among active backends is enforced by the `storage_backends_unique_active_name` partial index.
 - `Update`: fetches existing object, merges via `applyStorageBackendUpdate`, validates immutability of `provider` and `metadata.name` fields, delegates to generic server
-- `Delete`: delegates directly to generic server (soft delete)
+- `Delete`: checks for referencing StorageTier records; rejects with `FAILED_PRECONDITION` if any exist, otherwise delegates to generic server (soft delete via standard DAO pattern). **[OPEN: soft-delete vs hard-delete — see Open Questions]**
 
 **Immutable fields on update:** `provider` and `metadata.name` are immutable after creation. Changing the storage provider would invalidate the endpoint, credentials, and any downstream StorageTier references. Name immutability ensures stable human-readable identifiers for operational use and prevents confusion when backends are referenced by name in logs and configurations.
 
@@ -224,7 +224,7 @@ create unique index storage_backends_unique_active_name
   where deletion_timestamp = 'epoch';
 ```
 
-This partial index permits name reuse after soft deletion while preventing duplicate names among active records. The DAO's unique violation error maps to gRPC `ALREADY_EXISTS`.
+This partial index permits name reuse after soft deletion while preventing duplicate names among active records. The DAO's unique violation error maps to gRPC `ALREADY_EXISTS`. **[OPEN: If hard-delete is chosen, this becomes a plain unique index without the partial condition.]**
 
 #### Generic Server Changes
 
@@ -265,6 +265,7 @@ No new authentication, authorization, or encryption mechanisms are introduced.
 |---|---|---|---|
 | Database unavailable during Create | gRPC interceptor rolls back the transaction | `UNAVAILABLE` error | Retry the request; the operation is idempotent (name uniqueness check prevents duplicates) |
 | Duplicate active name on Create | Unique partial index violation | `ALREADY_EXISTS` with the conflicting name | Choose a different name or delete the existing backend first |
+| Delete with referencing StorageTiers | Server checks for references before delete | `FAILED_PRECONDITION` listing the referencing tiers | Remove all StorageTier associations first, then retry |
 | Stale version on Update with `lock=true` | DAO rejects the write | `FAILED_PRECONDITION` | Re-fetch the current version and retry |
 All operations are transactional (wrapped by the gRPC database transaction interceptor) and idempotent. There is no reconciliation loop that could leave resources in a partially updated state.
 
@@ -287,9 +288,9 @@ No new observability changes. Existing monitoring mechanisms apply:
 
 ### Risks and Mitigations
 
-**Soft-delete name reuse and StorageTier references:** When a backend is soft-deleted and its name is reused for a new backend, a StorageTier referencing the old backend by ID continues to resolve correctly (references use ID, not name). However, confusion may arise if operators expect name-based lookup to return the latest backend.
+**Referential integrity on delete:** Delete is rejected if any StorageTier references the backend. This prevents orphaned tier-to-backend references but requires the admin to manually remove all tier associations before decommissioning a backend.
 
-*Mitigation:* StorageTier references backends by ID. The API documentation explicitly states that List excludes soft-deleted backends and that name reuse is permitted after decommission.
+*Mitigation:* The `FAILED_PRECONDITION` error message lists the referencing StorageTier IDs so the admin knows exactly what to clean up.
 
 ### Drawbacks
 
@@ -319,7 +320,15 @@ Instead of storing credentials inline, the fulfillment-service could store a `cr
 
 ## Open Questions
 
-None — all prior open questions have been resolved. Credentials are stored inline (matching existing OSAC patterns), and Signal RPC has been removed (no reconciler).
+**OQ-1: Soft-delete vs hard-delete for StorageBackend decommission.**
+
+The generic DAO uses soft-delete by default (sets `deletion_timestamp`, archives the record to `archived_storage_backends`). All existing OSAC entities follow this pattern. However, StorageBackend may not need the archived record — audit can be handled by the existing observability infrastructure (structured logging, PostgreSQL NOTIFY events), and referential integrity (rejecting delete when StorageTiers reference the backend) prevents orphaned references.
+
+Options:
+- **Keep soft-delete (current DAO default):** No DAO changes needed. Archived records are preserved. Name reuse is allowed via the partial index. Follows the established pattern.
+- **Switch to hard-delete:** Requires extending the generic DAO with a hard-delete option or implementing custom delete logic in the StorageBackend server. Simpler schema (no archived table, plain unique index on name). Aligns with AWS/GCP patterns where infrastructure resources are hard-deleted and audit relies on external logs.
+
+**Owner:** Storage architect. **Impact:** Database schema, DAO usage, FR-6, FR-9.
 
 ## Test Plan
 
@@ -328,10 +337,11 @@ Testing follows the fulfillment-service's established Ginkgo v2 test patterns:
 **Unit/integration tests** (co-located in `internal/servers/`):
 
 - `private_storage_backends_server_test.go`:
-  - CRUD lifecycle: Create with all fields, Get by ID, List with pagination, Update with field mask, Delete (soft-delete)
+  - CRUD lifecycle: Create with all fields, Get by ID, List with pagination, Update with field mask, Delete
   - Validation: missing `metadata.name`, missing `provider`, missing `endpoint`, missing `credentials` return `INVALID_ARGUMENT`; invalid DNS label name returns `INVALID_ARGUMENT`
   - Immutability: Update with changed `provider` returns `INVALID_ARGUMENT`; Update with changed `metadata.name` returns `INVALID_ARGUMENT`
-  - Name uniqueness: Create with duplicate active name returns `ALREADY_EXISTS`; Create after soft-delete of same name succeeds
+  - Name uniqueness: Create with duplicate active name returns `ALREADY_EXISTS`; Create after delete of same name succeeds
+  - Referential integrity: Delete with referencing StorageTier returns `FAILED_PRECONDITION`; Delete without references succeeds
   - Optimistic locking: Update with stale version and `lock=true` returns `FAILED_PRECONDITION`
   - CEL filtering: List with `this.provider == "vast"` returns matching backends
   - Ordering: List with `metadata.name asc` returns sorted results

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -28,12 +28,12 @@ OSAC manages networking infrastructure through first-class API entities (Network
 
 This gap blocks two capabilities: (1) composing tiered storage offerings where StorageTier entities (OSAC-1110) reference registered backends by ID, and (2) credential rotation without redeploying the fulfillment-service. Three prior enhancements addressed tenant-to-StorageClass resolution but left the infrastructure layer unmanaged.
 
-StorageBackend introduces the infrastructure registration layer. It stores the provider type, management endpoint, and credentials. The entity is platform-scoped (not tenant-scoped), managed exclusively by Cloud Provider Admins through the private API, and exposed read-only through the public API with credentials stripped.
+StorageBackend introduces the infrastructure registration layer. It stores the provider type, management endpoint, and credentials. The entity is platform-scoped (not tenant-scoped), managed exclusively by Cloud Provider Admins through the private API. There is no public API — tenants do not need visibility into storage backends; they interact with storage through StorageTier (OSAC-1110).
 
 ### Goals
 
 - Reuse the NetworkClass DB-backed server pattern (generic server, generic DAO, builder construction) with no reconciler or CRD. [Codebase: internal/servers/private_network_classes_server.go]
-- Expose both private (full CRUD) and public (read-only) API layers following the established dual-API pattern.
+- Expose a private CRUD API only — no public API. Tenants interact with storage through StorageTier (OSAC-1110), not directly with backends.
 - Store credentials inline in the JSONB `data` column, consistent with all existing OSAC entities (break_glass_credentials, identity_provider, user, cluster_template, hub).
 - Keep the StorageBackend schema provider-agnostic so that non-VAST backends (Ceph, Pure) use the same entity without schema changes.
 - Provide the foundation entity for StorageTier (OSAC-1110) composition without introducing StorageTier dependencies.
@@ -50,9 +50,7 @@ StorageBackend introduces the infrastructure registration layer. It stores the p
 
 StorageBackend is a new entity in the fulfillment-service with two API surfaces:
 
-1. **Private API** (`osac.private.v1.StorageBackends`): Full CRUD (Create, Get, List, Update, Delete). Used by Cloud Provider Admins. No Signal RPC — StorageBackend has no reconciler or controller, so there is nothing to signal.
-
-2. **Public API** (`osac.public.v1.StorageBackends`): Read-only (List, Get). Delegates to the private server with field mapping. Credential fields are excluded from the public API via `AddIgnoredFields()`.
+**Private API** (`osac.private.v1.StorageBackends`): Full CRUD (Create, Get, List, Update, Delete). Used by Cloud Provider Admins and internal systems (e.g., future tenant onboarding controller that needs credentials to pass to AAP). No Signal RPC — StorageBackend has no reconciler or controller. No public API — tenants interact with storage through StorageTier, not directly with backends.
 
 The database schema follows the standard JSONB `data` column pattern with `storage_backends` and `archived_storage_backends` tables. A unique partial index on `name` enforces FR-9 (name uniqueness among active records).
 
@@ -62,7 +60,7 @@ The generic server's `setPayload()` switch statement requires a new case for `St
 
 **Actors:**
 - Cloud Provider Admin — registers and manages storage backends via the private API
-- Tenant — discovers available backends (provider, endpoint, status) via the public API; cannot see credentials
+- Tenant — no direct access to StorageBackend; interacts with storage through StorageTier (OSAC-1110)
 
 **Starting state:** The fulfillment-service is deployed with no StorageBackend records. Storage configuration exists only in Ansible extra vars.
 
@@ -99,8 +97,9 @@ The diagram shows the registration path. The admin registers the backend via the
 This enhancement adds the following API extensions:
 
 - **Private gRPC service** `osac.private.v1.StorageBackends` — CRUD, registered in the gRPC server startup alongside `NetworkClasses`.
-- **Public gRPC service** `osac.public.v1.StorageBackends` — List + Get only, registered alongside the public `NetworkClasses` server.
 - **Event payload field** `storage_backend` added to `osac.private.v1.Event` — enables event-driven notifications for StorageBackend changes.
+
+No public API is registered. Tenants do not need direct access to storage backends.
 
 No CRDs, webhooks, or finalizers are introduced. No existing resources are modified. If the fulfillment-service is unavailable, StorageBackend operations fail but no other OSAC resources are affected — StorageBackend has no controller loop that could leave resources in an inconsistent state.
 
@@ -168,25 +167,6 @@ The service defines five RPCs following the NetworkClass service pattern (withou
 
 No Signal RPC is defined. Signal exists on other entities to wake up a reconciler when external state changes — StorageBackend has no reconciler, so Signal would have no consumer. Status fields (model, firmware_version) can be updated via the standard `Update` RPC if needed in the future.
 
-#### Proto Schema — Public API
-
-**`storage_backend_type.proto`** (`osac.public.v1`):
-
-The public message mirrors the private message with these differences:
-- `credentials` is excluded entirely (not present in the message definition)
-- `endpoint.host` is included (tenants need to know which array serves their storage)
-- `status` is included (tenants need to see backend availability)
-- All fields are effectively `OUTPUT_ONLY` since the public API is read-only
-
-**`storage_backends_service.proto`** (`osac.public.v1`):
-
-| RPC | HTTP Method | Path |
-|-----|-------------|------|
-| `List` | `GET` | `/api/fulfillment/v1/storage_backends` |
-| `Get` | `GET` | `/api/fulfillment/v1/storage_backends/{id}` |
-
-No Create, Update, or Delete RPCs in the public API.
-
 #### Server Implementation
 
 **`private_storage_backends_server.go`**: Follows the `PrivateNetworkClassesServer` pattern:
@@ -198,13 +178,6 @@ No Create, Update, or Delete RPCs in the public API.
 - `Delete`: delegates directly to generic server (soft delete)
 
 **Immutable fields on update:** `provider` is immutable after creation. Changing the storage provider would invalidate the endpoint, credentials, and any downstream StorageTier references.
-
-**`storage_backends_server.go`** (public): Follows the `NetworkClassesServer` pattern:
-
-- Composes a `PrivateStorageBackendsServer` delegate + `GenericMapper` pair
-- `inMapper` is not needed (no write RPCs on public API), but the pattern requires it for consistency with the builder; unused mapper fields can be nil
-- `outMapper` maps private StorageBackend to public StorageBackend, skipping `credentials`
-- Exposes only `List` and `Get`
 
 #### Database Migration
 
@@ -270,16 +243,6 @@ This partial index permits name reuse after soft deletion while preventing dupli
 In `start_grpc_server_cmd.go`, add registration blocks for both servers following the NetworkClass pattern:
 
 ```go
-// Public StorageBackends server
-storageBackendsServer, err := servers.NewStorageBackendsServer().
-    SetLogger(logger).
-    SetNotifier(notifier).
-    SetAttributionLogic(attributionLogic).
-    SetTenancyLogic(tenancyLogic).
-    SetMetricsRegisterer(metricsRegisterer).
-    Build()
-publicv1.RegisterStorageBackendsServer(grpcServer, storageBackendsServer)
-
 // Private StorageBackends server
 privateStorageBackendsServer, err := servers.NewPrivateStorageBackendsServer().
     SetLogger(logger).
@@ -296,8 +259,8 @@ privatev1.RegisterStorageBackendsServer(grpcServer, privateStorageBackendsServer
 StorageBackend inherits the existing fulfillment-service security model:
 
 - **Authentication:** JWT validation via the gRPC interceptor chain. No changes to the authentication flow.
-- **Authorization:** OPA policies control access to private vs. public API endpoints. Cloud Provider Admins have access to private CRUD. Tenants have access to public List + Get only.
-- **Credential storage:** Credentials are stored inline in the JSONB `data` column, consistent with all existing OSAC entities. The public API excludes `credentials` entirely — tenants cannot see credential fields. This follows the same pattern as `break_glass_credentials`, `identity_provider`, `user`, `cluster_template`, and `hub`.
+- **Authorization:** OPA policies control access to the private API endpoint. Only Cloud Provider Admins have access. There is no public API — tenants cannot access StorageBackend at all.
+- **Credential storage:** Credentials are stored inline in the JSONB `data` column, consistent with all existing OSAC entities (`break_glass_credentials`, `identity_provider`, `user`, `cluster_template`, `hub`). Since there is no public API, credentials are never exposed to tenants.
 - **Input validation:** The server validates required fields (`provider`, `endpoint.host`, `credentials.username`, `credentials.password`) and provider immutability. The `endpoint.host` field is a string stored as-is; no DNS resolution or connection attempt is made during registration.
 
 No new authentication, authorization, or encryption mechanisms are introduced.
@@ -315,8 +278,8 @@ All operations are transactional (wrapped by the gRPC database transaction inter
 
 StorageBackend is platform-scoped, not tenant-scoped. It follows the same access model as NetworkClass:
 
-- **Private API:** Accessible to Cloud Provider Admins. OPA policies enforce role-based access. No Signal RPC. The `tenants` column in the database is empty (platform-scoped resources have no tenant owner).
-- **Public API:** Accessible to all authenticated users (tenants). List and Get return all active backends (no tenant filtering). Credential fields are stripped by the public server's output mapper.
+- **Private API:** Accessible to Cloud Provider Admins and internal systems (osac-operator). OPA policies enforce role-based access. The `tenants` column in the database is empty (platform-scoped resources have no tenant owner).
+- **No public API.** Tenants interact with storage through StorageTier (OSAC-1110), not directly with backends.
 
 No `osac.openshift.io/tenant` or `osac.openshift.io/owner-reference` annotations are set on StorageBackend. This is consistent with NetworkClass, which is also platform-scoped. Tenant isolation applies at the StorageTier level (OSAC-1110), where tiers are assigned to tenants.
 
@@ -336,7 +299,7 @@ No new observability changes. Existing monitoring mechanisms apply:
 
 ### Drawbacks
 
-**Platform-scoped entity with credentials in the database.** StorageBackend stores credentials inline in the JSONB `data` column, which means credential content (username/password) lives in PostgreSQL. This is consistent with all existing OSAC entities that store credentials (break_glass_credentials, identity_provider, user, cluster_template, hub), but worth noting as the attack surface grows with the number of backends. The public API strips credentials, but the private API exposes them to all Cloud Provider Admins regardless of which backend they manage.
+**Platform-scoped entity with credentials in the database.** StorageBackend stores credentials inline in the JSONB `data` column, which means credential content (username/password) lives in PostgreSQL. This is consistent with all existing OSAC entities that store credentials (break_glass_credentials, identity_provider, user, cluster_template, hub), but worth noting as the attack surface grows with the number of backends. The private API exposes credentials to all Cloud Provider Admins regardless of which backend they manage.
 
 ## Alternatives (Not Implemented)
 
@@ -378,11 +341,6 @@ Testing follows the fulfillment-service's established Ginkgo v2 test patterns:
   - Optimistic locking: Update with stale version and `lock=true` returns `FAILED_PRECONDITION`
   - CEL filtering: List with `this.provider == "vast"` returns matching backends
   - Ordering: List with `metadata.name asc` returns sorted results
-- `storage_backends_server_test.go` (public API):
-  - List and Get delegate correctly to private server
-  - `credentials` is absent from public responses
-  - Create/Update/Delete are not exposed
-
 **Integration tests** (`it/`): StorageBackend CRUD via gRPC and REST endpoints against a kind cluster deployment, covering authentication and authorization.
 
 **E2E tests** (deferred to StorageTier integration): End-to-end tests covering the StorageBackend -> StorageTier -> tenant onboarding flow are scoped to OSAC-1110.
@@ -395,8 +353,7 @@ For initial merge:
 
 - All integration tests pass
 - `buf lint` passes with no warnings
-- Private and public API endpoints are accessible via both gRPC and REST
-- `credentials` is confirmed absent from public API responses
+- Private API endpoints are accessible via both gRPC and REST
 
 ## Upgrade / Downgrade Strategy
 

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -73,7 +73,7 @@ sequenceDiagram
     participant DB as PostgreSQL
 
     Admin->>FS: CreateStorageBackend(provider, endpoint, credentials, description)
-    FS->>FS: Validate required fields (metadata.name, provider, endpoint.host, credentials)
+    FS->>FS: Validate required fields (metadata.name, provider, endpoint, credentials)
     FS->>FS: Set state = READY, clear caller-provided ID
     FS->>DB: Insert into storage_backends (JSONB data column)
     DB-->>FS: Return with generated UUID
@@ -88,7 +88,7 @@ The diagram shows the registration path. The admin registers the backend via the
 
 **Error cases:**
 - Duplicate name on active backend: Create returns `ALREADY_EXISTS` (enforced by the unique partial index).
-- Missing required fields (metadata.name, provider, endpoint.host, credentials): Create returns `INVALID_ARGUMENT`.
+- Missing required fields (metadata.name, provider, endpoint, credentials): Create returns `INVALID_ARGUMENT`.
 - Name change on Update: returns `INVALID_ARGUMENT` (`metadata.name` is immutable after creation).
 - Update with stale version and `lock=true`: returns `FAILED_PRECONDITION` (optimistic concurrency control).
 - Delete of non-existent backend: returns `NOT_FOUND`.
@@ -116,16 +116,9 @@ No CRDs, webhooks, or finalizers are introduced. No existing resources are modif
 | `metadata` | `Metadata` | Yes | Standard OSAC metadata (name, labels, annotations, version) |
 | `provider` | `string` | Yes | Storage provider identifier (e.g., `"vast"`, `"ceph"`, `"pure"`) |
 | `description` | `string` | No | Human-readable description of the backend |
-| `endpoint` | `StorageBackendEndpoint` | Yes | Management endpoint for the storage array |
+| `endpoint` | `string` | Yes | Management endpoint for the storage array (URL or `host:port`) |
 | `credentials` | `StorageBackendCredentials` | Yes | Provider-specific credentials stored inline, consistent with existing OSAC credential patterns |
 | `status` | `StorageBackendStatus` | System | Operational status, set on create |
-
-**`StorageBackendEndpoint` message:**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `host` | `string` | Yes | Hostname or IP of the storage management API |
-| `port` | `int32` | No | Port number; provider-specific default if omitted |
 
 **`StorageBackendCredentials` message:**
 
@@ -174,7 +167,7 @@ No Signal RPC is defined. Signal exists on other entities to wake up a reconcile
 
 - Struct wraps `GenericServer[*privatev1.StorageBackend]`
 - Builder pattern: `NewPrivateStorageBackendsServer()` returns a builder with `SetLogger`, `SetNotifier`, `SetAttributionLogic`, `SetTenancyLogic`, `SetMetricsRegisterer`, `Build()`
-- `Create`: validates required fields (`metadata.name`, `provider`, `endpoint.host`, `credentials.username`, `credentials.password`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID. The generic server's `validateName()` enforces RFC 1035 DNS label format (1–63 chars, lowercase alphanumeric + hyphens, no leading/trailing hyphens). Name uniqueness among active backends is enforced by the `storage_backends_unique_active_name` partial index.
+- `Create`: validates required fields (`metadata.name`, `provider`, `endpoint`, `credentials.username`, `credentials.password`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID. The generic server's `validateName()` enforces RFC 1035 DNS label format (1–63 chars, lowercase alphanumeric + hyphens, no leading/trailing hyphens). Name uniqueness among active backends is enforced by the `storage_backends_unique_active_name` partial index.
 - `Update`: fetches existing object, merges via `applyStorageBackendUpdate`, validates immutability of `provider` and `metadata.name` fields, delegates to generic server
 - `Delete`: delegates directly to generic server (soft delete)
 
@@ -262,7 +255,7 @@ StorageBackend inherits the existing fulfillment-service security model:
 - **Authentication:** JWT validation via the gRPC interceptor chain. No changes to the authentication flow.
 - **Authorization:** OPA policies control access to the private API endpoint. Only Cloud Provider Admins have access. There is no public API — tenants cannot access StorageBackend at all.
 - **Credential storage:** Credentials are stored inline in the JSONB `data` column, consistent with all existing OSAC entities (`break_glass_credentials`, `identity_provider`, `user`, `cluster_template`, `hub`). Since there is no public API, credentials are never exposed to tenants.
-- **Input validation:** The server validates required fields (`metadata.name`, `provider`, `endpoint.host`, `credentials.username`, `credentials.password`), DNS label format for `metadata.name` (RFC 1035, enforced by the generic server), and immutability of `provider` and `metadata.name` on update. The `endpoint.host` field is a string stored as-is; no DNS resolution or connection attempt is made during registration.
+- **Input validation:** The server validates required fields (`metadata.name`, `provider`, `endpoint`, `credentials.username`, `credentials.password`), DNS label format for `metadata.name` (RFC 1035, enforced by the generic server), and immutability of `provider` and `metadata.name` on update. The `endpoint` field is an opaque string (URL or `host:port`) stored as-is; no DNS resolution or connection attempt is made during registration.
 
 No new authentication, authorization, or encryption mechanisms are introduced.
 
@@ -336,7 +329,7 @@ Testing follows the fulfillment-service's established Ginkgo v2 test patterns:
 
 - `private_storage_backends_server_test.go`:
   - CRUD lifecycle: Create with all fields, Get by ID, List with pagination, Update with field mask, Delete (soft-delete)
-  - Validation: missing `metadata.name`, missing `provider`, missing `endpoint.host`, missing `credentials` return `INVALID_ARGUMENT`; invalid DNS label name returns `INVALID_ARGUMENT`
+  - Validation: missing `metadata.name`, missing `provider`, missing `endpoint`, missing `credentials` return `INVALID_ARGUMENT`; invalid DNS label name returns `INVALID_ARGUMENT`
   - Immutability: Update with changed `provider` returns `INVALID_ARGUMENT`; Update with changed `metadata.name` returns `INVALID_ARGUMENT`
   - Name uniqueness: Create with duplicate active name returns `ALREADY_EXISTS`; Create after soft-delete of same name succeeds
   - Optimistic locking: Update with stale version and `lock=true` returns `FAILED_PRECONDITION`

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -137,8 +137,6 @@ Credentials are stored inline in the JSONB `data` column, following the same pat
 |-------|------|----------|-------------|
 | `state` | `StorageBackendState` | Yes | Current lifecycle state |
 | `message` | `string` | No | Human-readable status detail |
-| `model` | `string` | No | Storage array model (e.g., `"VAST C-100"`) |
-| `firmware_version` | `string` | No | Reported firmware version |
 
 **`StorageBackendState` enum:**
 
@@ -175,7 +173,7 @@ The service defines five RPCs following the NetworkClass service pattern (withou
 | `Update` | `PATCH` | `/api/private/v1/storage_backends/{object.id}` | `body: "object"`, `response_body: "object"` |
 | `Delete` | `DELETE` | `/api/private/v1/storage_backends/{id}` | |
 
-No Signal RPC is defined. Signal exists on other entities to wake up a reconciler when external state changes — StorageBackend has no reconciler, so Signal would have no consumer. Status fields (model, firmware_version) can be updated via the standard `Update` RPC if needed in the future.
+No Signal RPC is defined. Signal exists on other entities to wake up a reconciler when external state changes — StorageBackend has no reconciler, so Signal would have no consumer.
 
 #### Server Implementation
 
@@ -204,11 +202,12 @@ create table storage_backends (
   creation_timestamp timestamp with time zone not null default now(),
   deletion_timestamp timestamp with time zone not null default 'epoch',
   finalizers text[] not null default '{}',
-  creators text[] not null default '{}',
-  tenants text[] not null default '{}',
+  creator text not null default '',
+  tenant text not null default '',
   labels jsonb not null default '{}'::jsonb,
   annotations jsonb not null default '{}'::jsonb,
-  data jsonb not null
+  data jsonb not null,
+  version integer not null default 0
 );
 
 create table archived_storage_backends (
@@ -217,11 +216,12 @@ create table archived_storage_backends (
   creation_timestamp timestamp with time zone not null,
   deletion_timestamp timestamp with time zone not null,
   archival_timestamp timestamp with time zone not null default now(),
-  creators text[] not null default '{}',
-  tenants text[] not null default '{}',
+  creator text not null default '',
+  tenant text not null default '',
   labels jsonb not null default '{}'::jsonb,
   annotations jsonb not null default '{}'::jsonb,
-  data jsonb not null
+  data jsonb not null,
+  version integer not null default 0
 );
 ```
 
@@ -229,7 +229,8 @@ Indexes:
 
 ```sql
 create index storage_backends_by_name on storage_backends (name);
-create index storage_backends_by_owner on storage_backends using gin (creators);
+create index storage_backends_by_creator on storage_backends (creator);
+create index storage_backends_by_tenant on storage_backends (tenant);
 create index storage_backends_by_label on storage_backends using gin (labels);
 ```
 

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -20,7 +20,7 @@ superseded-by:
 
 ## Summary
 
-This enhancement adds a `StorageBackend` entity to the fulfillment-service, providing a private gRPC API (CRUD) and a public read-only API for managing storage array registrations. StorageBackend follows the NetworkClass pattern: DB-backed with no Kubernetes CRD and no reconciler. See [PRD](prd.md) for detailed requirements.
+This enhancement adds a `StorageBackend` entity to the fulfillment-service, providing a private gRPC API (CRUD) for managing storage array registrations. StorageBackend follows the NetworkClass pattern: DB-backed with no Kubernetes CRD and no reconciler. See [PRD](prd.md) for detailed requirements.
 
 ## Motivation
 
@@ -48,7 +48,7 @@ StorageBackend introduces the infrastructure registration layer. It stores the p
 
 ## Proposal
 
-StorageBackend is a new entity in the fulfillment-service with two API surfaces:
+StorageBackend is a new entity in the fulfillment-service with a private API surface:
 
 **Private API** (`osac.private.v1.StorageBackends`): Full CRUD (Create, Get, List, Update, Delete). Used by Cloud Provider Admins and internal systems (e.g., future tenant onboarding controller that needs credentials to pass to AAP). No Signal RPC — StorageBackend has no reconciler or controller. No public API — tenants interact with storage through StorageTier, not directly with backends.
 
@@ -230,7 +230,6 @@ Indexes:
 ```sql
 create index storage_backends_by_name on storage_backends (name);
 create index storage_backends_by_owner on storage_backends using gin (creators);
-create index storage_backends_by_tenant on storage_backends using gin (tenants);
 create index storage_backends_by_label on storage_backends using gin (labels);
 ```
 
@@ -380,7 +379,11 @@ For initial merge:
 
 This is a new API with no upgrade impact. The database migration (`54_create_storage_backends_tables.up.sql`) is additive — it creates new tables and indexes without modifying existing schema.
 
-**Downgrade:** Requires deleting all StorageBackend records and then reverting the database migration (dropping the `storage_backends` and `archived_storage_backends` tables). No other OSAC entities reference StorageBackend in this phase, so deletion has no cascading effects.
+**Phase 1 → Phase 0.2 behavioral change:** In phase 1, `Delete` is allowed on any backend with no StorageTier references. In phase 0.2, `Delete` is restricted to backends in `DECOMMISSIONED` state. Admins who previously deleted backends directly must first transition them to `DECOMMISSIONED`. This is a deliberate tightening — document in release notes.
+
+**Downgrade (phase 0.2 → phase 1):** Any backends in `MAINTENANCE` or `DECOMMISSIONED` state must be transitioned back to `READY` or deleted before downgrading, since phase 1 only recognizes the `READY` state.
+
+**Downgrade (phase 1 → removal):** Requires deleting all StorageBackend records and then reverting the database migration (dropping the `storage_backends` and `archived_storage_backends` tables). No other OSAC entities reference StorageBackend in this phase, so deletion has no cascading effects.
 
 ## Version Skew Strategy
 

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -73,14 +73,14 @@ sequenceDiagram
     participant DB as PostgreSQL
 
     Admin->>FS: CreateStorageBackend(provider, endpoint, credentials, description)
-    FS->>FS: Validate required fields (provider, endpoint.host, credentials)
+    FS->>FS: Validate required fields (metadata.name, provider, endpoint.host, credentials)
     FS->>FS: Set state = READY, clear caller-provided ID
     FS->>DB: Insert into storage_backends (JSONB data column)
     DB-->>FS: Return with generated UUID
     FS-->>Admin: StorageBackend with id, state=READY
 ```
 
-The diagram shows the registration path. The admin registers the backend via the private API with credentials provided inline. The fulfillment-service validates required fields, sets the initial state to `READY`, generates a UUID, and persists the entity. Credentials are stored in the JSONB `data` column, consistent with how all other OSAC entities store credentials.
+The diagram shows the registration path. The admin registers the backend via the private API with credentials provided inline. The fulfillment-service validates required fields (including `metadata.name`, which must be a valid DNS label per RFC 1035), sets the initial state to `READY`, generates a UUID, and persists the entity. Credentials are stored in the JSONB `data` column, consistent with how all other OSAC entities store credentials.
 
 **Credential rotation:** The admin calls `UpdateStorageBackend` with new `credentials` fields. No redeployment is required.
 
@@ -88,7 +88,8 @@ The diagram shows the registration path. The admin registers the backend via the
 
 **Error cases:**
 - Duplicate name on active backend: Create returns `ALREADY_EXISTS` (enforced by the unique partial index).
-- Missing required fields (provider, endpoint.host, credentials): Create/Update returns `INVALID_ARGUMENT`.
+- Missing required fields (metadata.name, provider, endpoint.host, credentials): Create returns `INVALID_ARGUMENT`.
+- Name change on Update: returns `INVALID_ARGUMENT` (`metadata.name` is immutable after creation).
 - Update with stale version and `lock=true`: returns `FAILED_PRECONDITION` (optimistic concurrency control).
 - Delete of non-existent backend: returns `NOT_FOUND`.
 
@@ -173,11 +174,11 @@ No Signal RPC is defined. Signal exists on other entities to wake up a reconcile
 
 - Struct wraps `GenericServer[*privatev1.StorageBackend]`
 - Builder pattern: `NewPrivateStorageBackendsServer()` returns a builder with `SetLogger`, `SetNotifier`, `SetAttributionLogic`, `SetTenancyLogic`, `SetMetricsRegisterer`, `Build()`
-- `Create`: validates required fields (`provider`, `endpoint.host`, `credentials.username`, `credentials.password`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID
-- `Update`: fetches existing object, merges via `applyStorageBackendUpdate`, validates immutability of `provider` field, delegates to generic server
+- `Create`: validates required fields (`metadata.name`, `provider`, `endpoint.host`, `credentials.username`, `credentials.password`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID. The generic server's `validateName()` enforces RFC 1035 DNS label format (1–63 chars, lowercase alphanumeric + hyphens, no leading/trailing hyphens). Name uniqueness among active backends is enforced by the `storage_backends_unique_active_name` partial index.
+- `Update`: fetches existing object, merges via `applyStorageBackendUpdate`, validates immutability of `provider` and `metadata.name` fields, delegates to generic server
 - `Delete`: delegates directly to generic server (soft delete)
 
-**Immutable fields on update:** `provider` is immutable after creation. Changing the storage provider would invalidate the endpoint, credentials, and any downstream StorageTier references.
+**Immutable fields on update:** `provider` and `metadata.name` are immutable after creation. Changing the storage provider would invalidate the endpoint, credentials, and any downstream StorageTier references. Name immutability ensures stable human-readable identifiers for operational use and prevents confusion when backends are referenced by name in logs and configurations.
 
 #### Database Migration
 
@@ -261,7 +262,7 @@ StorageBackend inherits the existing fulfillment-service security model:
 - **Authentication:** JWT validation via the gRPC interceptor chain. No changes to the authentication flow.
 - **Authorization:** OPA policies control access to the private API endpoint. Only Cloud Provider Admins have access. There is no public API — tenants cannot access StorageBackend at all.
 - **Credential storage:** Credentials are stored inline in the JSONB `data` column, consistent with all existing OSAC entities (`break_glass_credentials`, `identity_provider`, `user`, `cluster_template`, `hub`). Since there is no public API, credentials are never exposed to tenants.
-- **Input validation:** The server validates required fields (`provider`, `endpoint.host`, `credentials.username`, `credentials.password`) and provider immutability. The `endpoint.host` field is a string stored as-is; no DNS resolution or connection attempt is made during registration.
+- **Input validation:** The server validates required fields (`metadata.name`, `provider`, `endpoint.host`, `credentials.username`, `credentials.password`), DNS label format for `metadata.name` (RFC 1035, enforced by the generic server), and immutability of `provider` and `metadata.name` on update. The `endpoint.host` field is a string stored as-is; no DNS resolution or connection attempt is made during registration.
 
 No new authentication, authorization, or encryption mechanisms are introduced.
 
@@ -335,8 +336,8 @@ Testing follows the fulfillment-service's established Ginkgo v2 test patterns:
 
 - `private_storage_backends_server_test.go`:
   - CRUD lifecycle: Create with all fields, Get by ID, List with pagination, Update with field mask, Delete (soft-delete)
-  - Validation: missing `provider`, missing `endpoint.host`, missing `credentials` return `INVALID_ARGUMENT`
-  - Immutability: Update with changed `provider` returns `INVALID_ARGUMENT`
+  - Validation: missing `metadata.name`, missing `provider`, missing `endpoint.host`, missing `credentials` return `INVALID_ARGUMENT`; invalid DNS label name returns `INVALID_ARGUMENT`
+  - Immutability: Update with changed `provider` returns `INVALID_ARGUMENT`; Update with changed `metadata.name` returns `INVALID_ARGUMENT`
   - Name uniqueness: Create with duplicate active name returns `ALREADY_EXISTS`; Create after soft-delete of same name succeeds
   - Optimistic locking: Update with stale version and `lock=true` returns `FAILED_PRECONDITION`
   - CEL filtering: List with `this.provider == "vast"` returns matching backends

--- a/enhancements/storage-backend-osac-1111/design.md
+++ b/enhancements/storage-backend-osac-1111/design.md
@@ -28,13 +28,13 @@ OSAC manages networking infrastructure through first-class API entities (Network
 
 This gap blocks two capabilities: (1) composing tiered storage offerings where StorageTier entities (OSAC-1110) reference registered backends by ID, and (2) credential rotation without redeploying the fulfillment-service. Three prior enhancements addressed tenant-to-StorageClass resolution but left the infrastructure layer unmanaged.
 
-StorageBackend introduces the infrastructure registration layer. It stores the provider type, management endpoint, and a reference to a Kubernetes Secret containing credentials. The entity is platform-scoped (not tenant-scoped), managed exclusively by Cloud Provider Admins through the private API, and exposed read-only through the public API with credential references stripped.
+StorageBackend introduces the infrastructure registration layer. It stores the provider type, management endpoint, and credentials. The entity is platform-scoped (not tenant-scoped), managed exclusively by Cloud Provider Admins through the private API, and exposed read-only through the public API with credentials stripped.
 
 ### Goals
 
 - Reuse the NetworkClass DB-backed server pattern (generic server, generic DAO, builder construction) with no reconciler or CRD. [Codebase: internal/servers/private_network_classes_server.go]
 - Expose both private (full CRUD) and public (read-only) API layers following the established dual-API pattern.
-- Store credentials as opaque Kubernetes Secret references — no credential content touches the fulfillment-service database.
+- Store credentials inline in the JSONB `data` column, consistent with all existing OSAC entities (break_glass_credentials, identity_provider, user, cluster_template, hub).
 - Keep the StorageBackend schema provider-agnostic so that non-VAST backends (Ceph, Pure) use the same entity without schema changes.
 - Provide the foundation entity for StorageTier (OSAC-1110) composition without introducing StorageTier dependencies.
 
@@ -52,7 +52,7 @@ StorageBackend is a new entity in the fulfillment-service with two API surfaces:
 
 1. **Private API** (`osac.private.v1.StorageBackends`): Full CRUD (Create, Get, List, Update, Delete). Used by Cloud Provider Admins. No Signal RPC — StorageBackend has no reconciler or controller, so there is nothing to signal.
 
-2. **Public API** (`osac.public.v1.StorageBackends`): Read-only (List, Get). Delegates to the private server with field mapping. The `credentials_ref` field is excluded from the public API via `AddIgnoredFields()`.
+2. **Public API** (`osac.public.v1.StorageBackends`): Read-only (List, Get). Delegates to the private server with field mapping. Credential fields are excluded from the public API via `AddIgnoredFields()`.
 
 The database schema follows the standard JSONB `data` column pattern with `storage_backends` and `archived_storage_backends` tables. A unique partial index on `name` enforces FR-9 (name uniqueness among active records).
 
@@ -71,28 +71,26 @@ The generic server's `setPayload()` switch statement requires a new case for `St
 ```mermaid
 sequenceDiagram
     participant Admin as Cloud Provider Admin
-    participant K8s as Kubernetes API
     participant FS as fulfillment-service (private)
     participant DB as PostgreSQL
 
-    Admin->>K8s: Create Secret with storage credentials
-    Admin->>FS: CreateStorageBackend(provider, endpoint, credentials_ref, description)
-    FS->>FS: Validate required fields (provider, endpoint.host, credentials_ref)
+    Admin->>FS: CreateStorageBackend(provider, endpoint, credentials, description)
+    FS->>FS: Validate required fields (provider, endpoint.host, credentials)
     FS->>FS: Set state = READY, clear caller-provided ID
     FS->>DB: Insert into storage_backends (JSONB data column)
     DB-->>FS: Return with generated UUID
     FS-->>Admin: StorageBackend with id, state=READY
 ```
 
-The diagram shows the registration path. The admin first creates a Kubernetes Secret containing provider-specific credentials, then registers the backend via the private API. The fulfillment-service validates required fields, sets the initial state to `READY`, generates a UUID, and persists the entity.
+The diagram shows the registration path. The admin registers the backend via the private API with credentials provided inline. The fulfillment-service validates required fields, sets the initial state to `READY`, generates a UUID, and persists the entity. Credentials are stored in the JSONB `data` column, consistent with how all other OSAC entities store credentials.
 
-**Credential rotation:** The admin calls `UpdateStorageBackend` with a new `credentials_ref` pointing to a rotated Secret. No redeployment is required.
+**Credential rotation:** The admin calls `UpdateStorageBackend` with new `credentials` fields. No redeployment is required.
 
 **Decommission:** The admin calls `DeleteStorageBackend`. The backend is soft-deleted: excluded from List results but preserved in the `archived_storage_backends` table for audit. Name reuse is allowed after soft deletion.
 
 **Error cases:**
 - Duplicate name on active backend: Create returns `ALREADY_EXISTS` (enforced by the unique partial index).
-- Missing required fields (provider, endpoint.host, credentials_ref): Create/Update returns `INVALID_ARGUMENT`.
+- Missing required fields (provider, endpoint.host, credentials): Create/Update returns `INVALID_ARGUMENT`.
 - Update with stale version and `lock=true`: returns `FAILED_PRECONDITION` (optimistic concurrency control).
 - Delete of non-existent backend: returns `NOT_FOUND`.
 
@@ -119,7 +117,7 @@ No CRDs, webhooks, or finalizers are introduced. No existing resources are modif
 | `provider` | `string` | Yes | Storage provider identifier (e.g., `"vast"`, `"ceph"`, `"pure"`) |
 | `description` | `string` | No | Human-readable description of the backend |
 | `endpoint` | `StorageBackendEndpoint` | Yes | Management endpoint for the storage array |
-| `credentials_ref` | `string` | Yes | Reference to a Kubernetes Secret (`namespace/secret-name` or `secret-name`). **Temporary** — the credential storage mechanism will be revisited when OSAC core establishes a unified credential management pattern. |
+| `credentials` | `StorageBackendCredentials` | Yes | Provider-specific credentials stored inline, consistent with existing OSAC credential patterns |
 | `status` | `StorageBackendStatus` | System | Operational status, set on create |
 
 **`StorageBackendEndpoint` message:**
@@ -128,6 +126,15 @@ No CRDs, webhooks, or finalizers are introduced. No existing resources are modif
 |-------|------|----------|-------------|
 | `host` | `string` | Yes | Hostname or IP of the storage management API |
 | `port` | `int32` | No | Port number; provider-specific default if omitted |
+
+**`StorageBackendCredentials` message:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `username` | `string` | Yes | Username for storage management API authentication |
+| `password` | `string` | Yes | Password for storage management API authentication |
+
+Credentials are stored inline in the JSONB `data` column, following the same pattern as `break_glass_credentials.password`, `identity_provider.client_secret`, `user.password`, `cluster_template.pull_secret`, and `hub.kubeconfig`. The credential content is opaque to the fulfillment-service — no provider-specific validation is performed (NFR-2).
 
 **`StorageBackendStatus` message:**
 
@@ -166,7 +173,7 @@ No Signal RPC is defined. Signal exists on other entities to wake up a reconcile
 **`storage_backend_type.proto`** (`osac.public.v1`):
 
 The public message mirrors the private message with these differences:
-- `credentials_ref` is excluded entirely (not present in the message definition)
+- `credentials` is excluded entirely (not present in the message definition)
 - `endpoint.host` is included (tenants need to know which array serves their storage)
 - `status` is included (tenants need to see backend availability)
 - All fields are effectively `OUTPUT_ONLY` since the public API is read-only
@@ -186,7 +193,7 @@ No Create, Update, or Delete RPCs in the public API.
 
 - Struct wraps `GenericServer[*privatev1.StorageBackend]`
 - Builder pattern: `NewPrivateStorageBackendsServer()` returns a builder with `SetLogger`, `SetNotifier`, `SetAttributionLogic`, `SetTenancyLogic`, `SetMetricsRegisterer`, `Build()`
-- `Create`: validates required fields (`provider`, `endpoint.host`, `credentials_ref`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID
+- `Create`: validates required fields (`provider`, `endpoint.host`, `credentials.username`, `credentials.password`), sets state to `STORAGE_BACKEND_STATE_READY`, clears caller-provided ID
 - `Update`: fetches existing object, merges via `applyStorageBackendUpdate`, validates immutability of `provider` field, delegates to generic server
 - `Delete`: delegates directly to generic server (soft delete)
 
@@ -196,7 +203,7 @@ No Create, Update, or Delete RPCs in the public API.
 
 - Composes a `PrivateStorageBackendsServer` delegate + `GenericMapper` pair
 - `inMapper` is not needed (no write RPCs on public API), but the pattern requires it for consistency with the builder; unused mapper fields can be nil
-- `outMapper` maps private StorageBackend to public StorageBackend, skipping `credentials_ref`
+- `outMapper` maps private StorageBackend to public StorageBackend, skipping `credentials`
 - Exposes only `List` and `Get`
 
 #### Database Migration
@@ -290,8 +297,8 @@ StorageBackend inherits the existing fulfillment-service security model:
 
 - **Authentication:** JWT validation via the gRPC interceptor chain. No changes to the authentication flow.
 - **Authorization:** OPA policies control access to private vs. public API endpoints. Cloud Provider Admins have access to private CRUD. Tenants have access to public List + Get only.
-- **Credential isolation:** The `credentials_ref` field stores a Secret reference string, not credential content. The fulfillment-service never reads, decrypts, or forwards the Secret's data. The public API excludes `credentials_ref` entirely — tenants cannot discover Secret names. This mechanism is temporary — it will be revisited when OSAC core establishes a unified credential management pattern across all entities.
-- **Input validation:** The server validates required fields (`provider`, `endpoint.host`, `credentials_ref`) and provider immutability. The `endpoint.host` field is a string stored as-is; no DNS resolution or connection attempt is made during registration. The `credentials_ref` format is validated syntactically (non-empty string) but not resolved against the Kubernetes API.
+- **Credential storage:** Credentials are stored inline in the JSONB `data` column, consistent with all existing OSAC entities. The public API excludes `credentials` entirely — tenants cannot see credential fields. This follows the same pattern as `break_glass_credentials`, `identity_provider`, `user`, `cluster_template`, and `hub`.
+- **Input validation:** The server validates required fields (`provider`, `endpoint.host`, `credentials.username`, `credentials.password`) and provider immutability. The `endpoint.host` field is a string stored as-is; no DNS resolution or connection attempt is made during registration.
 
 No new authentication, authorization, or encryption mechanisms are introduced.
 
@@ -309,7 +316,7 @@ All operations are transactional (wrapped by the gRPC database transaction inter
 StorageBackend is platform-scoped, not tenant-scoped. It follows the same access model as NetworkClass:
 
 - **Private API:** Accessible to Cloud Provider Admins. OPA policies enforce role-based access. No Signal RPC. The `tenants` column in the database is empty (platform-scoped resources have no tenant owner).
-- **Public API:** Accessible to all authenticated users (tenants). List and Get return all active backends (no tenant filtering). The `credentials_ref` field is stripped by the public server's output mapper.
+- **Public API:** Accessible to all authenticated users (tenants). List and Get return all active backends (no tenant filtering). Credential fields are stripped by the public server's output mapper.
 
 No `osac.openshift.io/tenant` or `osac.openshift.io/owner-reference` annotations are set on StorageBackend. This is consistent with NetworkClass, which is also platform-scoped. Tenant isolation applies at the StorageTier level (OSAC-1110), where tiers are assigned to tenants.
 
@@ -319,13 +326,9 @@ No new observability changes. Existing monitoring mechanisms apply:
 
 - The gRPC Prometheus interceptor records request counts, latencies, and error rates for all StorageBackend RPCs automatically (same as all other gRPC services).
 - PostgreSQL NOTIFY events for StorageBackend CRUD operations are published through the existing event infrastructure.
-- Structured logging via `slog` in the server implementation covers validation failures, Signal updates, and DAO errors.
+- Structured logging via `slog` in the server implementation covers validation failures and DAO errors.
 
 ### Risks and Mitigations
-
-**Credential reference format ambiguity:** The `credentials_ref` format (namespace-scoped `namespace/secret-name` vs. implicit namespace) is deferred to implementation. Choosing the wrong format creates a breaking API change later.
-
-*Mitigation:* The `credentials_ref` is an opaque string. Namespace-scoped format (`namespace/secret-name`) is the safer default because it avoids ambiguity when backends span namespaces. The format is documented in the proto field comments and validated syntactically (must contain `/`).
 
 **Soft-delete name reuse and StorageTier references:** When a backend is soft-deleted and its name is reused for a new backend, a StorageTier referencing the old backend by ID continues to resolve correctly (references use ID, not name). However, confusion may arise if operators expect name-based lookup to return the latest backend.
 
@@ -333,7 +336,7 @@ No new observability changes. Existing monitoring mechanisms apply:
 
 ### Drawbacks
 
-**Platform-scoped entity with credentials.** StorageBackend stores a reference to a Kubernetes Secret. Although the fulfillment-service never reads the Secret, the reference itself (namespace + name) is sensitive metadata. The public API strips it, but the private API exposes it to all Cloud Provider Admins regardless of which backend they manage. In a multi-admin scenario, this provides full visibility of all credential Secret names. This is consistent with NetworkClass, where all admins see all configuration, but worth noting as the attack surface grows with the number of backends.
+**Platform-scoped entity with credentials in the database.** StorageBackend stores credentials inline in the JSONB `data` column, which means credential content (username/password) lives in PostgreSQL. This is consistent with all existing OSAC entities that store credentials (break_glass_credentials, identity_provider, user, cluster_template, hub), but worth noting as the attack surface grows with the number of backends. The public API strips credentials, but the private API exposes them to all Cloud Provider Admins regardless of which backend they manage.
 
 ## Alternatives (Not Implemented)
 
@@ -347,19 +350,19 @@ StorageBackend could be a Kubernetes Custom Resource (like VirtualNetwork or Sub
 
 *Rejection:* The DB-backed pattern is simpler, already proven for this use case, and aligns with the NetworkClass precedent. A CRD can be introduced later if reconciliation requirements emerge.
 
-### Credentials stored in the database
+### Credentials as Kubernetes Secret reference
 
-Instead of referencing a Kubernetes Secret, the fulfillment-service could store credentials directly in the JSONB `data` column (encrypted at rest).
+Instead of storing credentials inline, the fulfillment-service could store a `credentials_ref` string referencing a Kubernetes Secret.
 
-*Pros:* Self-contained entity — no dependency on Kubernetes Secret management. Simpler operational model for credential rotation.
+*Pros:* Credential content never touches the database. Delegates security to the Kubernetes Secret infrastructure (encryption at rest, RBAC, integration with external secret managers like Vault via External Secrets Operator).
 
-*Cons:* Credential content in PostgreSQL requires application-level encryption, key rotation, and access auditing. The fulfillment-service becomes a credential store, expanding its attack surface. Kubernetes Secrets already provide encryption at rest (via etcd encryption), RBAC-controlled access, and integration with external secret managers (e.g., Vault via External Secrets Operator).
+*Cons:* Introduces a new credential pattern that no existing OSAC entity uses — all current entities (break_glass_credentials, identity_provider, user, cluster_template, hub) store credentials inline. Adds operational complexity (Secret must exist, namespace resolution, lifecycle management). Creates an inconsistency in the codebase.
 
-*Rejection:* Storing credential references delegates security responsibility to the Kubernetes Secret infrastructure, which is purpose-built for this function. However, this is a temporary approach — all existing OSAC entities currently store credentials inline. The credential storage mechanism will be revisited when OSAC core establishes a unified pattern, and StorageBackend will adopt whatever pattern is chosen.
+*Rejection:* Consistency with existing OSAC patterns outweighs the security benefit for phase 1. All other entities store credentials inline, and introducing a divergent pattern without an OSAC-core decision on unified credential management would create unnecessary complexity. This can be revisited when OSAC establishes a platform-wide credential storage strategy.
 
 ## Open Questions
 
-1. **credentials_ref format and longevity.** Should the format be `namespace/secret-name` (explicit namespace) or `secret-name` (implicit `osac-system` namespace)? Explicit namespace is more flexible but requires the admin to know the Secret's namespace. Implicit namespace is simpler but constrains all credential Secrets to a single namespace. Note: existing OSAC entities (break_glass_credentials, identity_provider, user, cluster_template, hub) all store credentials inline in the JSONB data column. The `credentials_ref` approach is a temporary divergence — the credential storage mechanism will be revisited when OSAC core establishes a unified pattern.
+None — all prior open questions have been resolved. Credentials are stored inline (matching existing OSAC patterns), and Signal RPC has been removed (no reconciler).
 
 ## Test Plan
 
@@ -369,7 +372,7 @@ Testing follows the fulfillment-service's established Ginkgo v2 test patterns:
 
 - `private_storage_backends_server_test.go`:
   - CRUD lifecycle: Create with all fields, Get by ID, List with pagination, Update with field mask, Delete (soft-delete)
-  - Validation: missing `provider`, missing `endpoint.host`, missing `credentials_ref` return `INVALID_ARGUMENT`
+  - Validation: missing `provider`, missing `endpoint.host`, missing `credentials` return `INVALID_ARGUMENT`
   - Immutability: Update with changed `provider` returns `INVALID_ARGUMENT`
   - Name uniqueness: Create with duplicate active name returns `ALREADY_EXISTS`; Create after soft-delete of same name succeeds
   - Optimistic locking: Update with stale version and `lock=true` returns `FAILED_PRECONDITION`
@@ -377,7 +380,7 @@ Testing follows the fulfillment-service's established Ginkgo v2 test patterns:
   - Ordering: List with `metadata.name asc` returns sorted results
 - `storage_backends_server_test.go` (public API):
   - List and Get delegate correctly to private server
-  - `credentials_ref` is absent from public responses
+  - `credentials` is absent from public responses
   - Create/Update/Delete are not exposed
 
 **Integration tests** (`it/`): StorageBackend CRUD via gRPC and REST endpoints against a kind cluster deployment, covering authentication and authorization.
@@ -393,7 +396,7 @@ For initial merge:
 - All integration tests pass
 - `buf lint` passes with no warnings
 - Private and public API endpoints are accessible via both gRPC and REST
-- `credentials_ref` is confirmed absent from public API responses
+- `credentials` is confirmed absent from public API responses
 
 ## Upgrade / Downgrade Strategy
 

--- a/enhancements/storage-backend-osac-1111/prd.md
+++ b/enhancements/storage-backend-osac-1111/prd.md
@@ -17,7 +17,7 @@ Three prior enhancements addressed tenant-to-StorageClass resolution (`tenant-sp
 ### 2.1 Goals
 
 - Cloud Provider Admins can register, list, update, and decommission storage backends through the OSAC private gRPC API without modifying environment variables or Ansible playbooks.
-- Cloud Provider Admins can rotate storage backend credentials by updating the `credentials_ref` field, without redeploying the fulfillment-service.
+- Cloud Provider Admins can rotate storage backend credentials by updating the credential fields, without redeploying the fulfillment-service.
 - Cloud Provider Admins can inspect backend operational status (state, model, firmware version) through the API to verify availability and troubleshoot connectivity.
 - The StorageBackend entity follows the same DB-backed private API pattern as NetworkClass and PublicIPPool, maintaining consistency across OSAC infrastructure entities.
 - The StorageBackend entity provides the foundation for future StorageTier composition (OSAC-1110), where tiers reference registered backends.
@@ -37,14 +37,14 @@ Three prior enhancements addressed tenant-to-StorageClass resolution (`tenant-sp
 
 - **FR-1:** The fulfillment-service must expose a `StorageBackends` gRPC service under `osac.private.v1` with Create, Get, List, Update, and Delete RPCs.
 - **FR-2:** All CRUD RPCs must include HTTP annotations for REST access via grpc-gateway (POST, GET, GET, PATCH, DELETE).
-- **FR-3:** `CreateStorageBackend` must accept provider type, management endpoint (host + optional port), credentials reference (Kubernetes Secret), and optional description. The backend must be created with initial state `READY`.
+- **FR-3:** `CreateStorageBackend` must accept provider type, management endpoint (host + optional port), credentials (username and password), and optional description. The backend must be created with initial state `READY`.
 - **FR-4:** `ListStorageBackends` must support pagination (`offset`/`limit`), CEL-based filtering, and SQL-like ordering. This follows the established OSAC List API pattern used by all existing entities (NetworkClass, Clusters, ComputeInstances, Roles, etc.).
 - **FR-5:** `UpdateStorageBackend` must support partial updates (only specified fields are modified) and optimistic concurrency control to prevent conflicting writes.
 - **FR-6:** `DeleteStorageBackend` must perform a soft delete. Deleted backends must be excluded from List results but preserved for audit and future references from StorageTier.
 - **FR-7:** Cloud Provider Admins must be able to update backend operational metadata (model, firmware_version) and status message via the standard `Update` RPC. No Signal RPC is needed — StorageBackend has no reconciler or controller.
 - **FR-8:** Backend state must include `READY` (backend registered and available). Additional states will be introduced as needed when reconciliation or health probing capabilities are added in future phases. [User]
 - **FR-9:** Backend names must be unique among active (non-deleted) backends, allowing name reuse after decommission.
-- **FR-10:** The `credentials_ref` field must reference a Kubernetes Secret. The reference format (namespace-scoped `namespace/secret-name` or implicit namespace) is determined during implementation. This credential storage mechanism is temporary — it will be revisited when OSAC core establishes a unified credential management pattern.
+- **FR-10:** Credentials (username, password) must be stored inline in the StorageBackend entity, consistent with how all existing OSAC entities store credentials (break_glass_credentials, identity_provider, user, cluster_template, hub). Credentials must be excluded from the public API.
 
 ### 3.2 Non-Functional Requirements
 
@@ -66,7 +66,7 @@ Three prior enhancements addressed tenant-to-StorageClass resolution (`tenant-sp
 
 - The management cluster (hub) is the same cluster that runs the fulfillment-service and creates HostedClusters via Hosted Control Planes. The terms "hub" (ACM terminology) and "management cluster" refer to the same cluster.
 - StorageClasses are associated with tenants and tiers by naming convention, not by Kubernetes labels. The prior EP label-based approach (`osac.openshift.io/tenant`, `osac.openshift.io/storage-tier`) is superseded.
-- The `credentials_ref` Secret is created and managed by the Cloud Provider Admin outside of the StorageBackend API. The API stores only the reference, not the credential content.
+- Credentials are provided by the Cloud Provider Admin during backend registration and stored inline in the database, consistent with all existing OSAC credential patterns.
 
 ## 6. Dependencies
 
@@ -90,9 +90,4 @@ Three prior enhancements addressed tenant-to-StorageClass resolution (`tenant-sp
 ### 8.1 Should credential rotation trigger re-validation?
 
 - **Owner:** Storage architect
-- **Impact:** FR-3, FR-8. When `credentials_ref` is updated via `UpdateStorageBackend`, should the backend state change to indicate re-validation is needed? Deferred until additional states (e.g., `PENDING`) are introduced in a future phase.
-
-### 8.2 What is the credentials_ref format?
-
-- **Owner:** Storage architect, fulfillment-service maintainers
-- **Impact:** FR-10. The reference format — namespace-scoped (`namespace/secret-name`) vs. implicit namespace (`secret-name` assuming `osac-system`) — has security implications for cross-namespace access. A decision is needed before implementation.
+- **Impact:** FR-3, FR-8. When credentials are updated via `UpdateStorageBackend`, should the backend state change to indicate re-validation is needed? Deferred until additional states (e.g., `PENDING`) are introduced in a future phase.


### PR DESCRIPTION
## Design: StorageBackend API

**Jira:** https://redhat.atlassian.net/browse/OSAC-1111
**PRD:** Merged in PR #51

### Summary

Adds a design document for the StorageBackend API — a new DB-backed entity in the fulfillment-service following the NetworkClass pattern. The design covers private CRUD (Create, Get, List, Update, Delete) and public read-only APIs, PostgreSQL schema with soft-delete support, and server implementation details. No Signal RPC, no CRD, no reconciler.

### Requesting Review On

- **credentials_ref format and longevity** — the `credentials_ref` approach (K8s Secret reference) diverges from all existing OSAC entities which store credentials inline. This is marked as temporary pending an OSAC-core decision on unified credential management. See the Open Questions section.
- **No Signal RPC** — StorageBackend omits Signal since there is no reconciler. Status fields (model, firmware_version) are updated via the standard Update RPC. Is this acceptable, or should we keep a Signal RPC for future use?
- **StorageBackendStatus fields** — the status message includes model and firmware_version. Are these the right fields for phase 1?

### How to Review
- Comment inline on specific sections
- Approve when the design accurately reflects a viable implementation approach


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for the StorageBackend feature, including lifecycle/state model (READY/MAINTENANCE/DECOMMISSIONED), phase-gated transitions, and private API/event payload behavior.
  * Updated the StorageBackend PRD to support inline credential provisioning stored in the database, with an explicit goal of rotating credentials by updating credential fields without redeploying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->