### PR TITLE
PRD OSAC-1425: Align with design feedback from batzionb

### DIFF
--- a/enhancements/networking-ui-vmaas-scope/prd.md
+++ b/enhancements/networking-ui-vmaas-scope/prd.md
@@ -28,9 +28,9 @@ Tenant users and tenant admins currently lack a dedicated UI for managing networ
 
 - **FR-1:** The UI must provide a VirtualNetworks list page (`/networking/virtual-networks`) displaying all VirtualNetworks owned by the tenant with columns for Name, IPv4 CIDR, Subnets count, and Status
 - **FR-2:** The VirtualNetworks list page must support filtering by Status, sorting by Name/Status, and searching by Name
-- **FR-3:** The UI must provide a "Create virtual network" action that opens a side panel form with fields for Name (required, DNS-valid, unique within tenant), IPv4 CIDR (required, /16 to /24 range), and IPv6 CIDR (optional). NetworkClass is assigned automatically by the platform and is not exposed to tenant users.
-- **FR-4:** The Create VirtualNetwork form must validate inputs inline (show validation errors below each field) and disable the Create button until all required fields are valid
-- **FR-5:** After successful VirtualNetwork creation, the UI must close the form, refresh the list, show a success toast notification, and display the new VN with "Provisioning" status
+- **FR-3:** The UI must provide a "Create virtual network" action that opens a modal form with fields for Name (required, DNS-valid, unique within tenant), IPv4 CIDR (required, /16 to /24 range), and IPv6 CIDR (optional). NetworkClass is assigned automatically by the platform and is not exposed to tenant users.
+- **FR-4:** The Create VirtualNetwork form must validate inputs inline (show validation errors below each field after blur or submit attempt) and keep the Create button enabled (following VM wizard pattern). On submit with invalid fields, highlight validation errors and show an inline validation alert.
+- **FR-5:** After successful VirtualNetwork creation, the UI must close the modal, navigate to the VirtualNetwork detail page (`/networking/virtual-networks/{id}`), and display the VN with "Provisioning" status
 - **FR-6:** The UI must provide a VirtualNetwork detail page (`/networking/virtual-networks/:id`) showing the VN name as page title, breadcrumb navigation, status badge, IPv4 CIDR (and IPv6 CIDR if configured) as key properties, and a Delete action in the header
 - **FR-7:** The VirtualNetwork detail page must display three tabs: Subnets (default), Security Groups, and Details
 - **FR-8:** The UI must block deletion of a VirtualNetwork if it has subnets or security groups, showing an error message directing the user to delete child resources first
@@ -38,7 +38,7 @@ Tenant users and tenant admins currently lack a dedicated UI for managing networ
 #### Subnets
 
 - **FR-9:** The Subnets tab on the VirtualNetwork detail page must display all subnets belonging to that VN in a table with columns for Name, CIDR, and Status
-- **FR-10:** The Subnets tab must provide a "Create subnet" action that opens a side panel form with the parent VN pre-selected and fields for Name (required, DNS-valid) and CIDR (required, must be within parent VN CIDR, must not overlap existing subnets)
+- **FR-10:** The Subnets tab must provide a "Create subnet" action that opens a modal form with the parent VN pre-selected and fields for Name (required, DNS-valid) and CIDR (required, must be within parent VN CIDR, must not overlap existing subnets). Create button stays enabled; validation errors highlighted on submit if present.
 - **FR-11:** The Create Subnet form must show the parent VN CIDR as context and display existing subnet CIDRs to help users select a non-overlapping range
 - **FR-12:** Clicking on a subnet name must show subnet metadata and a list of attached resources (compute instances) in a side drawer
 - **FR-13:** Subnets must not have their own top-level sidebar entry—they are managed exclusively from the VirtualNetwork detail page
@@ -48,7 +48,7 @@ Tenant users and tenant admins currently lack a dedicated UI for managing networ
 
 - **FR-15:** The UI must provide a SecurityGroups list page (`/networking/security-groups`) displaying all SecurityGroups across all VirtualNetworks with columns for Name, Virtual Network (link to VN detail), Inbound Rules count, Outbound Rules count, and Status
 - **FR-16:** The SecurityGroups list page must support filtering by Virtual Network and Status, and searching by Name
