### PR TITLE
OSAC-1550: rename ssh_key to ssh_public_key in unified-networking EP

### DIFF
--- a/enhancements/unified-networking/README.md
+++ b/enhancements/unified-networking/README.md
@@ -663,7 +663,7 @@ message ComputeInstanceSpec {
 ```protobuf
 message BaremetalInstanceSpec {
   string template = 1;
-  optional string ssh_key = 2;
+  optional string ssh_public_key = 2;
   optional string user_data = 3;
   optional BaremetalInstanceRunStrategy run_strategy = 4;
   optional google.protobuf.Timestamp restart_requested_at = 5;


### PR DESCRIPTION
## Summary

- Update remaining BareMetalInstance `ssh_key` reference to `ssh_public_key` in the unified-networking EP proto example

Completes the BareMetalInstance field rename started in PR #68.