### PR TITLE
OSAC-1332: PRD: CaaS Cluster Storage

### DIFF
--- a/enhancements/caas-cluster-storage/prd.md
+++ b/enhancements/caas-cluster-storage/prd.md
@@ -76,8 +76,7 @@ A tenant can have multiple CaaS clusters. Each cluster's storage is set up and t
 
 ## 6. Dependencies
 
-- **Tenant Storage Onboarding (OSAC-23):** Merged. Provides the storage automation framework that this PRD extends for CaaS clusters.
-- **Playbook split (osac-aap PR #338):** Merged. Provides independent setup and teardown actions required for per-cluster operations.
+- **Tenant Storage Onboarding (OSAC-23):** Merged. Provides the storage automation framework and independent per-cluster setup and teardown actions that this PRD extends for CaaS clusters.
 - **VAST for CaaS (OSAC-1122):** In progress. The storage provider must support CaaS clusters as a target. Required for end-to-end functionality.
 - **Tier API (OSAC-1110):** In progress. Not blocking. The system integrates when available, falls back to existing configuration.
 - **StorageBackend API (OSAC-1111):** In progress. Not blocking. The system integrates when available, falls back to single implicit backend.

--- a/enhancements/caas-cluster-storage/prd.md
+++ b/enhancements/caas-cluster-storage/prd.md
@@ -4,79 +4,44 @@
 |-------------|---------|
 | Author(s)   | Akshay Nadkarni |
 | Jira        | https://redhat.atlassian.net/browse/OSAC-1332 |
-| Date        | 2026-06-24 |
+| Date        | 2026-06-25 |
 
-## 1. Problem Statement
+## Problem Statement
 
-CaaS tenant clusters are provisioned without persistent storage. When a cluster is ready, it has compute but no way for tenant workloads to create persistent volumes. Storage backend resources (credentials, views, quotas) are already provisioned during tenant onboarding, but nothing connects cluster readiness to storage installation on that cluster. Cloud Provider Admins have no visibility into whether a cluster's storage is ready, and Tenant Admins and Users cannot use persistent storage until someone manually configures it.
+CaaS tenant clusters are provisioned without persistent storage. When a tenant's cluster becomes ready, it has compute but no way to create persistent volumes. Tenants cannot run stateful workloads until someone manually configures storage, and there is no visibility into whether storage is available on a given cluster.
 
-## 2. Goals and Non-Goals
+## In Scope
 
-### 2.1 Goals
+- Automatic storage provisioning on CaaS clusters
+- Storage readiness visibility for tenants and cloud admins
+- Storage cleanup on CaaS cluster deletion
 
-- When a CaaS cluster is provisioned and ready, persistent storage (CSI driver and per-tenant, per-tier StorageClasses) is automatically available without manual configuration.
-- Cloud Provider Admins can see tenant-level storage status across all CaaS clusters.
-- Tenant Admins and Users can see whether their cluster's storage is ready.
-- When a CaaS cluster is deleted, storage resources on that cluster are cleaned up. Backend resources are left intact for other clusters.
-- Multiple CaaS clusters per tenant are handled independently, each with its own storage readiness.
-- When the Storage Tier API (OSAC-1110) and StorageBackend API (OSAC-1111) are available, the system uses them. Otherwise it falls back to the existing configuration.
+## Out of Scope
 
-### 2.2 Non-Goals
+- Storage provider changes for CaaS support
+- Storage UI
+- Storage backend provisioning for a tenant (runs during tenant onboarding, before any cluster is ready)
+- VMaaS storage changes
 
-- Making the storage provider CaaS-ready. Covered by OSAC-1122.
-- Storage UI.
-- Storage backend provisioning (runs during tenant onboarding, assumed complete before any cluster is ready).
-- VMaaS cluster-side storage changes. Existing flow is unchanged.
-- Cloud Infrastructure Admin responsibilities (storage backend configuration, tier definitions). Covered by OSAC-1122 and OSAC-1110.
+## User Stories
 
-## 3. Capabilities
+### Tenant Admin / Tenant User
 
-### Automatic Storage Setup
+- As a Tenant Admin or Tenant User, I want persistent storage to be available on my CaaS cluster when it is ready, so that I can run stateful workloads without waiting for manual configuration.
+- As a Tenant Admin or Tenant User, I want to select a storage tier via StorageClasses when creating persistent volumes, so that I can choose the right performance level for my workload.
+- As a Tenant Admin or Tenant User, I want to see whether my CaaS cluster's storage is ready and the reason if it is not, so that I know when I can deploy stateful workloads.
+- As a Tenant Admin or Tenant User, I want storage resources on my CaaS cluster to be cleaned up when the cluster is deleted, without affecting my other clusters or backend resources.
 
-When a CaaS cluster is provisioned and ready, the system automatically installs the CSI driver and creates per-tenant, per-tier StorageClasses on that cluster. The tenant's storage backend must be fully provisioned before this happens. No manual intervention is required from any persona.
+### Cloud Provider Admin
 
-The system determines which tiers and backends are available for the tenant. If the Tier API or StorageBackend API are deployed, they are used. Otherwise the system falls back to the existing tier and backend configuration.
+- As a Cloud Provider Admin, I want to see storage readiness across all tenant clusters, so that I can identify and troubleshoot failures.
 
-### Storage Readiness Visibility
+## Assumptions
 
-As a Cloud Provider Admin, I can see the storage readiness of each tenant's CaaS clusters at the tenant level, so I can monitor onboarding progress and troubleshoot failures across tenants.
+- Storage backend provisioning is complete before a CaaS cluster becomes ready.
+- CaaS cluster nodes have network reachability to the storage backend.
 
-As a Tenant Admin or Tenant User, I can see whether my specific CaaS cluster's storage is ready, so I know when I can start creating persistent volumes. If storage setup failed, I can see the reason.
+## Dependencies
 
-### Cluster Deletion and Cleanup
-
-When a CaaS cluster is deleted, storage resources installed on that cluster are cleaned up. Backend resources shared across the tenant's clusters are not affected, because other clusters may still use them.
-
-### Multi-Cluster Independence
-
-A tenant can have multiple CaaS clusters. Each cluster's storage is set up and torn down independently. Adding or removing a CaaS cluster does not affect storage on other clusters belonging to the same tenant.
-
-### 3.1 Operational Expectations
-
-- Storage should be available shortly after the cluster is ready.
-- Credentials and secrets are never exposed in user-visible error messages, status fields, or events.
-
-## 4. Acceptance Criteria
-
-- [ ] A tenant user can create a PVC on a newly provisioned CaaS cluster without manual storage configuration
-- [ ] A Cloud Provider Admin can see storage readiness status for each tenant's CaaS clusters
-- [ ] A Tenant Admin or User can see whether their specific CaaS cluster's storage is ready and the reason if it failed
-- [ ] When a CaaS cluster is deleted, storage resources on that cluster are cleaned up
-- [ ] Deleting one CaaS cluster does not affect storage on other clusters belonging to the same tenant
-- [ ] Backend resources are unaffected by CaaS cluster deletion
-- [ ] A second CaaS cluster for the same tenant gets independent storage setup
-
-## 5. Assumptions
-
-- Storage backend provisioning is always complete before a CaaS cluster reaches ready. The system does not handle a ready cluster with an unprovisioned backend.
-- The storage provider's automation accepts CaaS clusters as a target and uses the provided cluster credentials. This is delivered by OSAC-1122.
-- VAST is the only storage provider for v0.1.
-- Cluster credentials are obtainable from the cluster provisioning infrastructure. Confirmed by the CaaS team.
-- CaaS cluster nodes have network reachability to the storage backend. This is an infrastructure prerequisite managed by the Cloud Infrastructure Admin.
-
-## 6. Dependencies
-
-- **Tenant Storage Onboarding (OSAC-23):** Merged. Provides the storage automation framework and independent per-cluster setup and teardown actions that this PRD extends for CaaS clusters.
-- **VAST for CaaS (OSAC-1122):** In progress. The storage provider must support CaaS clusters as a target. Required for end-to-end functionality.
-- **Tier API (OSAC-1110):** In progress. Not blocking. The system integrates when available, falls back to existing configuration.
-- **StorageBackend API (OSAC-1111):** In progress. Not blocking. The system integrates when available, falls back to single implicit backend.
+- **Tenant Storage Onboarding:** Provides the storage automation framework that CaaS cluster storage builds on.
+- **Storage provider CaaS support:** The storage provider must accept CaaS clusters as a target. Required for end-to-end functionality.

--- a/enhancements/caas-cluster-storage/prd.md
+++ b/enhancements/caas-cluster-storage/prd.md
@@ -21,13 +21,7 @@ CaaS tenant clusters are provisioned without persistent storage. When a cluster 
 - Multiple CaaS clusters per tenant are handled independently, each with its own storage readiness.
 - When the Storage Tier API (OSAC-1110) and StorageBackend API (OSAC-1111) are available, the system uses them. Otherwise it falls back to the existing configuration.
 
-### 2.2 Success Metrics
-
-| Metric | Target | Baseline |
-|--------|--------|----------|
-| Time from cluster ready to storage available | < 5 minutes | N/A (new feature) |
-
-### 2.3 Non-Goals
+### 2.2 Non-Goals
 
 - VAST provider CaaS-specific changes (storage path conventions, credential scoping, CaaS provisioning targets). Covered by OSAC-1122.
 - Storage UI.
@@ -59,19 +53,18 @@ A tenant can have multiple CaaS clusters. Each cluster's storage is set up and t
 
 ### 3.1 Operational Expectations
 
-- Storage setup completes within 5 minutes of a CaaS cluster becoming ready.
+- Storage should be available shortly after the cluster is ready.
 - Credentials and secrets are never exposed in user-visible error messages, status fields, or events.
 
 ## 4. Acceptance Criteria
 
 - [ ] A tenant user can create a PVC on a newly provisioned CaaS cluster without manual storage configuration
 - [ ] A Cloud Provider Admin can see storage readiness status for each tenant's CaaS clusters
-- [ ] A Tenant Admin can see whether their specific CaaS cluster's storage is ready and the reason if it failed
+- [ ] A Tenant Admin or User can see whether their specific CaaS cluster's storage is ready and the reason if it failed
 - [ ] When a CaaS cluster is deleted, storage resources on that cluster are cleaned up
 - [ ] Deleting one CaaS cluster does not affect storage on other clusters belonging to the same tenant
 - [ ] Backend resources are unaffected by CaaS cluster deletion
 - [ ] A second CaaS cluster for the same tenant gets independent storage setup
-- [ ] Unit tests cover setup, readiness, teardown, and multi-cluster scenarios
 
 ## 5. Assumptions
 
@@ -83,9 +76,8 @@ A tenant can have multiple CaaS clusters. Each cluster's storage is set up and t
 
 ## 6. Dependencies
 
-- **Tenant Storage Onboarding (OSAC-23):** The storage automation framework, two-stage model, and cluster watch are implemented and merged (osac-operator PR #299). This PRD extends the framework to act on CaaS cluster events. The Helm chart needs to be updated to expose the storage controller configuration.
+- **Tenant Storage Onboarding (OSAC-23):** The storage automation framework, two-stage model, and cluster watch are implemented and merged (osac-operator PR #299). This PRD extends the framework to act on CaaS cluster events.
 - **Playbook split (osac-aap PR #338):** Merged. Provides the independent setup and teardown actions required for CaaS cluster-scoped operations.
 - **VAST for CaaS (OSAC-1122):** The storage provider automation must support CaaS clusters as a provisioning target. Without this, the trigger fires but setup cannot complete.
 - **Tier API (OSAC-1110):** Not blocking. The system integrates when available, falls back to existing configuration otherwise.
 - **StorageBackend API (OSAC-1111):** Not blocking. In development (fulfillment-service PR #728). The system integrates when available, falls back to single implicit backend otherwise.
-

--- a/enhancements/caas-cluster-storage/prd.md
+++ b/enhancements/caas-cluster-storage/prd.md
@@ -8,7 +8,7 @@
 
 ## 1. Problem Statement
 
-CaaS tenant clusters are provisioned without persistent storage. When a ClusterOrder reaches Ready, the cluster has compute but no StorageClasses or CSI driver, so tenant workloads cannot create PVCs. The OSAC Storage Controller already handles backend setup (Stage 1) at tenant onboarding and cluster-side setup (Stage 2) for VMaaS, but it ignores ClusterOrder events. There is no automation connecting CaaS cluster readiness to storage installation.
+CaaS tenant clusters are provisioned without persistent storage. When a ClusterOrder reaches Ready, the cluster has compute but no StorageClasses or CSI driver, so tenant workloads cannot create PVCs. The OSAC Storage Controller already handles backend setup (Stage 1) at tenant onboarding and cluster-side setup (Stage 2) for VMaaS, but it ignores ClusterOrder events. There is no automation connecting CaaS cluster readiness to storage installation. This affects Tenant Admins and Tenant Users (who provision clusters and need to know when storage is ready) and Cloud Provider Admins (who monitor tenant-level storage status across clusters).
 
 ## 2. Goals and Non-Goals
 
@@ -20,12 +20,19 @@ CaaS tenant clusters are provisioned without persistent storage. When a ClusterO
 - Handle multiple CaaS clusters per tenant independently, each with its own storage readiness.
 - Integrate with the Storage Tier API (OSAC-1110) and StorageBackend API (OSAC-1111) when available, falling back to `STORAGE_TIERS` env var and single implicit backend otherwise.
 
-### 2.2 Non-Goals
+### 2.2 Success Metrics
+
+| Metric | Target | Baseline |
+|--------|--------|----------|
+| Time from ClusterOrder Ready to ClusterStorageReady=True | < 5 minutes | N/A (new feature) |
+
+### 2.3 Non-Goals
 
 - VAST provider CaaS changes (tenant-UID paths, RBAC credentials, `hcp_data_plane` target). Covered by OSAC-1122.
 - UI for storage.
 - Stage 1 (backend setup). Assumed complete before any CaaS cluster reaches Ready.
 - VMaaS cluster-side storage. Existing flow is unchanged.
+- Cloud Infrastructure Admin responsibilities (storage backend configuration, tier definitions). Covered by OSAC-1122 and OSAC-1110.
 
 ## 3. Requirements
 
@@ -40,14 +47,19 @@ CaaS tenant clusters are provisioned without persistent storage. When a ClusterO
 
 #### Storage Readiness
 
-- **FR-5:** The storage controller sets a `ClusterStorageReady` condition on the ClusterOrder CR: `True` when the AAP job succeeds and StorageClasses are confirmed, `False` with reason on failure.
-- **FR-6:** The storage controller records per-cluster detail in the Tenant CR's `status.clusterStorage` array (ClusterOrder name, readiness, reason).
+- **FR-5:** The storage controller sets a `ClusterStorageReady` condition on the ClusterOrder CR: `True` when the AAP job succeeds and all expected StorageClasses (derived from resolved tiers) are present on the CaaS cluster, `False` with reason on failure. This is the primary readiness signal for Tenant Admins and Tenant Users.
+- **FR-6:** The storage controller records per-cluster detail in the Tenant CR's `status.clusterStorage` array (ClusterOrder name, readiness, reason). This provides Cloud Provider Admins a tenant-level view of storage across all CaaS clusters.
 - **FR-7:** `kubectl get clusterorder -o wide` shows a `ClusterStorageReady` column.
 
 #### Teardown
 
 - **FR-8:** The storage controller places a finalizer on each ClusterOrder where storage was set up. On deletion, it triggers `osac-delete-tenant-cluster-storage` to remove StorageClasses, VolumeSnapshotClasses, and CSI Secret from the CaaS cluster. The finalizer is removed only after cleanup completes.
 - **FR-9:** After cleanup, the storage controller removes the ClusterOrder's entry from `status.clusterStorage` on the Tenant CR.
+
+#### API Surface
+
+- **ClusterOrder CR:** New `ClusterStorageReady` condition, `osac.openshift.io/storage` finalizer, `status.clusterStorageJobs` for AAP job tracking.
+- **Tenant CR:** New entries in `status.clusterStorage[]` array (field introduced by OSAC-23, extended here for CaaS clusters).
 
 ### 3.2 Non-Functional Requirements
 
@@ -78,6 +90,9 @@ CaaS tenant clusters are provisioned without persistent storage. When a ClusterO
 - [ ] Second ClusterOrder for the same tenant gets independent storage setup
 - [ ] Deleting one ClusterOrder does not affect other clusters
 
+**Security**
+- [ ] Controller logs and Kubernetes events from CaaS storage operations contain no credential values or Secret contents
+
 **Testing**
 - [ ] Unit tests with mock AAP providers cover trigger, readiness, teardown, and multi-cluster
 - [ ] (Stretch) E2E against live VAST + CaaS cluster
@@ -88,11 +103,12 @@ CaaS tenant clusters are provisioned without persistent storage. When a ClusterO
 - AAP playbooks accept `hcp_data_plane` and use the passed kubeconfig to target the CaaS cluster. Delivered by OSAC-1122.
 - VAST is the only storage provider for v0.1. A global VIP Pool is shared by all tenants.
 - The kubeconfig for a CaaS cluster is obtainable from the HostedControlPlane status via the ClusterOrder's cluster reference. Exact mechanism pending CaaS working group confirmation.
+- CaaS cluster nodes have network reachability to the VAST VIP pools for CSI volume operations. This is an infrastructure prerequisite managed by the Cloud Infrastructure Admin.
 
 ## 6. Dependencies
 
-- **OSAC-23 (Storage Controller):** Implemented and merged (osac-operator PR #299). This PRD extends the controller's ClusterOrder handling.
-- **osac-aap PR #338 (playbook split):** Under review. Required for CaaS setup and teardown to operate independently from backend operations.
+- **OSAC-23 (Storage Controller):** Implemented and merged (osac-operator PR #299). This PRD extends the controller's ClusterOrder handling. The osac-operator Helm chart needs to be updated to expose the storage controller enable flag (`controllers.storage`) and storage AAP template env vars.
+- **osac-aap PR #338 (playbook split):** Merged. Registers the four split AAP templates required for CaaS setup and teardown to operate independently from backend operations.
 - **OSAC-1122 (VAST for CaaS):** VAST provider must accept `hcp_data_plane` and use the passed kubeconfig. Without this, the trigger fires but the playbook cannot act.
 - **OSAC-1110 (Tier API):** Not blocking. Controller integrates when available, falls back to env var.
 - **OSAC-1111 (StorageBackend API):** Not blocking. In development (fulfillment-service PR #728). Controller integrates when available, falls back to single implicit backend.

--- a/enhancements/caas-cluster-storage/prd.md
+++ b/enhancements/caas-cluster-storage/prd.md
@@ -8,121 +8,84 @@
 
 ## 1. Problem Statement
 
-CaaS tenant clusters are provisioned without persistent storage. When a ClusterOrder reaches Ready, the cluster has compute but no StorageClasses or CSI driver, so tenant workloads cannot create PVCs. The OSAC Storage Controller already handles backend setup (Stage 1) at tenant onboarding and cluster-side setup (Stage 2) for VMaaS, but it ignores ClusterOrder events. There is no automation connecting CaaS cluster readiness to storage installation. This affects Tenant Admins and Tenant Users (who provision clusters and need to know when storage is ready) and Cloud Provider Admins (who monitor tenant-level storage status across clusters).
+CaaS tenant clusters are provisioned without persistent storage. When a cluster is ready, it has compute but no way for tenant workloads to create persistent volumes. Storage backend resources (credentials, views, quotas) are already provisioned during tenant onboarding, but nothing connects cluster readiness to storage installation on that cluster. Cloud Provider Admins have no visibility into whether a cluster's storage is ready, and Tenant Admins and Users cannot use persistent storage until someone manually configures it.
 
 ## 2. Goals and Non-Goals
 
 ### 2.1 Goals
 
-- Automatically install the CSI driver and per-tenant, per-tier StorageClasses on a CaaS cluster when it reaches Ready.
-- Track storage readiness on the ClusterOrder CR via a `ClusterStorageReady` condition, visible to Cloud Provider Admins.
-- Clean up cluster-side storage resources on CaaS cluster deletion. Leave backend resources (VAST tenant, views, quotas, hub Secret) intact for other clusters.
-- Handle multiple CaaS clusters per tenant independently, each with its own storage readiness.
-- Integrate with the Storage Tier API (OSAC-1110) and StorageBackend API (OSAC-1111) when available, falling back to `STORAGE_TIERS` env var and single implicit backend otherwise.
+- When a CaaS cluster is provisioned and ready, persistent storage (CSI driver and per-tenant, per-tier StorageClasses) is automatically available without manual configuration.
+- Cloud Provider Admins can see tenant-level storage status across all CaaS clusters.
+- Tenant Admins and Users can see whether their cluster's storage is ready.
+- When a CaaS cluster is deleted, storage resources on that cluster are cleaned up. Backend resources are left intact for other clusters.
+- Multiple CaaS clusters per tenant are handled independently, each with its own storage readiness.
+- When the Storage Tier API (OSAC-1110) and StorageBackend API (OSAC-1111) are available, the system uses them. Otherwise it falls back to the existing configuration.
 
 ### 2.2 Success Metrics
 
 | Metric | Target | Baseline |
 |--------|--------|----------|
-| Time from ClusterOrder Ready to ClusterStorageReady=True | < 5 minutes | N/A (new feature) |
+| Time from cluster ready to storage available | < 5 minutes | N/A (new feature) |
 
 ### 2.3 Non-Goals
 
-- VAST provider CaaS changes (tenant-UID paths, RBAC credentials, `hcp_data_plane` target). Covered by OSAC-1122.
-- UI for storage.
-- Stage 1 (backend setup). Assumed complete before any CaaS cluster reaches Ready.
-- VMaaS cluster-side storage. Existing flow is unchanged.
+- VAST provider CaaS-specific changes (storage path conventions, credential scoping, CaaS provisioning targets). Covered by OSAC-1122.
+- Storage UI.
+- Storage backend provisioning (runs during tenant onboarding, assumed complete before any cluster is ready).
+- VMaaS cluster-side storage changes. Existing flow is unchanged.
 - Cloud Infrastructure Admin responsibilities (storage backend configuration, tier definitions). Covered by OSAC-1122 and OSAC-1110.
 
-## 3. Requirements
+## 3. Capabilities
 
-### 3.1 Functional Requirements
+### Automatic Storage Setup
 
-#### CaaS Stage 2 Trigger
+When a CaaS cluster is provisioned and ready, the system automatically installs the CSI driver and creates per-tenant, per-tier StorageClasses on that cluster. The tenant's storage backend must be fully provisioned before this happens. No manual intervention is required from any persona.
 
-- **FR-1:** When a ClusterOrder reaches `phase=Ready` and the owning Tenant has `StorageBackendReady=True`, the storage controller invokes `osac-create-tenant-cluster-storage` with `provisioning_target=hcp_data_plane`.
-- **FR-2:** The storage controller passes the CaaS cluster's connection details (kubeconfig or equivalent) to the AAP playbook as extra vars. The playbook does not discover cluster access on its own.
-- **FR-3:** The storage controller resolves tiers from the Tier API (OSAC-1110) when available, falling back to `STORAGE_TIERS` env var.
-- **FR-4:** The storage controller discovers backends from the StorageBackend API (OSAC-1111) when available, falling back to the single implicit backend.
+The system determines which tiers and backends are available for the tenant. If the Tier API or StorageBackend API are deployed, they are used. Otherwise the system falls back to the existing tier and backend configuration.
 
-#### Storage Readiness
+### Storage Readiness Visibility
 
-- **FR-5:** The storage controller sets a `ClusterStorageReady` condition on the ClusterOrder CR: `True` when the AAP job succeeds and all expected StorageClasses (derived from resolved tiers) are present on the CaaS cluster, `False` with reason on failure. This is the primary readiness signal for Tenant Admins and Tenant Users.
-- **FR-6:** The storage controller records per-cluster detail in the Tenant CR's `status.clusterStorage` array (ClusterOrder name, readiness, reason). This provides Cloud Provider Admins a tenant-level view of storage across all CaaS clusters.
-- **FR-7:** `kubectl get clusterorder -o wide` shows a `ClusterStorageReady` column.
+As a Cloud Provider Admin, I can see the storage readiness of each tenant's CaaS clusters at the tenant level, so I can monitor onboarding progress and troubleshoot failures across tenants.
 
-#### Teardown
+As a Tenant Admin or Tenant User, I can see whether my specific CaaS cluster's storage is ready, so I know when I can start creating persistent volumes. If storage setup failed, I can see the reason.
 
-- **FR-8:** The storage controller places a finalizer on each ClusterOrder where storage was set up. On deletion, it triggers `osac-delete-tenant-cluster-storage` to remove StorageClasses, VolumeSnapshotClasses, and CSI Secret from the CaaS cluster. The finalizer is removed only after cleanup completes.
-- **FR-9:** After cleanup, the storage controller removes the ClusterOrder's entry from `status.clusterStorage` on the Tenant CR.
+### Cluster Deletion and Cleanup
 
-#### API Surface
+When a CaaS cluster is deleted, storage resources installed on that cluster (StorageClasses, CSI credentials, snapshot classes) are cleaned up. Backend resources (storage provider tenant, views, quotas, credentials on the hub) are not affected, because other clusters belonging to the same tenant may still use them.
 
-- **ClusterOrder CR:** New `ClusterStorageReady` condition, `osac.openshift.io/storage` finalizer, `status.clusterStorageJobs` for AAP job tracking.
-- **Tenant CR:** New entries in `status.clusterStorage[]` array (field introduced by OSAC-23, extended here for CaaS clusters).
+### Multi-Cluster Independence
 
-### 3.2 Non-Functional Requirements
+A tenant can have multiple CaaS clusters. Each cluster's storage is set up and torn down independently. Adding or removing a CaaS cluster does not affect storage on other clusters belonging to the same tenant.
 
-- **NFR-1:** The storage controller must not log or emit events containing credentials, Secret contents, or sensitive AAP parameters.
+### 3.1 Operational Expectations
+
+- Storage setup completes within 5 minutes of a CaaS cluster becoming ready.
+- Credentials and secrets are never exposed in user-visible error messages, status fields, or events.
 
 ## 4. Acceptance Criteria
 
-**Trigger**
-- [ ] ClusterOrder reaching Ready with `StorageBackendReady=True` triggers `osac-create-tenant-cluster-storage` with `provisioning_target=hcp_data_plane`
-- [ ] AAP playbook receives cluster connection details as extra vars
-- [ ] Tiers resolved from Tier API when available, `STORAGE_TIERS` env var otherwise
-- [ ] Backends discovered from StorageBackend API when available, single implicit backend otherwise
-
-**Readiness**
-- [ ] `ClusterStorageReady=True` on ClusterOrder when setup succeeds
-- [ ] `ClusterStorageReady=False` with reason on failure
-- [ ] `kubectl get clusterorder -o wide` shows storage readiness
-- [ ] Tenant CR `status.clusterStorage` has an entry per CaaS cluster
-
-**Teardown**
-- [ ] Finalizer placed on ClusterOrders where storage was set up
-- [ ] ClusterOrder deletion triggers `osac-delete-tenant-cluster-storage`
-- [ ] Finalizer removed only after cleanup completes
-- [ ] Backend resources unaffected by cluster deletion
-- [ ] `status.clusterStorage` entry removed after cleanup
-
-**Multi-Cluster**
-- [ ] Second ClusterOrder for the same tenant gets independent storage setup
-- [ ] Deleting one ClusterOrder does not affect other clusters
-
-**Security**
-- [ ] Controller logs and Kubernetes events from CaaS storage operations contain no credential values or Secret contents
-
-**Testing**
-- [ ] Unit tests with mock AAP providers cover trigger, readiness, teardown, and multi-cluster
-- [ ] (Stretch) E2E against live VAST + CaaS cluster
+- [ ] A tenant user can create a PVC on a newly provisioned CaaS cluster without manual storage configuration
+- [ ] A Cloud Provider Admin can see storage readiness status for each tenant's CaaS clusters
+- [ ] A Tenant Admin can see whether their specific CaaS cluster's storage is ready and the reason if it failed
+- [ ] When a CaaS cluster is deleted, storage resources on that cluster are cleaned up
+- [ ] Deleting one CaaS cluster does not affect storage on other clusters belonging to the same tenant
+- [ ] Backend resources are unaffected by CaaS cluster deletion
+- [ ] A second CaaS cluster for the same tenant gets independent storage setup
+- [ ] Unit tests cover setup, readiness, teardown, and multi-cluster scenarios
 
 ## 5. Assumptions
 
-- Stage 1 is always complete before a CaaS cluster reaches Ready. The controller does not handle a Ready ClusterOrder with an unprovisioned backend.
-- AAP playbooks accept `hcp_data_plane` and use the passed kubeconfig to target the CaaS cluster. Delivered by OSAC-1122.
+- Storage backend provisioning is always complete before a CaaS cluster reaches ready. The system does not handle a ready cluster with an unprovisioned backend.
+- The storage provider's automation accepts CaaS clusters as a target and uses the provided cluster credentials. This is delivered by OSAC-1122.
 - VAST is the only storage provider for v0.1. A global VIP Pool is shared by all tenants.
-- The kubeconfig for a CaaS cluster is obtainable from the HostedControlPlane status via the ClusterOrder's cluster reference. Exact mechanism pending CaaS working group confirmation.
-- CaaS cluster nodes have network reachability to the VAST VIP pools for CSI volume operations. This is an infrastructure prerequisite managed by the Cloud Infrastructure Admin.
+- Cluster credentials are obtainable from the cluster provisioning infrastructure via the HostedControlPlane kubeconfig Secret. Confirmed by the CaaS team.
+- CaaS cluster nodes have network reachability to storage VIP pools. This is an infrastructure prerequisite managed by the Cloud Infrastructure Admin.
 
 ## 6. Dependencies
 
-- **OSAC-23 (Storage Controller):** Implemented and merged (osac-operator PR #299). This PRD extends the controller's ClusterOrder handling. The osac-operator Helm chart needs to be updated to expose the storage controller enable flag (`controllers.storage`) and storage AAP template env vars.
-- **osac-aap PR #338 (playbook split):** Merged. Registers the four split AAP templates required for CaaS setup and teardown to operate independently from backend operations.
-- **OSAC-1122 (VAST for CaaS):** VAST provider must accept `hcp_data_plane` and use the passed kubeconfig. Without this, the trigger fires but the playbook cannot act.
-- **OSAC-1110 (Tier API):** Not blocking. Controller integrates when available, falls back to env var.
-- **OSAC-1111 (StorageBackend API):** Not blocking. In development (fulfillment-service PR #728). Controller integrates when available, falls back to single implicit backend.
+- **Tenant Storage Onboarding (OSAC-23):** The storage automation framework, two-stage model, and cluster watch are implemented and merged (osac-operator PR #299). This PRD extends the framework to act on CaaS cluster events. The Helm chart needs to be updated to expose the storage controller configuration.
+- **Playbook split (osac-aap PR #338):** Merged. Provides the independent setup and teardown actions required for CaaS cluster-scoped operations.
+- **VAST for CaaS (OSAC-1122):** The storage provider automation must support CaaS clusters as a provisioning target. Without this, the trigger fires but setup cannot complete.
+- **Tier API (OSAC-1110):** Not blocking. The system integrates when available, falls back to existing configuration otherwise.
+- **StorageBackend API (OSAC-1111):** Not blocking. In development (fulfillment-service PR #728). The system integrates when available, falls back to single implicit backend otherwise.
 
-## 7. Risks
-
-### 7.1 CaaS cluster kubeconfig access is unconfirmed
-
-- **Owner:** Akshay Nadkarni / CaaS working group
-- **Mitigation:** The expected path (`ClusterOrder.status.clusterReference` to `HostedControlPlane.status.kubeConfig`) is traceable through the HyperShift API. If the mechanism differs, only credential retrieval changes; trigger and condition logic are unaffected.
-
-## 8. Open Questions
-
-### 8.1 What credential should the storage controller use for CaaS cluster access?
-
-- **Owner:** CaaS working group
-- **Impact:** Affects FR-2. The expected path is `HostedControlPlane.status.kubeConfig`, but a scoped service account token may be preferred.

--- a/enhancements/caas-cluster-storage/prd.md
+++ b/enhancements/caas-cluster-storage/prd.md
@@ -1,0 +1,112 @@
+# CaaS Cluster Storage
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | Akshay Nadkarni |
+| Jira        | https://redhat.atlassian.net/browse/OSAC-1332 |
+| Date        | 2026-06-24 |
+
+## 1. Problem Statement
+
+CaaS tenant clusters are provisioned without persistent storage. When a ClusterOrder reaches Ready, the cluster has compute but no StorageClasses or CSI driver, so tenant workloads cannot create PVCs. The OSAC Storage Controller already handles backend setup (Stage 1) at tenant onboarding and cluster-side setup (Stage 2) for VMaaS, but it ignores ClusterOrder events. There is no automation connecting CaaS cluster readiness to storage installation.
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+- Automatically install the CSI driver and per-tenant, per-tier StorageClasses on a CaaS cluster when it reaches Ready.
+- Track storage readiness on the ClusterOrder CR via a `ClusterStorageReady` condition, visible to Cloud Provider Admins.
+- Clean up cluster-side storage resources on CaaS cluster deletion. Leave backend resources (VAST tenant, views, quotas, hub Secret) intact for other clusters.
+- Handle multiple CaaS clusters per tenant independently, each with its own storage readiness.
+- Integrate with the Storage Tier API (OSAC-1110) and StorageBackend API (OSAC-1111) when available, falling back to `STORAGE_TIERS` env var and single implicit backend otherwise.
+
+### 2.2 Non-Goals
+
+- VAST provider CaaS changes (tenant-UID paths, RBAC credentials, `hcp_data_plane` target). Covered by OSAC-1122.
+- UI for storage.
+- Stage 1 (backend setup). Assumed complete before any CaaS cluster reaches Ready.
+- VMaaS cluster-side storage. Existing flow is unchanged.
+
+## 3. Requirements
+
+### 3.1 Functional Requirements
+
+#### CaaS Stage 2 Trigger
+
+- **FR-1:** When a ClusterOrder reaches `phase=Ready` and the owning Tenant has `StorageBackendReady=True`, the storage controller invokes `osac-create-tenant-cluster-storage` with `provisioning_target=hcp_data_plane`.
+- **FR-2:** The storage controller passes the CaaS cluster's connection details (kubeconfig or equivalent) to the AAP playbook as extra vars. The playbook does not discover cluster access on its own.
+- **FR-3:** The storage controller resolves tiers from the Tier API (OSAC-1110) when available, falling back to `STORAGE_TIERS` env var.
+- **FR-4:** The storage controller discovers backends from the StorageBackend API (OSAC-1111) when available, falling back to the single implicit backend.
+
+#### Storage Readiness
+
+- **FR-5:** The storage controller sets a `ClusterStorageReady` condition on the ClusterOrder CR: `True` when the AAP job succeeds and StorageClasses are confirmed, `False` with reason on failure.
+- **FR-6:** The storage controller records per-cluster detail in the Tenant CR's `status.clusterStorage` array (ClusterOrder name, readiness, reason).
+- **FR-7:** `kubectl get clusterorder -o wide` shows a `ClusterStorageReady` column.
+
+#### Teardown
+
+- **FR-8:** The storage controller places a finalizer on each ClusterOrder where storage was set up. On deletion, it triggers `osac-delete-tenant-cluster-storage` to remove StorageClasses, VolumeSnapshotClasses, and CSI Secret from the CaaS cluster. The finalizer is removed only after cleanup completes.
+- **FR-9:** After cleanup, the storage controller removes the ClusterOrder's entry from `status.clusterStorage` on the Tenant CR.
+
+### 3.2 Non-Functional Requirements
+
+- **NFR-1:** The storage controller must not log or emit events containing credentials, Secret contents, or sensitive AAP parameters.
+
+## 4. Acceptance Criteria
+
+**Trigger**
+- [ ] ClusterOrder reaching Ready with `StorageBackendReady=True` triggers `osac-create-tenant-cluster-storage` with `provisioning_target=hcp_data_plane`
+- [ ] AAP playbook receives cluster connection details as extra vars
+- [ ] Tiers resolved from Tier API when available, `STORAGE_TIERS` env var otherwise
+- [ ] Backends discovered from StorageBackend API when available, single implicit backend otherwise
+
+**Readiness**
+- [ ] `ClusterStorageReady=True` on ClusterOrder when setup succeeds
+- [ ] `ClusterStorageReady=False` with reason on failure
+- [ ] `kubectl get clusterorder -o wide` shows storage readiness
+- [ ] Tenant CR `status.clusterStorage` has an entry per CaaS cluster
+
+**Teardown**
+- [ ] Finalizer placed on ClusterOrders where storage was set up
+- [ ] ClusterOrder deletion triggers `osac-delete-tenant-cluster-storage`
+- [ ] Finalizer removed only after cleanup completes
+- [ ] Backend resources unaffected by cluster deletion
+- [ ] `status.clusterStorage` entry removed after cleanup
+
+**Multi-Cluster**
+- [ ] Second ClusterOrder for the same tenant gets independent storage setup
+- [ ] Deleting one ClusterOrder does not affect other clusters
+
+**Testing**
+- [ ] Unit tests with mock AAP providers cover trigger, readiness, teardown, and multi-cluster
+- [ ] (Stretch) E2E against live VAST + CaaS cluster
+
+## 5. Assumptions
+
+- Stage 1 is always complete before a CaaS cluster reaches Ready. The controller does not handle a Ready ClusterOrder with an unprovisioned backend.
+- AAP playbooks accept `hcp_data_plane` and use the passed kubeconfig to target the CaaS cluster. Delivered by OSAC-1122.
+- VAST is the only storage provider for v0.1. A global VIP Pool is shared by all tenants.
+- The kubeconfig for a CaaS cluster is obtainable from the HostedControlPlane status via the ClusterOrder's cluster reference. Exact mechanism pending CaaS working group confirmation.
+
+## 6. Dependencies
+
+- **OSAC-23 (Storage Controller):** Implemented and merged (osac-operator PR #299). This PRD extends the controller's ClusterOrder handling.
+- **osac-aap PR #338 (playbook split):** Under review. Required for CaaS setup and teardown to operate independently from backend operations.
+- **OSAC-1122 (VAST for CaaS):** VAST provider must accept `hcp_data_plane` and use the passed kubeconfig. Without this, the trigger fires but the playbook cannot act.
+- **OSAC-1110 (Tier API):** Not blocking. Controller integrates when available, falls back to env var.
+- **OSAC-1111 (StorageBackend API):** Not blocking. In development (fulfillment-service PR #728). Controller integrates when available, falls back to single implicit backend.
+
+## 7. Risks
+
+### 7.1 CaaS cluster kubeconfig access is unconfirmed
+
+- **Owner:** Akshay Nadkarni / CaaS working group
+- **Mitigation:** The expected path (`ClusterOrder.status.clusterReference` to `HostedControlPlane.status.kubeConfig`) is traceable through the HyperShift API. If the mechanism differs, only credential retrieval changes; trigger and condition logic are unaffected.
+
+## 8. Open Questions
+
+### 8.1 What credential should the storage controller use for CaaS cluster access?
+
+- **Owner:** CaaS working group
+- **Impact:** Affects FR-2. The expected path is `HostedControlPlane.status.kubeConfig`, but a scoped service account token may be preferred.

--- a/enhancements/caas-cluster-storage/prd.md
+++ b/enhancements/caas-cluster-storage/prd.md
@@ -23,7 +23,7 @@ CaaS tenant clusters are provisioned without persistent storage. When a cluster 
 
 ### 2.2 Non-Goals
 
-- VAST provider CaaS-specific changes (storage path conventions, credential scoping, CaaS provisioning targets). Covered by OSAC-1122.
+- Making the storage provider CaaS-ready. Covered by OSAC-1122.
 - Storage UI.
 - Storage backend provisioning (runs during tenant onboarding, assumed complete before any cluster is ready).
 - VMaaS cluster-side storage changes. Existing flow is unchanged.
@@ -45,7 +45,7 @@ As a Tenant Admin or Tenant User, I can see whether my specific CaaS cluster's s
 
 ### Cluster Deletion and Cleanup
 
-When a CaaS cluster is deleted, storage resources installed on that cluster (StorageClasses, CSI credentials, snapshot classes) are cleaned up. Backend resources (storage provider tenant, views, quotas, credentials on the hub) are not affected, because other clusters belonging to the same tenant may still use them.
+When a CaaS cluster is deleted, storage resources installed on that cluster are cleaned up. Backend resources shared across the tenant's clusters are not affected, because other clusters may still use them.
 
 ### Multi-Cluster Independence
 
@@ -70,14 +70,14 @@ A tenant can have multiple CaaS clusters. Each cluster's storage is set up and t
 
 - Storage backend provisioning is always complete before a CaaS cluster reaches ready. The system does not handle a ready cluster with an unprovisioned backend.
 - The storage provider's automation accepts CaaS clusters as a target and uses the provided cluster credentials. This is delivered by OSAC-1122.
-- VAST is the only storage provider for v0.1. A global VIP Pool is shared by all tenants.
-- Cluster credentials are obtainable from the cluster provisioning infrastructure via the HostedControlPlane kubeconfig Secret. Confirmed by the CaaS team.
-- CaaS cluster nodes have network reachability to storage VIP pools. This is an infrastructure prerequisite managed by the Cloud Infrastructure Admin.
+- VAST is the only storage provider for v0.1.
+- Cluster credentials are obtainable from the cluster provisioning infrastructure. Confirmed by the CaaS team.
+- CaaS cluster nodes have network reachability to the storage backend. This is an infrastructure prerequisite managed by the Cloud Infrastructure Admin.
 
 ## 6. Dependencies
 
-- **Tenant Storage Onboarding (OSAC-23):** The storage automation framework, two-stage model, and cluster watch are implemented and merged (osac-operator PR #299). This PRD extends the framework to act on CaaS cluster events.
-- **Playbook split (osac-aap PR #338):** Merged. Provides the independent setup and teardown actions required for CaaS cluster-scoped operations.
-- **VAST for CaaS (OSAC-1122):** The storage provider automation must support CaaS clusters as a provisioning target. Without this, the trigger fires but setup cannot complete.
-- **Tier API (OSAC-1110):** Not blocking. The system integrates when available, falls back to existing configuration otherwise.
-- **StorageBackend API (OSAC-1111):** Not blocking. In development (fulfillment-service PR #728). The system integrates when available, falls back to single implicit backend otherwise.
+- **Tenant Storage Onboarding (OSAC-23):** Merged. Provides the storage automation framework that this PRD extends for CaaS clusters.
+- **Playbook split (osac-aap PR #338):** Merged. Provides independent setup and teardown actions required for per-cluster operations.
+- **VAST for CaaS (OSAC-1122):** In progress. The storage provider must support CaaS clusters as a target. Required for end-to-end functionality.
+- **Tier API (OSAC-1110):** In progress. Not blocking. The system integrates when available, falls back to existing configuration.
+- **StorageBackend API (OSAC-1111):** In progress. Not blocking. The system integrates when available, falls back to single implicit backend.


### PR DESCRIPTION
## PRD: CaaS Cluster Storage

**Feature:** https://redhat.atlassian.net/browse/OSAC-1332
**Epic:** https://redhat.atlassian.net/browse/OSAC-1123

### Summary

PRD for enabling persistent storage on CaaS tenant clusters. When a CaaS cluster becomes ready, storage is automatically provisioned so tenants can create persistent volumes using StorageClasses to select storage tiers. Storage readiness is visible to tenants and cloud admins, and storage resources are cleaned up on cluster deletion.

### Requesting Review On

- User story completeness: do the stories capture what we won't ship without?
- Scope boundary between this PRD and storage provider CaaS support
- Assumptions: anything missing or incorrect?

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a product requirements document for CaaS Cluster Storage.
  * Defines automatic persistent storage setup when CaaS clusters reach readiness, with tenant and cloud-admin visibility into readiness and failure reasons.
  * Covers StorageClass tier selection, multi-cluster independence, and cluster deletion cleanup behavior while preserving shared backend resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->