-- **FR-17:** The UI must provide a "Create security group" action (available from both the SG list page and the VN detail Security Groups tab) that opens a side panel form with fields for Virtual Network (required dropdown, pre-selected if triggered from VN detail), Name (required, DNS-valid), and expandable Inbound/Outbound Rules sections
+- **FR-17:** The UI must provide a "Create security group" action (available from both the SG list page and the VN detail Security Groups tab) that opens a modal form with fields for Virtual Network (required dropdown, pre-selected if triggered from VN detail), Name (required, DNS-valid), and expandable Inbound/Outbound Rules sections. Create button stays enabled; validation errors highlighted on submit if present.
 - **FR-18:** The Create SecurityGroup form must allow users to add multiple inbound and outbound rules inline, with each rule having fields for Protocol (dropdown: TCP/UDP/ICMP/All), Port Range (text input, disabled for ICMP), and Source/Destination CIDR (text with CIDR validation)
 - **FR-19:** The UI must provide a SecurityGroup detail page (`/networking/security-groups/:id`) with tabs for Inbound Rules, Outbound Rules, and Details
 - **FR-20:** The Inbound Rules and Outbound Rules tabs must display rules in a table (columns: Protocol, Port Range, Source/Destination CIDR) with "Add Rule" action and row-level Edit/Delete actions. Rule edits use `PATCH /api/fulfillment/v1/security_groups/{id}` to replace the full rule set (the API does not support individual rule-level endpoints)
@@ -72,12 +72,12 @@ Tenant users and tenant admins currently lack a dedicated UI for managing networ
 #### VMaaS Wizard Integration
 
 - **FR-31:** The VM creation wizard (`/vms/create/:catalogItemId`) must include a Network Configuration step after basic VM settings (name, SSH key, etc.) with sections for Network Attachment and Public IP (optional)
-- **FR-32:** The Network Attachment section must provide fields for Virtual Network (required dropdown showing all tenant VNs with name and CIDR, with "Create new VN" link), Subnet (required dropdown filtered to selected VN, showing CIDR, with "Create new Subnet" link), and Security Groups (optional multi-select checkboxes showing SGs scoped to selected VN with rule count summary, with "Create new Security Group" link)
-- **FR-33:** When a user clicks "Create new VN" from the wizard, the UI must open the Create VN side panel that overlays the wizard—after VN creation, the new VN must be auto-selected in the wizard
+- **FR-32:** The Network Attachment section must provide fields for Virtual Network (required dropdown showing all tenant VNs with name and CIDR, with "Create new VN" link), Subnet (required dropdown filtered to selected VN, showing CIDR), and Security Groups (optional multi-select with chips showing SGs scoped to selected VN with rule count summary). Note: Subnet and SecurityGroup selection controls already exist in `VmNetworkingStep`; only inline VirtualNetwork creation is added.
+- **FR-33:** When a user clicks "Create new VN" from the wizard, the UI must open the Create VN modal that overlays the wizard—after VN creation, the new VN must be auto-selected in the wizard
 - **FR-34:** The wizard's Public IP section must provide a checkbox "Allocate Public IP" and an IP Family dropdown (IPv4/IPv6). When checked, a PublicIP is automatically allocated from an available pool based on the selected IP family and attached during VM creation
 - **FR-35:** The wizard must enforce that VirtualNetwork is required (block VM creation without network attachment), Subnet is required, and show a warning if no Security Groups are selected ("No security groups selected. Your VM will have no firewall rules.")
 - **FR-36:** The wizard must implement smart defaults: if the tenant has exactly one VN auto-select it, if the selected VN has exactly one subnet auto-select it, if the selected VN has exactly one SG pre-check it, if the tenant has no existing PublicIPs, pre-check "Allocate Public IP" checkbox and default IP Family to IPv4
-- **FR-37:** If no VNs exist when the wizard reaches the Network Configuration step, the UI must show a prominent message "You need to create a virtual network before provisioning a VM" with a "Create Virtual Network" button that opens the inline Create VN side panel (see FR-33) with automatic return to the wizard after creation
+- **FR-37:** If no VNs exist when the wizard reaches the Network Configuration step, the UI must show a prominent message "You need to create a virtual network before provisioning a VM" with a "Create Virtual Network" button that opens the inline Create VN modal (see FR-33) with automatic return to the wizard after creation
 
 #### Error States and Edge Cases
 
@@ -95,15 +95,15 @@ Tenant users and tenant admins currently lack a dedicated UI for managing networ
 - **NFR-1:** The UI must be built with React 19 and TypeScript using the PatternFly 6 design system (Red Hat design system)
 - **NFR-2:** The UI must use react-router-dom v7 for routing, TanStack Query (React Query) for data fetching, and Connect-ES for gRPC-Web client integration
 - **NFR-3:** The UI must follow the file structure pattern: list pages in `libs/ui-components/src/pages/networking/`, detail pages in the same directory, table/form components in `libs/ui-components/src/components/networking/`, and TanStack Query hooks in `libs/ui-components/src/api/v1/`
-- **NFR-4:** The UI must use PatternFly components: PageSection/Title/Text for page layout, Table/Thead/Tr/Th/Tbody/Td for tables, Toolbar/ToolbarContent/ToolbarItem for search/filter toolbars, Form/FormGroup/TextInput/FormSelect for forms, DrawerPanelContent for side panels, Modal for confirmations, Label for status badges, EmptyState for empty states, Tabs/Tab for detail pages, Breadcrumb/BreadcrumbItem for navigation, Wizard/WizardStep for the VM wizard
-- **NFR-5:** Status badges must use consistent colors: Ready (green pf-m-green), Provisioning (blue pf-m-blue with spinner), Failed (red pf-m-red), Deleting (orange pf-m-orange), Available (green for PublicIPs), Attached (blue for PublicIPs)
+- **NFR-4:** The UI must use PatternFly components: PageSection/Title/Text for page layout, Table/Thead/Tr/Th/Tbody/Td for tables, Toolbar/ToolbarContent/ToolbarItem for search/filter toolbars, Form/FormGroup/TextInput/FormSelect for forms, Modal for create forms and confirmations, ResourceStatusLabel for status badges (with resource-specific wrappers like VirtualNetworkStatusLabel), EmptyState for empty states, Tabs/Tab for detail pages, Breadcrumb/BreadcrumbItem for navigation, Wizard/WizardStep for the VM wizard
+- **NFR-5:** Status badges must use ResourceStatusLabel component with resource-specific wrappers (VirtualNetworkStatusLabel, SecurityGroupStatusLabel, PublicIPStatusLabel) that map API states to StatusKind: PENDING→StatusKind.InProgress (blue, spinner), READY→StatusKind.Success (green), FAILED→StatusKind.Danger (red), DELETING→StatusKind.InProgress (blue, spinner), AVAILABLE→StatusKind.Success (green, PublicIPs), ATTACHED→StatusKind.Info (blue, PublicIPs)
 - **NFR-6:** Tables must be responsive using PatternFly's responsive table breakpoints—on small screens, use compound expansion to show row details instead of navigating to a detail page
-- **NFR-7:** Side panels (create forms) must become full-width drawers on mobile, and the sidebar must remain collapsible as in the current OSAC UI
-- **NFR-8:** All form inputs must have associated labels (PatternFly FormGroup handles this), status badges must have aria-labels (include text like "Status: Ready," not just color), table row actions must be keyboard-navigable, modal focus must be trapped (PatternFly Modal handles this), status changes must be announced via aria-live regions, and CIDR inputs must have helper text explaining the expected format
-- **NFR-9:** The UI must handle at least 100 VirtualNetworks, 500 Subnets, 200 SecurityGroups, and 1000 PublicIPs per tenant with acceptable performance—pagination should be enforced when counts exceed these thresholds
+- **NFR-7:** Create forms must use PatternFly Modal on all screen sizes (consistent with PublicIPAllocateModal and VM wizard pattern), and the sidebar must remain collapsible as in the current OSAC UI
+- **NFR-8:** All form inputs must have associated labels (PatternFly FormGroup handles this), status badges must use ResourceStatusLabel which handles aria-labels automatically, table row actions must be keyboard-navigable, modal focus must be trapped (PatternFly Modal handles this), status changes must be announced via aria-live regions, and CIDR inputs must have helper text explaining the expected format
+- **NFR-9:** Pagination is out of scope for this feature. Existing osac-ui list tables (VMs, clusters, catalog) do not use pagination; networking list pages follow the same non-paginated pattern. Table pagination should be tracked as a separate Jira to implement holistically for all list pages.
 ## 4. Acceptance Criteria
 - [ ] A tenant user can navigate to Networking > Virtual Networks from the sidebar and see a list of all their VirtualNetworks with Name, IPv4 CIDR, Subnets count, and Status columns
-- [ ] A tenant user can click "Create virtual network" and successfully create a VN by filling in Name and IPv4 CIDR fields with inline validation
+- [ ] A tenant user can click "Create virtual network", fill in Name and IPv4 CIDR fields with inline validation (Create button stays enabled, errors highlighted on submit), and after successful creation, navigate to the VN detail page showing "Provisioning" status
 - [ ] A tenant user can click on a VirtualNetwork name to see the detail page with Subnets, Security Groups, and Details tabs
 - [ ] A tenant user can create a Subnet from the Subnets tab with the parent VN pre-selected, and the form validates that the subnet CIDR is within the parent VN CIDR and does not overlap existing subnets
 - [ ] A tenant user can view all SecurityGroups across all VNs from the Networking > Security Groups page, filtered by VirtualNetwork
@@ -112,8 +112,8 @@ Tenant users and tenant admins currently lack a dedicated UI for managing networ
 - [ ] A tenant user can allocate a PublicIP from the Networking > Public IPs page by selecting a pool and providing a name
 - [ ] A tenant user can see Attach and Detach actions for PublicIPs—Attach shows a searchable list of VMs, Detach shows a confirmation modal
 - [ ] A new tenant creating their first VM sees "You need to create a virtual network before provisioning a VM" when reaching the Network Configuration step in the VM wizard
-- [ ] A new tenant can click "Create Virtual Network" from the wizard, create a VN inline (side panel overlay), and the new VN is auto-selected in the wizard after creation
-- [ ] A new tenant can create Subnets and SecurityGroups inline from the wizard using "Create new Subnet" and "Create new Security Group" links, with the current VN pre-selected
+- [ ] A new tenant can click "Create Virtual Network" from the wizard, create a VN inline (modal overlay), and the new VN is auto-selected in the wizard after creation
+- [ ] The wizard's subnet dropdown and security groups multi-select (with chips) work as existing controls in `VmNetworkingStep`—only VirtualNetwork inline creation is added
 - [ ] A returning tenant with one VN, one Subnet, and one SG sees all three auto-selected in the VM wizard Network Configuration step
 - [ ] A new tenant creating their first VM has "Allocate Public IP" checkbox pre-checked and IP Family defaulted to IPv4 in the Network Configuration step
 - [ ] The wizard blocks VM creation if no VirtualNetwork is selected and shows a warning if no SecurityGroups are selected
@@ -123,8 +123,8 @@ Tenant users and tenant admins currently lack a dedicated UI for managing networ
 - [ ] Deletion of a Subnet is blocked if it has attached compute instances, with an error message
 - [ ] Deletion of a SecurityGroup is blocked if it is attached to compute instances, with an error message
 - [ ] Deletion of a PublicIP is blocked if it is currently attached to a resource
-- [ ] All forms validate inputs inline and disable the Create/Submit button until all required fields are valid
-- [ ] Status badges use correct colors (Ready=green, Provisioning=blue with spinner, Failed=red, Deleting=orange, Available=green for PublicIPs, Attached=blue for PublicIPs) and include aria-labels for accessibility
+- [ ] All forms validate inputs inline (errors shown after blur or submit attempt) and keep the Create/Submit button enabled (following VM wizard pattern). On submit with invalid fields, validation errors are highlighted.
+- [ ] Status badges use ResourceStatusLabel component with resource-specific wrappers (VirtualNetworkStatusLabel, SecurityGroupStatusLabel, PublicIPStatusLabel), rendering correct colors and aria-labels for accessibility
 ## 5. Assumptions
 - The OSAC UI codebase uses a pnpm monorepo structure with the UI components in `libs/ui-components/src/`
 - The fulfillment API endpoints listed in Section 3.1 (FR-43 to FR-44) are already implemented and stable, including PublicIP attach/detach operations (FR-27, FR-28, FR-35) which are available in the public API at `/api/fulfillment/v1/public_ip_attachments`


### PR DESCRIPTION
## Summary

Updates the PRD to align with design changes based on @batzionb's feedback on PR #84.

## Changes

### UX Patterns
- **Modals not side drawers**: VN/Subnet/SG create forms use PatternFly Modal (FR-3, FR-10, FR-17)
- **Validation UX**: Create button stays enabled, errors highlighted on submit (FR-4)
- **Post-create navigation**: Navigate to detail page after creation (FR-5)

### Wizard Integration
- **Clarified scope**: Subnet/SG selection already exist in VmNetworkingStep; only VN inline creation is added (FR-32, FR-33, FR-37)

### Status Badges
- **ResourceStatusLabel**: Use component with resource-specific wrappers (NFR-5)

### Pagination
- **Out of scope**: Removed pagination from NFRs (NFR-9) - track separately for all list pages

### Acceptance Criteria
- Updated to reflect modal UX, validation pattern, and navigation behavior

## Related
- Design PR: #84
- Jira: https://redhat.atlassian.net/browse/OSAC-1425
- All 5 Jira subtasks updated to match