### PR TITLE
NO-ISSUE: Fix terminology and add region to non-goals

### DIFF
--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -491,9 +491,10 @@ parent is deleted.
   with `osac.openshift.io/auto-provisioned: "true"`
 - If no ExternalIPPool has available capacity, the resource creation fails
   with a clear error
-- When `nat_gateway_mode=AUTO`, the system creates a NATGateway on the
-  resource's VirtualNetwork if one does not already exist; if one exists,
-  it is reused (one NATGateway per VN)
+- When `nat_gateway_mode=AUTO`, the system auto-selects an ExternalIP
+  from the best available pool and creates a NATGateway on the resource's
+  VirtualNetwork using that ExternalIP as the SNAT source; if a NATGateway
+  already exists on the VN, it is reused (one NATGateway per VN)
 
 ## Success Metrics
 

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -270,8 +270,6 @@ for VMs), which does not work for CaaS.
 - Load Balancer API
 - Internet Gateway API
 - Quota enforcement for networking resources
-- Region-scoped networking (region is not yet a fully defined concept in
-  OSAC — this design assumes a single-region deployment)
 
 ## Requirements
 

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -55,7 +55,7 @@ This section defines key terms used throughout this document.
     [BareMetal Instance API enhancement](/enhancements/baremetal-instance-api)).
 
 - **VirtualNetwork**: A tenant's isolated network environment with its own
-  address space (CIDR). Analogous to an AWS VPC or Azure VNet. Scoped to a
+  address space (CIDR). Analogous to a cloud VPC or VNet. Scoped to a
   region.
 
 - **Subnet**: A subdivision of a VirtualNetwork's IP address space. Resources
@@ -417,7 +417,7 @@ descriptions provided by the template.
 On first use, the system provisions a set of default networking resources
 (VirtualNetwork, Subnet, SecurityGroup) per tenant per region, eliminating
 the need for tenants to understand the networking resource model before
-creating their first resource. This follows the AWS Default VPC model
+creating their first resource. This follows a Default VPC model
 adapted for OSAC's single-region, fabric-first architecture.
 
 **Acceptance criteria:**

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -228,6 +228,17 @@ for VMs), which does not work for CaaS.
   clusters, or bare-metal servers for inbound access
 - As a tenant, I want to create a NATGateway for outbound access from my
   VirtualNetwork
+- As a tenant, I want to create a resource (VM, cluster, or bare-metal
+  server) without pre-creating networking resources, so that the system
+  provides sensible defaults and I can get started quickly
+- As a tenant, I want to create a resource with `--external-ip=auto` and
+  have it externally reachable in a single API call, without manually
+  creating ExternalIP and ExternalIPAttachment resources
+- As a tenant, I want to inspect and customize my default networking
+  resources (e.g., modify SecurityGroup rules) after they are auto-created
+- As a tenant, I want auto-provisioned ExternalIPs to be automatically
+  cleaned up when I delete the parent resource, so that I do not accumulate
+  orphaned resources
 
 ### CaaS-Specific Stories
 
@@ -237,6 +248,12 @@ for VMs), which does not work for CaaS.
   ingress endpoints before provisioning
 - As a tenant, I want my cluster to work in air-gapped environments using
   data-center-routable IPs
+- As a tenant, I want to create a Cluster with `--external-ip=auto` and
+  have the system automatically provision ExternalIPs for both the API
+  server and ingress endpoints before cluster provisioning begins
+- As a tenant, I want to create a Cluster with `--nat-gateway=auto` and
+  have the system automatically provision a NATGateway on the VirtualNetwork
+  so that cluster nodes have outbound connectivity without manual setup
 
 ### BMaaS-Specific Stories
 
@@ -259,6 +276,11 @@ for VMs), which does not work for CaaS.
 - As a provider, I want to add new networking managers by deploying a
   ConfigMap and an Ansible role
 - As a provider, I want to be able to provision ExternalIP pools for tenants
+- As a provider, I want to configure a default CIDR range and default
+  SecurityGroup rules per region, so that the system can auto-create
+  default networking resources for tenants on first use
+- As a provider, I want to designate a default ExternalIPPool per region,
+  so that tenants using `--external-ip=auto` do not need to specify a pool
 
 ## Non-Goals
 
@@ -388,6 +410,90 @@ descriptions provided by the template.
 - The same interface cannot appear in multiple attachments
 - All referenced subnets must belong to the same VirtualNetwork
 
+### Simplified Resource Creation
+
+#### R8: Default networking resources per tenant per region
+
+On first use, the system provisions a set of default networking resources
+(VirtualNetwork, Subnet, SecurityGroup) per tenant per region, eliminating
+the need for tenants to understand the networking resource model before
+creating their first resource. This follows the AWS Default VPC model
+adapted for OSAC's single-region, fabric-first architecture.
+
+**Acceptance criteria:**
+- When a resource is created without `network_attachments`, the system
+  resolves defaults from the resource's region
+- Default VirtualNetwork is created per tenant per region using the
+  provider-configured default CIDR on the NetworkClass
+- Default Subnet is created within the default VirtualNetwork (one per
+  region — OSAC has no availability zones)
+- Default SecurityGroup is created within the default VirtualNetwork with
+  provider-configured default rules
+- Default resources are labeled with `osac.openshift.io/default: "true"`
+  and are visible in List/Get operations
+- Default resources can be modified by the tenant (e.g., adding
+  SecurityGroup rules) but cannot be deleted while resources depend on them
+- If default resources already exist for the tenant in the region, they are
+  reused, not recreated
+- Creating custom VirtualNetworks does not affect default resources — both
+  coexist
+- Two CIDR modes are supported, configured per NetworkClass: `shared_cidr`
+  (default — all tenants receive the same CIDR range, fabric-level
+  isolation separates them) and `isolated_cidr` (each tenant gets a unique
+  CIDR slice from the provider's supernet)
+
+#### R9: Optional network_attachments for simplified resource creation
+
+The `network_attachments` field on ComputeInstance, Cluster, and
+BaremetalInstance is optional. When omitted, the system resolves defaults:
+default Subnet and default SecurityGroup for the resource's region.
+
+**Acceptance criteria:**
+- ComputeInstance, Cluster, and BaremetalInstance can be created without
+  specifying `network_attachments`
+- The system populates `network_attachments` using the default Subnet and
+  default SecurityGroup for the region
+- The resolved `network_attachments` are stored in the resource spec (the
+  resource spec is self-describing after creation)
+- If the resource is created with explicit `network_attachments`, no
+  defaults are applied
+- If defaults cannot be resolved (e.g., no defaults configured on the
+  region's NetworkClass), the create request fails with a clear error
+
+#### R10: Auto ExternalIP provisioning
+
+Resources can request automatic ExternalIP allocation at creation time. The
+system allocates an ExternalIP from the region's default ExternalIPPool,
+creates an ExternalIPAttachment, and establishes ownership so that
+auto-created resources are garbage-collected when the parent is deleted.
+
+**Acceptance criteria:**
+- ComputeInstance and BaremetalInstance support an `external_ip_mode` field
+  with values `NONE` (default) and `AUTO`
+- Cluster supports a `external_ip_mode` field with values `NONE`
+  (default), `AUTO_API`, `AUTO_INGRESS`, and `AUTO_ALL` (both API and
+  ingress)
+- All resource types support a `nat_gateway_mode` field with values `NONE`
+  (default) and `AUTO`
+- When `AUTO` is requested, the system creates an ExternalIP from the
+  region's default ExternalIPPool and an ExternalIPAttachment binding it to
+  the resource
+- For clusters with `AUTO_ALL`, two ExternalIPs and two
+  ExternalIPAttachments are created (one for API, one for ingress)
+- For clusters, ExternalIPs are allocated before provisioning is dispatched,
+  resolving the CaaS prerequisite ordering requirement
+- Auto-created ExternalIP and ExternalIPAttachment resources have an
+  owner-reference annotation pointing to the parent resource
+- When the parent resource is deleted, auto-created ExternalIPs and
+  ExternalIPAttachments are garbage-collected
+- Auto-created resources are visible in List/Get operations and are labeled
+  with `osac.openshift.io/auto-provisioned: "true"`
+- If the default ExternalIPPool has no available addresses or no default
+  pool exists for the region, the resource creation fails with a clear error
+- When `nat_gateway_mode=AUTO`, the system creates a NATGateway on the
+  resource's VirtualNetwork if one does not already exist; if one exists,
+  it is reused (one NATGateway per VN)
+
 ## Success Metrics
 
 - All three service types consume the same networking API (R3)
@@ -395,6 +501,10 @@ descriptions provided by the template.
 - A new manager can be added without modifying existing managers or the API (R6)
 - Tenant experience is uniform across service types — same resources, same
   workflow, same CLI patterns (R3, R4)
+- A tenant can create a reachable VM with a single API call, without
+  pre-creating any networking resources (R8, R9, R10)
+- A tenant can create a fully connected cluster (API + ingress + outbound)
+  with a single API call (R8, R9, R10)
 
 ## Technical Design
 

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -503,8 +503,8 @@ parent is deleted.
 - A new manager can be added without modifying existing managers or the API (R6)
 - Tenant experience is uniform across service types — same resources, same
   workflow, same CLI patterns (R3, R4)
-- A tenant can create a reachable VM with a single API call, without
-  pre-creating any networking resources (R8, R9, R10)
+- A tenant can create a reachable VM, bare-metal server, or cluster with a
+  single API call, without pre-creating any networking resources (R8, R9, R10)
 - A tenant can create a fully connected cluster (API + ingress + outbound)
   with a single API call (R8, R9, R10)
 

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -279,8 +279,9 @@ for VMs), which does not work for CaaS.
 - As a provider, I want to configure a default CIDR range and default
   SecurityGroup rules per region, so that the system can auto-create
   default networking resources for tenants on first use
-- As a provider, I want to designate a default ExternalIPPool per region,
-  so that tenants using `--external-ip=auto` do not need to specify a pool
+- As a provider, I want ExternalIPPools to be region-scoped, so that the
+  system can auto-select the best available pool when tenants use
+  `--external-ip=auto`
 
 ## Non-Goals
 
@@ -463,9 +464,10 @@ default Subnet and default SecurityGroup for the resource's region.
 #### R10: Auto ExternalIP provisioning
 
 Resources can request automatic ExternalIP allocation at creation time. The
-system allocates an ExternalIP from the region's default ExternalIPPool,
-creates an ExternalIPAttachment, and establishes ownership so that
-auto-created resources are garbage-collected when the parent is deleted.
+system auto-selects the READY ExternalIPPool in the region with the most
+available capacity, creates an ExternalIP and ExternalIPAttachment, and
+establishes ownership so that auto-created resources are garbage-collected
+when the parent is deleted.
 
 **Acceptance criteria:**
 - ComputeInstance and BaremetalInstance support an `external_ip_mode` field
@@ -475,9 +477,9 @@ auto-created resources are garbage-collected when the parent is deleted.
   ingress)
 - All resource types support a `nat_gateway_mode` field with values `NONE`
   (default) and `AUTO`
-- When `AUTO` is requested, the system creates an ExternalIP from the
-  region's default ExternalIPPool and an ExternalIPAttachment binding it to
-  the resource
+- When `AUTO` is requested, the system auto-selects the READY pool in the
+  region with the most available capacity, creates an ExternalIP and an
+  ExternalIPAttachment binding it to the resource
 - For clusters with `AUTO_ALL`, two ExternalIPs and two
   ExternalIPAttachments are created (one for API, one for ingress)
 - For clusters, ExternalIPs are allocated before provisioning is dispatched,
@@ -488,8 +490,8 @@ auto-created resources are garbage-collected when the parent is deleted.
   ExternalIPAttachments are garbage-collected
 - Auto-created resources are visible in List/Get operations and are labeled
   with `osac.openshift.io/auto-provisioned: "true"`
-- If the default ExternalIPPool has no available addresses or no default
-  pool exists for the region, the resource creation fails with a clear error
+- If no ExternalIPPool in the region has available capacity, the resource
+  creation fails with a clear error
 - When `nat_gateway_mode=AUTO`, the system creates a NATGateway on the
   resource's VirtualNetwork if one does not already exist; if one exists,
   it is reused (one NATGateway per VN)

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -414,25 +414,27 @@ descriptions provided by the template.
 
 #### R8: Default networking resources per tenant
 
-On first use, the system provisions a set of default networking resources
-(VirtualNetwork, Subnet, SecurityGroup) per tenant, eliminating the need
-for tenants to understand the networking resource model before creating
-their first resource.
+At tenant onboarding, the system provisions a set of default networking
+resources (VirtualNetwork, Subnet, SecurityGroup) per tenant, eliminating
+the need for tenants to understand the networking resource model before
+creating their first resource.
 
 **Acceptance criteria:**
-- When a resource is created without `network_attachments`, the system
-  resolves defaults for the tenant
+- Default VirtualNetwork, Subnet, and SecurityGroup are created at tenant
+  onboarding, before the tenant creates any resources
+- The tenant transitions to READY only after all default networking
+  resources are also READY
 - Default VirtualNetwork is created per tenant using the
   provider-configured default CIDR on the NetworkClass
 - Default Subnet is created within the default VirtualNetwork
 - Default SecurityGroup is created within the default VirtualNetwork with
   provider-configured default rules
+- When a resource is created without `network_attachments`, the system
+  resolves the tenant's defaults
 - Default resources are labeled with `osac.openshift.io/default: "true"`
   and are visible in List/Get operations
 - Default resources can be modified by the tenant (e.g., adding
   SecurityGroup rules) but cannot be deleted while resources depend on them
-- If default resources already exist for the tenant, they are reused, not
-  recreated
 - Creating custom VirtualNetworks does not affect default resources — both
   coexist
 - Two CIDR modes are supported, configured per NetworkClass: `shared_cidr`

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -37,13 +37,9 @@ This section defines key terms used throughout this document.
   SecurityGroups, ExternalIPs) and place workloads on them.
 
 - **Provider**: The cloud administrator who deploys and configures OSAC
-  infrastructure. Providers define regions, install networking managers,
-  configure NetworkClasses, and manage ExternalIPPools. Tenants do not see
+  infrastructure. Providers install networking managers, configure
+  NetworkClasses, and manage ExternalIPPools. Tenants do not see
   provider-level configuration.
-
-- **Region**: A management boundary representing a deployment location (e.g.,
-  a data center). Networking resources are scoped to a region. Each region has
-  its own networking infrastructure and manager configuration.
 
 - **Service Types**: The three workload types OSAC supports:
   - **VMaaS** (Virtual Machine as a Service): Provisions virtual machines.
@@ -55,8 +51,7 @@ This section defines key terms used throughout this document.
     [BareMetal Instance API enhancement](/enhancements/baremetal-instance-api)).
 
 - **VirtualNetwork**: A tenant's isolated network environment with its own
-  address space (CIDR). Analogous to a cloud VPC or VNet. Scoped to a
-  region.
+  address space (CIDR). Analogous to a cloud VPC or VNet.
 
 - **Subnet**: A subdivision of a VirtualNetwork's IP address space. Resources
   are attached to subnets to receive IP addresses and network connectivity.
@@ -81,18 +76,18 @@ This section defines key terms used throughout this document.
   egress but without a controlled source identity.
 
 - **NetworkClass**: A provider-configured resource that defines how networking
-  is implemented in a region. Specifies which fabric manager and K8s manager
-  handle networking for the region. In the current design, tenants select it
-  when creating a VirtualNetwork (this is one of the gaps — see #2).
+  is implemented. Specifies which fabric manager and K8s manager handle
+  networking. In the current design, tenants select it when creating a
+  VirtualNetwork (this is one of the gaps — see #2).
 
 - **Fabric Manager**: A single product (e.g., Netris, Neutron) that manages
-  all physical networking for a region: tenant isolation, ACLs, IP
-  allocation, DNAT, SNAT. The physical fabric is one infrastructure — one
-  controller manages it all.
+  all physical networking: tenant isolation, ACLs, IP allocation, DNAT,
+  SNAT. The physical fabric is one infrastructure — one controller manages
+  it all.
 
 - **K8s Manager**: Handles everything needed to make VMs part of the fabric:
   creates the K8s overlay and bridges it to the fabric segment. Only needed
-  for regions that host VMs.
+  for deployments that host VMs.
 
 - **Fabric**: The physical network infrastructure — switches, routers,
   gateways — that connects bare-metal servers and provides external
@@ -117,7 +112,7 @@ each service type to implement networking independently:
   A tenant running VMs, clusters, and bare-metal servers must use three
   different networking models.
 - **Providers** cannot swap network managers without API changes. Adding a
-  new fabric manager or changing the one for a region requires modifying the
+  new fabric manager or changing the active one requires modifying the
   fulfillment service and operator.
 
 The result is fragmented networking with no consistency, no reuse, and no
@@ -194,7 +189,7 @@ cluster. Bare-metal servers use physical VLANs configured on switches in the
 fabric. These are fundamentally different L2 domains. A K8s manager using
 LocalNet mode can bridge OVN to the physical fabric, making VMs first-class
 participants alongside BM servers. The current design does not address how
-VMs and bare-metal servers coexist in the same region, whether they can share
+VMs and bare-metal servers coexist in the same deployment, whether they can share
 a VirtualNetwork, or how traffic flows between them.
 
 ### 8. Air-gapped environments not considered
@@ -252,8 +247,8 @@ for VMs), which does not work for CaaS.
 
 ### Provider Stories
 
-- As a provider, I want to configure a fabric manager and K8s manager per
-  region without exposing implementation details to tenants
+- As a provider, I want to configure a fabric manager and K8s manager
+  without exposing implementation details to tenants
 - As a provider, I want to register new managers without modifying the API
   or the operator
 - As a provider, I want to add new networking managers by deploying a
@@ -298,7 +293,7 @@ fabric is the single source of truth for isolation across all resource types.
 
 The same subnet must be able to host VMs, BM servers, and cluster nodes.
 The tenant does not declare the resource type when creating a VirtualNetwork
-or Subnet. Multiple hosting clusters per region are supported — VMs on
+or Subnet. Multiple hosting clusters are supported — VMs on
 different hosting clusters share the same subnet via the fabric.
 
 **Acceptance criteria:**
@@ -356,8 +351,8 @@ The API must clearly separate inbound and outbound external access.
 
 #### R6: Pluggable managers with transparent selection
 
-Providers configure which fabric manager and K8s manager handle networking
-for a region. Tenants never choose networking managers — the system selects
+Providers configure which fabric manager and K8s manager handle networking.
+Tenants never choose networking managers — the system selects
 them based on the provider's NetworkClass configuration.
 
 **Acceptance criteria:**

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -277,11 +277,8 @@ for VMs), which does not work for CaaS.
   ConfigMap and an Ansible role
 - As a provider, I want to be able to provision ExternalIP pools for tenants
 - As a provider, I want to configure a default CIDR range and default
-  SecurityGroup rules per region, so that the system can auto-create
-  default networking resources for tenants on first use
-- As a provider, I want ExternalIPPools to be region-scoped, so that the
-  system can auto-select the best available pool when tenants use
-  `--external-ip=auto`
+  SecurityGroup rules, so that the system can auto-create default
+  networking resources for tenants on first use
 
 ## Non-Goals
 
@@ -413,29 +410,32 @@ descriptions provided by the template.
 
 ### Simplified Resource Creation
 
-#### R8: Default networking resources per tenant per region
+#### R8: Default networking resources per tenant
 
 On first use, the system provisions a set of default networking resources
-(VirtualNetwork, Subnet, SecurityGroup) per tenant per region, eliminating
-the need for tenants to understand the networking resource model before
-creating their first resource. This follows a Default VPC model
-adapted for OSAC's single-region, fabric-first architecture.
+(VirtualNetwork, Subnet, SecurityGroup) per tenant, eliminating the need
+for tenants to understand the networking resource model before creating
+their first resource.
+
+Note: region is not yet a fully defined concept in OSAC. When region
+support is implemented, default networking resources will be scoped per
+tenant per region. Until then, the design assumes a single-region
+deployment.
 
 **Acceptance criteria:**
 - When a resource is created without `network_attachments`, the system
-  resolves defaults from the resource's region
-- Default VirtualNetwork is created per tenant per region using the
+  resolves defaults for the tenant
+- Default VirtualNetwork is created per tenant using the
   provider-configured default CIDR on the NetworkClass
-- Default Subnet is created within the default VirtualNetwork (one per
-  region — OSAC has no availability zones)
+- Default Subnet is created within the default VirtualNetwork
 - Default SecurityGroup is created within the default VirtualNetwork with
   provider-configured default rules
 - Default resources are labeled with `osac.openshift.io/default: "true"`
   and are visible in List/Get operations
 - Default resources can be modified by the tenant (e.g., adding
   SecurityGroup rules) but cannot be deleted while resources depend on them
-- If default resources already exist for the tenant in the region, they are
-  reused, not recreated
+- If default resources already exist for the tenant, they are reused, not
+  recreated
 - Creating custom VirtualNetworks does not affect default resources — both
   coexist
 - Two CIDR modes are supported, configured per NetworkClass: `shared_cidr`
@@ -447,27 +447,27 @@ adapted for OSAC's single-region, fabric-first architecture.
 
 The `network_attachments` field on ComputeInstance, Cluster, and
 BaremetalInstance is optional. When omitted, the system resolves defaults:
-default Subnet and default SecurityGroup for the resource's region.
+default Subnet and default SecurityGroup for the tenant.
 
 **Acceptance criteria:**
 - ComputeInstance, Cluster, and BaremetalInstance can be created without
   specifying `network_attachments`
-- The system populates `network_attachments` using the default Subnet and
-  default SecurityGroup for the region
+- The system populates `network_attachments` using the tenant's default
+  Subnet and default SecurityGroup
 - The resolved `network_attachments` are stored in the resource spec (the
   resource spec is self-describing after creation)
 - If the resource is created with explicit `network_attachments`, no
   defaults are applied
 - If defaults cannot be resolved (e.g., no defaults configured on the
-  region's NetworkClass), the create request fails with a clear error
+  NetworkClass), the create request fails with a clear error
 
 #### R10: Auto ExternalIP provisioning
 
 Resources can request automatic ExternalIP allocation at creation time. The
-system auto-selects the READY ExternalIPPool in the region with the most
-available capacity, creates an ExternalIP and ExternalIPAttachment, and
-establishes ownership so that auto-created resources are garbage-collected
-when the parent is deleted.
+system auto-selects the READY ExternalIPPool with the most available
+capacity, creates an ExternalIP and ExternalIPAttachment, and establishes
+ownership so that auto-created resources are garbage-collected when the
+parent is deleted.
 
 **Acceptance criteria:**
 - ComputeInstance and BaremetalInstance support an `external_ip_mode` field
@@ -477,8 +477,8 @@ when the parent is deleted.
   ingress)
 - All resource types support a `nat_gateway_mode` field with values `NONE`
   (default) and `AUTO`
-- When `AUTO` is requested, the system auto-selects the READY pool in the
-  region with the most available capacity, creates an ExternalIP and an
+- When `AUTO` is requested, the system auto-selects the READY pool with
+  the most available capacity, creates an ExternalIP and an
   ExternalIPAttachment binding it to the resource
 - For clusters with `AUTO_ALL`, two ExternalIPs and two
   ExternalIPAttachments are created (one for API, one for ingress)
@@ -490,8 +490,8 @@ when the parent is deleted.
   ExternalIPAttachments are garbage-collected
 - Auto-created resources are visible in List/Get operations and are labeled
   with `osac.openshift.io/auto-provisioned: "true"`
-- If no ExternalIPPool in the region has available capacity, the resource
-  creation fails with a clear error
+- If no ExternalIPPool has available capacity, the resource creation fails
+  with a clear error
 - When `nat_gateway_mode=AUTO`, the system creates a NATGateway on the
   resource's VirtualNetwork if one does not already exist; if one exists,
   it is reused (one NATGateway per VN)

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -503,8 +503,8 @@ parent is deleted.
 - A new manager can be added without modifying existing managers or the API (R6)
 - Tenant experience is uniform across service types — same resources, same
   workflow, same CLI patterns (R3, R4)
-- A tenant can create a reachable VM, bare-metal server, or cluster with a
-  single API call, without pre-creating any networking resources (R8, R9, R10)
+- A tenant can create a reachable VM or bare-metal server with a single
+  API call, without pre-creating any networking resources (R8, R9, R10)
 - A tenant can create a fully connected cluster (API + ingress + outbound)
   with a single API call (R8, R9, R10)
 

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -503,8 +503,9 @@ parent is deleted.
 - A new manager can be added without modifying existing managers or the API (R6)
 - Tenant experience is uniform across service types — same resources, same
   workflow, same CLI patterns (R3, R4)
-- A tenant can create a reachable VM or bare-metal server with a single
-  API call, without pre-creating any networking resources (R8, R9, R10)
+- A tenant can create a fully connected VM or bare-metal server (inbound +
+  outbound) with a single API call, without pre-creating any networking
+  resources (R8, R9, R10)
 - A tenant can create a fully connected cluster (API + ingress + outbound)
   with a single API call (R8, R9, R10)
 

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -228,17 +228,6 @@ for VMs), which does not work for CaaS.
   clusters, or bare-metal servers for inbound access
 - As a tenant, I want to create a NATGateway for outbound access from my
   VirtualNetwork
-- As a tenant, I want to create a resource (VM, cluster, or bare-metal
-  server) without pre-creating networking resources, so that the system
-  provides sensible defaults and I can get started quickly
-- As a tenant, I want to create a resource with `--external-ip=auto` and
-  have it externally reachable in a single API call, without manually
-  creating ExternalIP and ExternalIPAttachment resources
-- As a tenant, I want to inspect and customize my default networking
-  resources (e.g., modify SecurityGroup rules) after they are auto-created
-- As a tenant, I want auto-provisioned ExternalIPs to be automatically
-  cleaned up when I delete the parent resource, so that I do not accumulate
-  orphaned resources
 
 ### CaaS-Specific Stories
 
@@ -248,12 +237,6 @@ for VMs), which does not work for CaaS.
   ingress endpoints before provisioning
 - As a tenant, I want my cluster to work in air-gapped environments using
   data-center-routable IPs
-- As a tenant, I want to create a Cluster with `--external-ip=auto` and
-  have the system automatically provision ExternalIPs for both the API
-  server and ingress endpoints before cluster provisioning begins
-- As a tenant, I want to create a Cluster with `--nat-gateway=auto` and
-  have the system automatically provision a NATGateway on the VirtualNetwork
-  so that cluster nodes have outbound connectivity without manual setup
 
 ### BMaaS-Specific Stories
 
@@ -276,9 +259,6 @@ for VMs), which does not work for CaaS.
 - As a provider, I want to add new networking managers by deploying a
   ConfigMap and an Ansible role
 - As a provider, I want to be able to provision ExternalIP pools for tenants
-- As a provider, I want to configure a default CIDR range and default
-  SecurityGroup rules, so that the system can auto-create default
-  networking resources for tenants on first use
 
 ## Non-Goals
 
@@ -410,92 +390,6 @@ descriptions provided by the template.
 - The same interface cannot appear in multiple attachments
 - All referenced subnets must belong to the same VirtualNetwork
 
-### Simplified Resource Creation
-
-#### R8: Default networking resources per tenant
-
-At tenant onboarding, the system provisions a set of default networking
-resources (VirtualNetwork, Subnet, SecurityGroup) per tenant, eliminating
-the need for tenants to understand the networking resource model before
-creating their first resource.
-
-**Acceptance criteria:**
-- Default VirtualNetwork, Subnet, and SecurityGroup are created at tenant
-  onboarding, before the tenant creates any resources
-- The tenant transitions to READY only after all default networking
-  resources are also READY
-- Default VirtualNetwork is created per tenant using the
-  provider-configured default CIDR on the NetworkClass
-- Default Subnet is created within the default VirtualNetwork
-- Default SecurityGroup is created within the default VirtualNetwork with
-  provider-configured default rules
-- When a resource is created without `network_attachments`, the system
-  resolves the tenant's defaults
-- Default resources are labeled with `osac.openshift.io/default: "true"`
-  and are visible in List/Get operations
-- Default resources can be modified by the tenant (e.g., adding
-  SecurityGroup rules) but cannot be deleted while resources depend on them
-- Creating custom VirtualNetworks does not affect default resources — both
-  coexist
-- Two CIDR modes are supported, configured per NetworkClass: `shared_cidr`
-  (default — all tenants receive the same CIDR range, fabric-level
-  isolation separates them) and `isolated_cidr` (each tenant gets a unique
-  CIDR slice from the provider's supernet)
-
-#### R9: Optional network_attachments for simplified resource creation
-
-The `network_attachments` field on ComputeInstance, Cluster, and
-BaremetalInstance is optional. When omitted, the system resolves defaults:
-default Subnet and default SecurityGroup for the tenant.
-
-**Acceptance criteria:**
-- ComputeInstance, Cluster, and BaremetalInstance can be created without
-  specifying `network_attachments`
-- The system populates `network_attachments` using the tenant's default
-  Subnet and default SecurityGroup
-- The resolved `network_attachments` are stored in the resource spec (the
-  resource spec is self-describing after creation)
-- If the resource is created with explicit `network_attachments`, no
-  defaults are applied
-- If defaults cannot be resolved (e.g., no defaults configured on the
-  NetworkClass), the create request fails with a clear error
-
-#### R10: Auto ExternalIP provisioning
-
-Resources can request automatic ExternalIP allocation at creation time. The
-system auto-selects the READY ExternalIPPool with the most available
-capacity, creates an ExternalIP and ExternalIPAttachment, and establishes
-ownership so that auto-created resources are garbage-collected when the
-parent is deleted.
-
-**Acceptance criteria:**
-- ComputeInstance and BaremetalInstance support an `external_ip_mode` field
-  with values `NONE` (default) and `AUTO`
-- Cluster supports a `external_ip_mode` field with values `NONE`
-  (default), `AUTO_API`, `AUTO_INGRESS`, and `AUTO_ALL` (both API and
-  ingress)
-- All resource types support a `nat_gateway_mode` field with values `NONE`
-  (default) and `AUTO`
-- When `AUTO` is requested, the system auto-selects the READY pool with
-  the most available capacity, creates an ExternalIP and an
-  ExternalIPAttachment binding it to the resource
-- For clusters with `AUTO_ALL`, two ExternalIPs and two
-  ExternalIPAttachments are created (one for API, one for ingress)
-- For clusters, ExternalIPs are allocated before provisioning is dispatched,
-  resolving the CaaS prerequisite ordering requirement
-- Auto-created ExternalIP and ExternalIPAttachment resources have an
-  owner-reference annotation pointing to the parent resource
-- When the parent resource is deleted, auto-created ExternalIPs and
-  ExternalIPAttachments are garbage-collected
-- Auto-created resources are visible in List/Get operations and are labeled
-  with `osac.openshift.io/auto-provisioned: "true"`
-- If no ExternalIPPool has available capacity, the resource creation fails
-  with a clear error
-- When `nat_gateway_mode=AUTO`, the system auto-selects an ExternalIP
-  from the best available pool and creates a NATGateway on the resource's
-  VirtualNetwork using that ExternalIP as the SNAT source; if a NATGateway
-  already exists on the VN, it is reused (one NATGateway per VN)
-
 ## Success Metrics
 
 - All three service types consume the same networking API (R3)
@@ -503,11 +397,6 @@ parent is deleted.
 - A new manager can be added without modifying existing managers or the API (R6)
 - Tenant experience is uniform across service types — same resources, same
   workflow, same CLI patterns (R3, R4)
-- A tenant can create a fully connected VM or bare-metal server (inbound +
-  outbound) with a single API call, without pre-creating any networking
-  resources (R8, R9, R10)
-- A tenant can create a fully connected cluster (API + ingress + outbound)
-  with a single API call (R8, R9, R10)
 
 ## Technical Design
 

--- a/enhancements/unified-networking-prd/README.md
+++ b/enhancements/unified-networking-prd/README.md
@@ -290,6 +290,8 @@ for VMs), which does not work for CaaS.
 - Load Balancer API
 - Internet Gateway API
 - Quota enforcement for networking resources
+- Region-scoped networking (region is not yet a fully defined concept in
+  OSAC — this design assumes a single-region deployment)
 
 ## Requirements
 
@@ -416,11 +418,6 @@ On first use, the system provisions a set of default networking resources
 (VirtualNetwork, Subnet, SecurityGroup) per tenant, eliminating the need
 for tenants to understand the networking resource model before creating
 their first resource.
-
-Note: region is not yet a fully defined concept in OSAC. When region
-support is implemented, default networking resources will be scoped per
-tenant per region. Until then, the design assumes a single-region
-deployment.
 
 **Acceptance criteria:**
 - When a resource is created without `network_attachments`, the system

--- a/enhancements/unified-networking/README.md
+++ b/enhancements/unified-networking/README.md
@@ -348,7 +348,7 @@ handles IP allocation — one pool serves all resource types.
 OSAC provisions a set of default networking resources per tenant per region
 on first use. This eliminates the need for tenants to understand the
 networking resource model before creating their first resource. The design
-follows the AWS Default VPC model adapted for OSAC's architecture — one
+follows a Default VPC model adapted for OSAC's architecture — one
 default VirtualNetwork per tenant per region, with one default Subnet and
 one default SecurityGroup (OSAC has no availability zones).
 

--- a/enhancements/unified-networking/README.md
+++ b/enhancements/unified-networking/README.md
@@ -343,6 +343,285 @@ The API and flow are identical regardless of the deployment topology.
 ExternalIPPools are provider-managed and region-scoped. The fabric manager
 handles IP allocation — one pool serves all resource types.
 
+### Default Networking Resources
+
+OSAC provisions a set of default networking resources per tenant per region
+on first use. This eliminates the need for tenants to understand the
+networking resource model before creating their first resource. The design
+follows the AWS Default VPC model adapted for OSAC's architecture — one
+default VirtualNetwork per tenant per region, with one default Subnet and
+one default SecurityGroup (OSAC has no availability zones).
+
+#### What Is Auto-Created
+
+For each (tenant, region) pair, on first use:
+
+1. **Default VirtualNetwork** — one per tenant per region
+2. **Default Subnet** — one within the default VN
+3. **Default SecurityGroup** — one within the default VN
+
+Default resources are created **lazily** — on the first resource creation
+request that omits `network_attachments` in a given region. They are not
+created eagerly at tenant onboarding. This avoids provisioning networking
+infrastructure in regions the tenant never uses.
+
+#### CIDR Allocation
+
+The provider configures a `defaults` block on the NetworkClass. Two CIDR
+modes are supported:
+
+- **`shared_cidr`** (default): All tenants receive the same default CIDR
+  range. This is the natural choice for OSAC's fabric-first model — tenants
+  are already isolated at the fabric level (separate VLANs/VRFs), so
+  overlapping IPs between tenants are not a problem. Simpler, no supernet
+  carving needed.
+
+- **`isolated_cidr`**: The system carves non-overlapping CIDR slices from
+  the supernet. Each tenant gets a unique prefix (e.g., /24) from the
+  provider's supernet. Used when the provider wants IP-level uniqueness in
+  addition to fabric-level isolation.
+
+#### NetworkClass Defaults Configuration
+
+The provider configures defaults on the NetworkClass at region setup:
+
+```yaml
+apiVersion: osac.openshift.io/v1alpha1
+kind: NetworkClass
+metadata:
+  name: moc-region-1
+spec:
+  region: moc-region-1
+  fabricManager: netris
+  k8sManager: cudn_localnet
+  defaults:
+    ipv4_cidr: "10.0.0.0/24"
+    cidr_mode: shared_cidr
+    security_group:
+      ingress:
+        - protocol: tcp
+          port_from: 22
+          port_to: 22
+          ipv4_cidr: "0.0.0.0/0"
+      egress:
+        - protocol: all
+          ipv4_cidr: "0.0.0.0/0"
+```
+
+For `isolated_cidr` mode, the provider specifies a supernet and prefix
+length instead:
+
+```yaml
+  defaults:
+    ipv4_supernet: "10.0.0.0/16"
+    tenant_prefix_length: 24
+    cidr_mode: isolated_cidr
+```
+
+When `defaults` is not set on the NetworkClass, creating a resource without
+`network_attachments` returns an error directing the tenant to specify
+networking explicitly or ask the provider to configure defaults.
+
+#### Default Resource Specs
+
+Default resources are regular OSAC resources. They appear in List/Get
+responses, can be modified by the tenant (e.g., adding SecurityGroup
+rules), and participate in standard lifecycle operations. The
+`osac.openshift.io/default: "true"` label identifies them as system-created
+defaults.
+
+**Default VirtualNetwork:**
+
+```yaml
+metadata:
+  name: default
+  tenant: <tenant-id>
+  labels:
+    osac.openshift.io/default: "true"
+spec:
+  region: <region>
+  ipv4_cidr: "10.0.0.0/24"
+```
+
+**Default Subnet:**
+
+```yaml
+metadata:
+  name: default
+  tenant: <tenant-id>
+  labels:
+    osac.openshift.io/default: "true"
+  annotations:
+    osac.openshift.io/owner-reference: <default-vn-id>
+spec:
+  virtual_network: <default-vn-id>
+  ipv4_cidr: "10.0.0.0/24"
+```
+
+**Default SecurityGroup:**
+
+```yaml
+metadata:
+  name: default
+  tenant: <tenant-id>
+  labels:
+    osac.openshift.io/default: "true"
+  annotations:
+    osac.openshift.io/owner-reference: <default-vn-id>
+spec:
+  virtual_network: <default-vn-id>
+  ingress:
+    - protocol: tcp
+      port_from: 22
+      port_to: 22
+      ipv4_cidr: "0.0.0.0/0"
+  egress:
+    - protocol: all
+      ipv4_cidr: "0.0.0.0/0"
+```
+
+#### Coexistence with Custom VNs
+
+Creating custom VirtualNetworks does not affect default resources. A tenant
+can have both default and custom VNs in the same region. Resources created
+without `network_attachments` always use the defaults. Resources created
+with explicit `network_attachments` use the specified resources — no
+defaults are applied.
+
+Default resources cannot be deleted while any resource depends on them
+(standard referential integrity).
+
+### Simplified Resource Creation
+
+Two mechanisms reduce the number of API calls needed to create a reachable
+resource from 6+ to 1:
+
+1. **Optional `network_attachments`** — omitting them resolves to defaults
+2. **Auto ExternalIP** — a field on the resource spec requests automatic
+   ExternalIP and ExternalIPAttachment creation
+
+#### Optional network_attachments
+
+When `network_attachments` is empty on a ComputeInstance, Cluster, or
+BaremetalInstance create request, the fulfillment service resolves defaults
+before persisting:
+
+1. Determine the resource's region (from the template's region)
+2. Look up the default VirtualNetwork for (tenant, region)
+3. If none exists, trigger default resource creation (VN + Subnet + SG) and
+   wait for READY state
+4. Populate `network_attachments` with the default Subnet and default
+   SecurityGroup
+5. Store the resolved spec — the resource is self-describing after creation
+
+The resolved `network_attachments` are written to the spec before the
+resource is persisted. Get/List always shows the actual attachments, even if
+the tenant omitted them at creation.
+
+For BaremetalInstance with multiple physical interfaces, omitting
+`network_attachments` places the default interface on the default subnet.
+The fabric manager picks the default interface (same as existing behavior
+when `interface` is omitted).
+
+For Cluster, omitting `network_attachments` places all node sets on the
+default subnet with the default SecurityGroup.
+
+#### Auto ExternalIP
+
+A new `external_ip_mode` field on resource specs controls automatic
+ExternalIP provisioning. The provider designates a default ExternalIPPool
+per region (via `is_default` on ExternalIPPool) for auto-allocation.
+
+**ComputeInstance and BaremetalInstance:**
+
+```protobuf
+enum ExternalIPMode {
+  EXTERNAL_IP_MODE_NONE = 0;   // default: no auto ExternalIP
+  EXTERNAL_IP_MODE_AUTO = 1;   // auto-provision ExternalIP + attachment
+}
+```
+
+**Cluster:**
+
+```protobuf
+enum ClusterExternalIPMode {
+  CLUSTER_EXTERNAL_IP_MODE_NONE         = 0;
+  CLUSTER_EXTERNAL_IP_MODE_AUTO_API     = 1;  // API server only
+  CLUSTER_EXTERNAL_IP_MODE_AUTO_INGRESS = 2;  // ingress only
+  CLUSTER_EXTERNAL_IP_MODE_AUTO_ALL     = 3;  // both API and ingress
+}
+```
+
+When `external_ip_mode` is set to an AUTO value:
+
+1. The fulfillment service identifies the default ExternalIPPool for the
+   resource's region
+2. The service creates an ExternalIP from that pool, labeled with
+   `osac.openshift.io/auto-provisioned: "true"` and an owner-reference
+   annotation pointing to the parent resource
+3. Once the ExternalIP reaches ALLOCATED state, the service creates an
+   ExternalIPAttachment binding it to the parent
+4. For clusters with `AUTO_ALL`, steps 2–3 repeat for both API and ingress
+   endpoints (two ExternalIPs, two ExternalIPAttachments)
+
+#### Auto NATGateway
+
+A `nat_gateway_mode` field on all resource specs (ComputeInstance,
+BaremetalInstance, Cluster) controls automatic NATGateway provisioning:
+
+```protobuf
+enum NATGatewayMode {
+  NAT_GATEWAY_MODE_NONE = 0;   // default: no auto NATGateway
+  NAT_GATEWAY_MODE_AUTO = 1;   // auto-provision NATGateway on the VN
+}
+```
+
+When `AUTO`, the system creates a NATGateway on the resource's
+VirtualNetwork (default or explicit) with an ExternalIP from the default
+pool. Since the design constrains NATGateway to one per VN, auto-creation
+is idempotent — if a NATGateway already exists on the VN, no new one is
+created. The NATGateway is owned by the VirtualNetwork, not the individual
+resource.
+
+#### CaaS Prerequisite Ordering
+
+For clusters, ExternalIPs for API and ingress are prerequisites for
+provisioning (worker nodes reach the API server via hairpin NAT). Auto
+ExternalIP solves this:
+
+1. On Cluster create with `external_ip_mode = AUTO_ALL`:
+   a. Default networking resources are resolved/created
+   b. NATGateway is created if `nat_gateway_mode = AUTO`
+   c. ExternalIPs are allocated from the default pool
+   d. ExternalIPAttachments are created in Pending state
+   e. ExternalIP addresses are passed as template parameters
+   f. The Cluster is dispatched for provisioning
+2. Once cluster provisioning completes and VIPs are populated in
+   ClusterStatus, the ExternalIPAttachments transition to Ready
+
+This ensures ExternalIPs exist before provisioning, resolving gap #9
+without requiring the tenant to orchestrate the ordering manually.
+
+#### Ownership and Garbage Collection
+
+Auto-created resources use the existing owner-reference annotation pattern
+(`osac.openshift.io/owner-reference`):
+
+| Auto-created resource | Owner | GC behavior |
+|---|---|---|
+| Default VirtualNetwork | Tenant (no owner-ref) | Persists until tenant deletes it |
+| Default Subnet | Default VirtualNetwork | GC'd when default VN is deleted |
+| Default SecurityGroup | Default VirtualNetwork | GC'd when default VN is deleted |
+| Auto ExternalIP | Parent resource (CI/Cluster/BMI) | GC'd when parent is deleted |
+| Auto ExternalIPAttachment | Parent resource (CI/Cluster/BMI) | GC'd when parent is deleted |
+| Auto NATGateway | VirtualNetwork | Persists with VN |
+
+When a parent resource is deleted, the system deletes auto-created
+ExternalIPAttachments first, then ExternalIPs, following the standard
+finalizer pattern. Auto-created resources can be manually deleted by the
+tenant (e.g., detaching an auto ExternalIP), but the parent resource
+continues to function without it.
+
 ### End-to-End Flows
 
 This section shows how the unified networking API works from the tenant's
@@ -362,10 +641,13 @@ osac admin create externalippool \
   --region moc-region-1 \
   --cidrs 203.0.113.0/24 \
   --ip-family ipv4 \
+  --is-default \
   --name external-pool-1
 ```
 
-The fabric manager registers the IP range in its IPAM for allocation.
+The `--is-default` flag designates this pool for auto ExternalIP allocation
+in the region. One default pool per region. The fabric manager registers
+the IP range in its IPAM for allocation.
 
 #### Networking Setup (Same for All Resource Types)
 
@@ -576,6 +858,72 @@ The fabric manager creates a SNAT rule for the VN: all egress traffic from
 the VN's CIDR is source-NATted to the ExternalIP. Applies to all resources
 in the VN — VMs, BM servers, cluster nodes — since all are on the fabric.
 
+#### Simplified Flows (Default Networking + Auto ExternalIP)
+
+The explicit flows above show the full manual workflow. With default
+networking and auto ExternalIP, the same outcome is achieved in a single
+call. The explicit flow remains available for tenants who need custom
+networking.
+
+**1-call VM with external IP:**
+
+```bash
+osac create computeinstance --template ocp_virt_vm \
+  --external-ip=auto --name my-vm
+```
+
+System actions:
+1. Resolve region from template
+2. Look up default VN for (tenant, region) — create if missing (VN +
+   Subnet + SG)
+3. Wait for default networking to reach READY
+4. Populate `network_attachments` with default Subnet + default SG
+5. Allocate ExternalIP from region's default pool
+6. Create ExternalIPAttachment (Pending until VM IP is assigned)
+7. Dispatch VM creation
+8. On VM running: ExternalIPAttachment transitions to Ready
+
+**1-call cluster with full connectivity:**
+
+```bash
+osac create cluster --template ocp_4_17_small \
+  --external-ip=auto-all --nat-gateway=auto \
+  --node-set workers=large,size=3 --name my-cluster
+```
+
+System actions:
+1. Resolve region from template
+2. Look up/create default networking (VN + Subnet + SG)
+3. Create NATGateway on default VN (or reuse existing)
+4. Allocate 2 ExternalIPs (API + ingress) from default pool
+5. Create 2 ExternalIPAttachments (Pending state)
+6. Populate `network_attachments` with default Subnet + default SG
+7. Pass ExternalIP addresses as template parameters
+8. Dispatch cluster provisioning
+9. On cluster ready: ExternalIPAttachments activate
+
+**1-call bare-metal server:**
+
+```bash
+osac create baremetalinstance --template bcm_h100 \
+  --external-ip=auto --name my-server
+```
+
+System actions follow the same pattern as ComputeInstance — default
+interface is placed on the default subnet by the fabric manager.
+
+**Mixed: explicit networking with auto ExternalIP:**
+
+```bash
+osac create computeinstance --template ocp_virt_vm \
+  --network-attachment subnet=my-subnet,security-groups=my-sg \
+  --external-ip=auto --name my-vm
+```
+
+Explicit `network_attachments` are used (no defaults). Auto ExternalIP
+still works — the system allocates from the region's default pool and
+attaches to the resource.
+
 ### API Extensions
 
 #### VirtualNetwork
@@ -653,9 +1001,15 @@ compute workers on a standard one).
 ```protobuf
 message ComputeInstanceSpec {
   // ... existing fields ...
-  repeated ComputeNetworkAttachment network_attachments = 14;
+  repeated ComputeNetworkAttachment network_attachments = 14;  // optional
+  ExternalIPMode external_ip_mode = 18;                        // NEW: auto ExternalIP
+  NATGatewayMode nat_gateway_mode = 19;                        // NEW: auto NATGateway
 }
 ```
+
+`network_attachments` is optional. When omitted, the system resolves
+defaults (default Subnet + default SecurityGroup for the region).
+`external_ip_mode` and `nat_gateway_mode` are immutable after creation.
 
 **BaremetalInstance** (new — defined in the
 [BareMetal Instance API enhancement](/enhancements/baremetal-instance-api)):
@@ -669,7 +1023,9 @@ message BaremetalInstanceSpec {
   optional google.protobuf.Timestamp restart_requested_at = 5;
 
   // NEW: OSAC networking
-  repeated BareMetalNetworkAttachment network_attachments = 6;
+  repeated BareMetalNetworkAttachment network_attachments = 6;  // optional
+  ExternalIPMode external_ip_mode = 7;                          // NEW: auto ExternalIP
+  NATGatewayMode nat_gateway_mode = 8;                          // NEW: auto NATGateway
 }
 ```
 
@@ -682,7 +1038,9 @@ message ClusterSpec {
   map<string, ClusterNodeSet> node_sets = 3;
 
   // NEW: networking
-  repeated ClusterNetworkAttachment network_attachments = 4;
+  repeated ClusterNetworkAttachment network_attachments = 4;    // optional
+  ClusterExternalIPMode external_ip_mode = 5;                   // NEW: auto ExternalIP
+  NATGatewayMode nat_gateway_mode = 6;                          // NEW: auto NATGateway
 }
 ```
 
@@ -690,6 +1048,27 @@ message ClusterSpec {
 - The cluster's template determines whether nodes are VMs or BM. Both
   types are placed on the same subnet — VMs via the K8s overlay (already
   bridged to the fabric), BM nodes directly on the fabric.
+
+**Shared enums for simplified resource creation:**
+
+```protobuf
+enum ExternalIPMode {
+  EXTERNAL_IP_MODE_NONE = 0;   // default: no auto ExternalIP
+  EXTERNAL_IP_MODE_AUTO = 1;   // auto-provision ExternalIP + attachment
+}
+
+enum ClusterExternalIPMode {
+  CLUSTER_EXTERNAL_IP_MODE_NONE         = 0;  // default
+  CLUSTER_EXTERNAL_IP_MODE_AUTO_API     = 1;  // API server only
+  CLUSTER_EXTERNAL_IP_MODE_AUTO_INGRESS = 2;  // ingress only
+  CLUSTER_EXTERNAL_IP_MODE_AUTO_ALL     = 3;  // both API and ingress
+}
+
+enum NATGatewayMode {
+  NAT_GATEWAY_MODE_NONE = 0;   // default: no auto NATGateway
+  NAT_GATEWAY_MODE_AUTO = 1;   // auto-provision on the resource's VN
+}
+```
 
 The Cluster resource also gains two fields populated by the system
 during provisioning:
@@ -841,6 +1220,32 @@ k8sManager — there is no K8s overlay to place the VM on.
 The operator validates that Subnet CIDRs do not overlap within a
 VirtualNetwork at creation time.
 
+#### Default Resource Tracking
+
+The system tracks default networking resources for each (tenant, region)
+pair using a materialized helper table with columns `(tenant, region,
+virtual_network_id, subnet_id, security_group_id)`. This ensures
+idempotent creation — concurrent resource creates for the same tenant and
+region do not create duplicate defaults. The table uses a unique constraint
+on `(tenant, region)`.
+
+#### ExternalIPPool Region and Default Designation
+
+ExternalIPPool gains two fields:
+
+```protobuf
+message ExternalIPPoolSpec {
+  // ... existing fields ...
+  string region = 5;           // required, immutable
+  optional bool is_default = 6;
+}
+```
+
+The `region` field scopes the pool. The `is_default` flag designates the
+pool for auto ExternalIP allocation in that region. One default pool per
+region. When auto ExternalIP is requested and no default pool exists, the
+create request fails with a clear error.
+
 ### Risks and Mitigations
 
 | Risk | Impact | Mitigation |
@@ -850,6 +1255,11 @@ VirtualNetwork at creation time.
 | CaaS prerequisite ordering | ExternalIPs may be needed before cluster | Pending state for attachments; template validates its own prerequisites |
 | ExternalIPAttachment target validation | Target may not exist yet (CaaS) or may be deleted | Pending state for forward references; attachment tracks target lifecycle |
 | CIDR overlap | Overlapping subnets cause routing ambiguity | Operator validates at creation time; rejected with clear error |
+| Default CIDR supernet exhaustion (isolated_cidr mode) | No more tenants can get defaults in the region | Provider monitoring on allocation count; clear error; provider can widen supernet |
+| Default ExternalIPPool exhaustion | Auto ExternalIP requests fail | Pool capacity visible in status; clear error directs tenant to explicit allocation from another pool |
+| Race condition on default creation | Concurrent resource creates could create duplicate defaults | Materialized helper table with unique constraint on (tenant, region); first writer wins |
+| Default SecurityGroup too permissive | Security exposure for new tenants | Provider configures default rules per region; tenant can tighten after creation |
+| Auto ExternalIP orphans on partial failure | ExternalIP allocated but attachment creation fails | Standard finalizer pattern; controller retries; if permanently failed, ExternalIP is GC'd with parent |
 
 ### Drawbacks
 
@@ -927,6 +1337,37 @@ time. Creates ambiguous subnet state and complicates the tenant experience.
     type has a different selector concept (virtual NIC, physical interface,
     node set) — a shared type with optional fields would accumulate
     dead weight per resource type.
+
+12. **Default resource creation is lazy.** Defaults are created on first
+    resource creation that omits `network_attachments`, not at tenant
+    onboarding. This avoids provisioning networking infrastructure in
+    unused regions.
+
+13. **CIDR allocation uses a materialized helper table.** Per-tenant
+    defaults are tracked in a helper table with a unique constraint on
+    `(tenant, region)`. The system allocates the next available prefix from
+    the supernet (in `isolated_cidr` mode) or reuses the same CIDR (in
+    `shared_cidr` mode).
+
+14. **Auto ExternalIPs are owned by the parent resource.** They use the
+    standard owner-reference annotation and are garbage-collected on parent
+    deletion. They are visible and can be manually detached by the tenant.
+
+15. **Cluster ExternalIP allocation happens before provisioning dispatch.**
+    The system allocates ExternalIPs synchronously during the Cluster
+    create flow, passes the addresses to the CaaS template as parameters,
+    and creates ExternalIPAttachments in Pending state. This resolves the
+    CaaS prerequisite ordering problem (gap #9).
+
+16. **NATGateway auto-creation is per-VN, not per-resource.** Since the
+    design constrains NATGateway to one per VN, auto-creation is
+    idempotent — if a NATGateway already exists on the VN, no new one is
+    created.
+
+17. **Default CIDR mode is `shared_cidr`.** In OSAC's fabric-first model,
+    tenants are already isolated at the fabric level. Overlapping CIDRs
+    between tenants are not a problem. `isolated_cidr` is available for
+    providers who want IP-level uniqueness.
 
 ## Test Plan
 

--- a/enhancements/unified-networking/README.md
+++ b/enhancements/unified-networking/README.md
@@ -345,25 +345,26 @@ handles IP allocation — one pool serves all resource types.
 
 ### Default Networking Resources
 
-OSAC provisions a set of default networking resources per tenant per region
-on first use. This eliminates the need for tenants to understand the
-networking resource model before creating their first resource. The design
-follows a Default VPC model adapted for OSAC's architecture — one
-default VirtualNetwork per tenant per region, with one default Subnet and
-one default SecurityGroup (OSAC has no availability zones).
+OSAC provisions a set of default networking resources per tenant on first
+use. This eliminates the need for tenants to understand the networking
+resource model before creating their first resource.
+
+Note: region is not yet a fully defined concept in OSAC. When region
+support is implemented, default networking resources will be scoped per
+tenant per region. Until then, the design assumes a single-region
+deployment.
 
 #### What Is Auto-Created
 
-For each (tenant, region) pair, on first use:
+For each tenant, on first use:
 
-1. **Default VirtualNetwork** — one per tenant per region
+1. **Default VirtualNetwork** — one per tenant
 2. **Default Subnet** — one within the default VN
 3. **Default SecurityGroup** — one within the default VN
 
 Default resources are created **lazily** — on the first resource creation
-request that omits `network_attachments` in a given region. They are not
-created eagerly at tenant onboarding. This avoids provisioning networking
-infrastructure in regions the tenant never uses.
+request that omits `network_attachments`. They are not created eagerly at
+tenant onboarding.
 
 #### CIDR Allocation
 
@@ -383,7 +384,7 @@ modes are supported:
 
 #### NetworkClass Defaults Configuration
 
-The provider configures defaults on the NetworkClass at region setup:
+The provider configures defaults on the NetworkClass:
 
 ```yaml
 apiVersion: osac.openshift.io/v1alpha1
@@ -391,7 +392,6 @@ kind: NetworkClass
 metadata:
   name: moc-region-1
 spec:
-  region: moc-region-1
   fabricManager: netris
   k8sManager: cudn_localnet
   defaults:
@@ -439,7 +439,6 @@ metadata:
   labels:
     osac.openshift.io/default: "true"
 spec:
-  region: <region>
   ipv4_cidr: "10.0.0.0/24"
 ```
 
@@ -483,7 +482,7 @@ spec:
 #### Coexistence with Custom VNs
 
 Creating custom VirtualNetworks does not affect default resources. A tenant
-can have both default and custom VNs in the same region. Resources created
+can have both default and custom VNs. Resources created
 without `network_attachments` always use the defaults. Resources created
 with explicit `network_attachments` use the specified resources — no
 defaults are applied.
@@ -506,8 +505,7 @@ When `network_attachments` is empty on a ComputeInstance, Cluster, or
 BaremetalInstance create request, the fulfillment service resolves defaults
 before persisting:
 
-1. Determine the resource's region (from the template's region)
-2. Look up the default VirtualNetwork for (tenant, region)
+1. Look up the default VirtualNetwork for the tenant
 3. If none exists, trigger default resource creation (VN + Subnet + SG) and
    wait for READY state
 4. Populate `network_attachments` with the default Subnet and default
@@ -530,8 +528,8 @@ default subnet with the default SecurityGroup.
 
 A new `external_ip_mode` field on resource specs controls automatic
 ExternalIP provisioning. The system auto-selects a pool using the same
-strategy as manual ExternalIP creation: pick the READY pool in the region
-with the most available capacity matching the requested IP family
+strategy as manual ExternalIP creation: pick the READY pool with the most
+available capacity matching the requested IP family
 (defaulting to IPv4).
 
 **ComputeInstance and BaremetalInstance:**
@@ -556,9 +554,9 @@ enum ClusterExternalIPMode {
 
 When `external_ip_mode` is set to an AUTO value:
 
-1. The fulfillment service selects the READY ExternalIPPool in the
-   resource's region with the most available capacity (same auto-selection
-   logic as manual ExternalIP creation)
+1. The fulfillment service selects the READY ExternalIPPool with the most
+   available capacity (same auto-selection logic as manual ExternalIP
+   creation)
 2. The service creates an ExternalIP from that pool, labeled with
    `osac.openshift.io/auto-provisioned: "true"` and an owner-reference
    annotation pointing to the parent resource
@@ -581,7 +579,7 @@ enum NATGatewayMode {
 
 When `AUTO`, the system creates a NATGateway on the resource's
 VirtualNetwork (default or explicit) with an ExternalIP auto-selected from
-the best available pool in the region. Since the design constrains NATGateway to one per VN, auto-creation
+the best available pool. Since the design constrains NATGateway to one per VN, auto-creation
 is idempotent — if a NATGateway already exists on the VN, no new one is
 created. The NATGateway is owned by the VirtualNetwork, not the individual
 resource.
@@ -875,15 +873,13 @@ osac create computeinstance --template ocp_virt_vm \
 ```
 
 System actions:
-1. Resolve region from template
-2. Look up default VN for (tenant, region) — create if missing (VN +
-   Subnet + SG)
-3. Wait for default networking to reach READY
-4. Populate `network_attachments` with default Subnet + default SG
-5. Auto-select ExternalIP from best available pool in region
-6. Create ExternalIPAttachment (Pending until VM IP is assigned)
-7. Dispatch VM creation
-8. On VM running: ExternalIPAttachment transitions to Ready
+1. Look up default VN for tenant — create if missing (VN + Subnet + SG)
+2. Wait for default networking to reach READY
+3. Populate `network_attachments` with default Subnet + default SG
+4. Auto-select ExternalIP from best available pool
+5. Create ExternalIPAttachment (Pending until VM IP is assigned)
+6. Dispatch VM creation
+7. On VM running: ExternalIPAttachment transitions to Ready
 
 **1-call cluster with full connectivity:**
 
@@ -894,8 +890,7 @@ osac create cluster --template ocp_4_17_small \
 ```
 
 System actions:
-1. Resolve region from template
-2. Look up/create default networking (VN + Subnet + SG)
+1. Look up/create default networking for tenant (VN + Subnet + SG)
 3. Create NATGateway on default VN (or reuse existing)
 4. Auto-select 2 ExternalIPs (API + ingress) from best available pool
 5. Create 2 ExternalIPAttachments (Pending state)
@@ -923,8 +918,8 @@ osac create computeinstance --template ocp_virt_vm \
 ```
 
 Explicit `network_attachments` are used (no defaults). Auto ExternalIP
-still works — the system auto-selects from the best available pool in
-the region and attaches to the resource.
+still works — the system auto-selects from the best available pool and
+attaches to the resource.
 
 ### API Extensions
 
@@ -1224,30 +1219,19 @@ VirtualNetwork at creation time.
 
 #### Default Resource Tracking
 
-The system tracks default networking resources for each (tenant, region)
-pair using a materialized helper table with columns `(tenant, region,
-virtual_network_id, subnet_id, security_group_id)`. This ensures
-idempotent creation — concurrent resource creates for the same tenant and
-region do not create duplicate defaults. The table uses a unique constraint
-on `(tenant, region)`.
+The system tracks default networking resources per tenant using a
+materialized helper table with columns `(tenant, virtual_network_id,
+subnet_id, security_group_id)`. This ensures idempotent creation —
+concurrent resource creates for the same tenant do not create duplicate
+defaults. The table uses a unique constraint on `(tenant)`.
 
-#### ExternalIPPool Region Scoping
+#### ExternalIPPool Auto-Selection
 
-ExternalIPPool gains a region field:
-
-```protobuf
-message ExternalIPPoolSpec {
-  // ... existing fields ...
-  string region = 5;           // required, immutable
-}
-```
-
-The `region` field scopes the pool. When auto ExternalIP is requested, the
-system selects the READY pool in the region with the most available
-capacity matching the IP family (defaulting to IPv4) — the same
-auto-selection strategy used for manual ExternalIP creation. When no pool
-in the region has available capacity, the create request fails with a
-clear error.
+When auto ExternalIP is requested, the system selects the READY
+ExternalIPPool with the most available capacity matching the IP family
+(defaulting to IPv4) — the same auto-selection strategy used for manual
+ExternalIP creation. When no pool has available capacity, the create
+request fails with a clear error.
 
 ### Risks and Mitigations
 
@@ -1258,10 +1242,10 @@ clear error.
 | CaaS prerequisite ordering | ExternalIPs may be needed before cluster | Pending state for attachments; template validates its own prerequisites |
 | ExternalIPAttachment target validation | Target may not exist yet (CaaS) or may be deleted | Pending state for forward references; attachment tracks target lifecycle |
 | CIDR overlap | Overlapping subnets cause routing ambiguity | Operator validates at creation time; rejected with clear error |
-| Default CIDR supernet exhaustion (isolated_cidr mode) | No more tenants can get defaults in the region | Provider monitoring on allocation count; clear error; provider can widen supernet |
-| ExternalIPPool exhaustion in region | Auto ExternalIP requests fail | Pool capacity visible in status; clear error directs tenant to explicit allocation from another pool |
-| Race condition on default creation | Concurrent resource creates could create duplicate defaults | Materialized helper table with unique constraint on (tenant, region); first writer wins |
-| Default SecurityGroup too permissive | Security exposure for new tenants | Provider configures default rules per region; tenant can tighten after creation |
+| Default CIDR supernet exhaustion (isolated_cidr mode) | No more tenants can get defaults | Provider monitoring on allocation count; clear error; provider can widen supernet |
+| ExternalIPPool exhaustion | Auto ExternalIP requests fail | Pool capacity visible in status; clear error directs tenant to explicit allocation from another pool |
+| Race condition on default creation | Concurrent resource creates could create duplicate defaults | Materialized helper table with unique constraint on tenant; first writer wins |
+| Default SecurityGroup too permissive | Security exposure for new tenants | Provider configures default rules; tenant can tighten after creation |
 | Auto ExternalIP orphans on partial failure | ExternalIP allocated but attachment creation fails | Standard finalizer pattern; controller retries; if permanently failed, ExternalIP is GC'd with parent |
 
 ### Drawbacks
@@ -1343,13 +1327,12 @@ time. Creates ambiguous subnet state and complicates the tenant experience.
 
 12. **Default resource creation is lazy.** Defaults are created on first
     resource creation that omits `network_attachments`, not at tenant
-    onboarding. This avoids provisioning networking infrastructure in
-    unused regions.
+    onboarding.
 
 13. **CIDR allocation uses a materialized helper table.** Per-tenant
     defaults are tracked in a helper table with a unique constraint on
-    `(tenant, region)`. The system allocates the next available prefix from
-    the supernet (in `isolated_cidr` mode) or reuses the same CIDR (in
+    `(tenant)`. The system allocates the next available prefix from the
+    supernet (in `isolated_cidr` mode) or reuses the same CIDR (in
     `shared_cidr` mode).
 
 14. **Auto ExternalIPs are owned by the parent resource.** They use the

--- a/enhancements/unified-networking/README.md
+++ b/enhancements/unified-networking/README.md
@@ -345,21 +345,21 @@ handles IP allocation — one pool serves all resource types.
 
 ### Default Networking Resources
 
-OSAC provisions a set of default networking resources per tenant on first
-use. This eliminates the need for tenants to understand the networking
-resource model before creating their first resource.
+OSAC provisions a set of default networking resources per tenant at tenant
+onboarding. This eliminates the need for tenants to understand the
+networking resource model before creating their first resource.
 
 #### What Is Auto-Created
 
-For each tenant, on first use:
+At tenant creation, the system provisions:
 
 1. **Default VirtualNetwork** — one per tenant
 2. **Default Subnet** — one within the default VN
 3. **Default SecurityGroup** — one within the default VN
 
-Default resources are created **lazily** — on the first resource creation
-request that omits `network_attachments`. They are not created eagerly at
-tenant onboarding.
+Default resources are created **eagerly** at tenant onboarding. By the
+time a tenant creates their first resource, defaults are already in READY
+state — no mid-request provisioning or waiting needed.
 
 #### CIDR Allocation
 
@@ -500,12 +500,11 @@ When `network_attachments` is empty on a ComputeInstance, Cluster, or
 BaremetalInstance create request, the fulfillment service resolves defaults
 before persisting:
 
-1. Look up the default VirtualNetwork for the tenant
-3. If none exists, trigger default resource creation (VN + Subnet + SG) and
-   wait for READY state
-4. Populate `network_attachments` with the default Subnet and default
+1. Look up the tenant's default Subnet and default SecurityGroup (created
+   at tenant onboarding, already in READY state)
+2. Populate `network_attachments` with the default Subnet and default
    SecurityGroup
-5. Store the resolved spec — the resource is self-describing after creation
+3. Store the resolved spec — the resource is self-describing after creation
 
 The resolved `network_attachments` are written to the spec before the
 resource is persisted. Get/List always shows the actual attachments, even if
@@ -868,13 +867,12 @@ osac create computeinstance --template ocp_virt_vm \
 ```
 
 System actions:
-1. Look up default VN for tenant — create if missing (VN + Subnet + SG)
-2. Wait for default networking to reach READY
-3. Populate `network_attachments` with default Subnet + default SG
-4. Auto-select ExternalIP from best available pool
-5. Create ExternalIPAttachment (Pending until VM IP is assigned)
-6. Dispatch VM creation
-7. On VM running: ExternalIPAttachment transitions to Ready
+1. Resolve tenant's default Subnet + default SG (already READY)
+2. Populate `network_attachments`
+3. Auto-select ExternalIP from best available pool
+4. Create ExternalIPAttachment (Pending until VM IP is assigned)
+5. Dispatch VM creation
+6. On VM running: ExternalIPAttachment transitions to Ready
 
 **1-call cluster with full connectivity:**
 
@@ -885,14 +883,14 @@ osac create cluster --template ocp_4_17_small \
 ```
 
 System actions:
-1. Look up/create default networking for tenant (VN + Subnet + SG)
-3. Create NATGateway on default VN (or reuse existing)
-4. Auto-select 2 ExternalIPs (API + ingress) from best available pool
-5. Create 2 ExternalIPAttachments (Pending state)
-6. Populate `network_attachments` with default Subnet + default SG
-7. Pass ExternalIP addresses as template parameters
-8. Dispatch cluster provisioning
-9. On cluster ready: ExternalIPAttachments activate
+1. Resolve tenant's default Subnet + default SG (already READY)
+2. Create NATGateway on default VN (or reuse existing)
+3. Auto-select 2 ExternalIPs (API + ingress) from best available pool
+4. Create 2 ExternalIPAttachments (Pending state)
+5. Populate `network_attachments`
+6. Pass ExternalIP addresses as template parameters
+7. Dispatch cluster provisioning
+8. On cluster ready: ExternalIPAttachments activate
 
 **1-call bare-metal server:**
 
@@ -1214,11 +1212,10 @@ VirtualNetwork at creation time.
 
 #### Default Resource Tracking
 
-The system tracks default networking resources per tenant using a
-materialized helper table with columns `(tenant, virtual_network_id,
-subnet_id, security_group_id)`. This ensures idempotent creation —
-concurrent resource creates for the same tenant do not create duplicate
-defaults. The table uses a unique constraint on `(tenant)`.
+Default networking resources are created at tenant onboarding, not
+lazily. The Tenant controller provisions the default VN, Subnet, and SG
+as part of the tenant creation flow. The tenant transitions to READY
+only after all default networking resources are also READY.
 
 #### ExternalIPPool Auto-Selection
 
@@ -1239,7 +1236,6 @@ request fails with a clear error.
 | CIDR overlap | Overlapping subnets cause routing ambiguity | Operator validates at creation time; rejected with clear error |
 | Default CIDR supernet exhaustion (isolated_cidr mode) | No more tenants can get defaults | Provider monitoring on allocation count; clear error; provider can widen supernet |
 | ExternalIPPool exhaustion | Auto ExternalIP requests fail | Pool capacity visible in status; clear error directs tenant to explicit allocation from another pool |
-| Race condition on default creation | Concurrent resource creates could create duplicate defaults | Materialized helper table with unique constraint on tenant; first writer wins |
 | Default SecurityGroup too permissive | Security exposure for new tenants | Provider configures default rules; tenant can tighten after creation |
 | Auto ExternalIP orphans on partial failure | ExternalIP allocated but attachment creation fails | Standard finalizer pattern; controller retries; if permanently failed, ExternalIP is GC'd with parent |
 
@@ -1320,15 +1316,13 @@ time. Creates ambiguous subnet state and complicates the tenant experience.
     node set) — a shared type with optional fields would accumulate
     dead weight per resource type.
 
-12. **Default resource creation is lazy.** Defaults are created on first
-    resource creation that omits `network_attachments`, not at tenant
-    onboarding.
+12. **Default resource creation is eager.** Defaults are created at tenant
+    onboarding, not lazily on first use. The tenant transitions to READY
+    only after all default networking resources are also READY.
 
-13. **CIDR allocation uses a materialized helper table.** Per-tenant
-    defaults are tracked in a helper table with a unique constraint on
-    `(tenant)`. The system allocates the next available prefix from the
-    supernet (in `isolated_cidr` mode) or reuses the same CIDR (in
-    `shared_cidr` mode).
+13. **CIDR allocation.** In `shared_cidr` mode (default), all tenants
+    receive the same CIDR. In `isolated_cidr` mode, the system allocates
+    the next available prefix from the provider's supernet.
 
 14. **Auto ExternalIPs are owned by the parent resource.** They use the
     standard owner-reference annotation and are garbage-collected on parent

--- a/enhancements/unified-networking/README.md
+++ b/enhancements/unified-networking/README.md
@@ -529,8 +529,10 @@ default subnet with the default SecurityGroup.
 #### Auto ExternalIP
 
 A new `external_ip_mode` field on resource specs controls automatic
-ExternalIP provisioning. The provider designates a default ExternalIPPool
-per region (via `is_default` on ExternalIPPool) for auto-allocation.
+ExternalIP provisioning. The system auto-selects a pool using the same
+strategy as manual ExternalIP creation: pick the READY pool in the region
+with the most available capacity matching the requested IP family
+(defaulting to IPv4).
 
 **ComputeInstance and BaremetalInstance:**
 
@@ -554,8 +556,9 @@ enum ClusterExternalIPMode {
 
 When `external_ip_mode` is set to an AUTO value:
 
-1. The fulfillment service identifies the default ExternalIPPool for the
-   resource's region
+1. The fulfillment service selects the READY ExternalIPPool in the
+   resource's region with the most available capacity (same auto-selection
+   logic as manual ExternalIP creation)
 2. The service creates an ExternalIP from that pool, labeled with
    `osac.openshift.io/auto-provisioned: "true"` and an owner-reference
    annotation pointing to the parent resource
@@ -577,8 +580,8 @@ enum NATGatewayMode {
 ```
 
 When `AUTO`, the system creates a NATGateway on the resource's
-VirtualNetwork (default or explicit) with an ExternalIP from the default
-pool. Since the design constrains NATGateway to one per VN, auto-creation
+VirtualNetwork (default or explicit) with an ExternalIP auto-selected from
+the best available pool in the region. Since the design constrains NATGateway to one per VN, auto-creation
 is idempotent — if a NATGateway already exists on the VN, no new one is
 created. The NATGateway is owned by the VirtualNetwork, not the individual
 resource.
@@ -592,7 +595,7 @@ ExternalIP solves this:
 1. On Cluster create with `external_ip_mode = AUTO_ALL`:
    a. Default networking resources are resolved/created
    b. NATGateway is created if `nat_gateway_mode = AUTO`
-   c. ExternalIPs are allocated from the default pool
+   c. ExternalIPs are auto-selected from the best available pool
    d. ExternalIPAttachments are created in Pending state
    e. ExternalIP addresses are passed as template parameters
    f. The Cluster is dispatched for provisioning
@@ -641,13 +644,12 @@ osac admin create externalippool \
   --region moc-region-1 \
   --cidrs 203.0.113.0/24 \
   --ip-family ipv4 \
-  --is-default \
   --name external-pool-1
 ```
 
-The `--is-default` flag designates this pool for auto ExternalIP allocation
-in the region. One default pool per region. The fabric manager registers
-the IP range in its IPAM for allocation.
+The fabric manager registers the IP range in its IPAM for allocation.
+When auto ExternalIP is requested, the system selects the READY pool in
+the region with the most available capacity matching the IP family.
 
 #### Networking Setup (Same for All Resource Types)
 
@@ -878,7 +880,7 @@ System actions:
    Subnet + SG)
 3. Wait for default networking to reach READY
 4. Populate `network_attachments` with default Subnet + default SG
-5. Allocate ExternalIP from region's default pool
+5. Auto-select ExternalIP from best available pool in region
 6. Create ExternalIPAttachment (Pending until VM IP is assigned)
 7. Dispatch VM creation
 8. On VM running: ExternalIPAttachment transitions to Ready
@@ -895,7 +897,7 @@ System actions:
 1. Resolve region from template
 2. Look up/create default networking (VN + Subnet + SG)
 3. Create NATGateway on default VN (or reuse existing)
-4. Allocate 2 ExternalIPs (API + ingress) from default pool
+4. Auto-select 2 ExternalIPs (API + ingress) from best available pool
 5. Create 2 ExternalIPAttachments (Pending state)
 6. Populate `network_attachments` with default Subnet + default SG
 7. Pass ExternalIP addresses as template parameters
@@ -921,8 +923,8 @@ osac create computeinstance --template ocp_virt_vm \
 ```
 
 Explicit `network_attachments` are used (no defaults). Auto ExternalIP
-still works — the system allocates from the region's default pool and
-attaches to the resource.
+still works — the system auto-selects from the best available pool in
+the region and attaches to the resource.
 
 ### API Extensions
 
@@ -1229,22 +1231,23 @@ idempotent creation — concurrent resource creates for the same tenant and
 region do not create duplicate defaults. The table uses a unique constraint
 on `(tenant, region)`.
 
-#### ExternalIPPool Region and Default Designation
+#### ExternalIPPool Region Scoping
 
-ExternalIPPool gains two fields:
+ExternalIPPool gains a region field:
 
 ```protobuf
 message ExternalIPPoolSpec {
   // ... existing fields ...
   string region = 5;           // required, immutable
-  optional bool is_default = 6;
 }
 ```
 
-The `region` field scopes the pool. The `is_default` flag designates the
-pool for auto ExternalIP allocation in that region. One default pool per
-region. When auto ExternalIP is requested and no default pool exists, the
-create request fails with a clear error.
+The `region` field scopes the pool. When auto ExternalIP is requested, the
+system selects the READY pool in the region with the most available
+capacity matching the IP family (defaulting to IPv4) — the same
+auto-selection strategy used for manual ExternalIP creation. When no pool
+in the region has available capacity, the create request fails with a
+clear error.
 
 ### Risks and Mitigations
 
@@ -1256,7 +1259,7 @@ create request fails with a clear error.
 | ExternalIPAttachment target validation | Target may not exist yet (CaaS) or may be deleted | Pending state for forward references; attachment tracks target lifecycle |
 | CIDR overlap | Overlapping subnets cause routing ambiguity | Operator validates at creation time; rejected with clear error |
 | Default CIDR supernet exhaustion (isolated_cidr mode) | No more tenants can get defaults in the region | Provider monitoring on allocation count; clear error; provider can widen supernet |
-| Default ExternalIPPool exhaustion | Auto ExternalIP requests fail | Pool capacity visible in status; clear error directs tenant to explicit allocation from another pool |
+| ExternalIPPool exhaustion in region | Auto ExternalIP requests fail | Pool capacity visible in status; clear error directs tenant to explicit allocation from another pool |
 | Race condition on default creation | Concurrent resource creates could create duplicate defaults | Materialized helper table with unique constraint on (tenant, region); first writer wins |
 | Default SecurityGroup too permissive | Security exposure for new tenants | Provider configures default rules per region; tenant can tighten after creation |
 | Auto ExternalIP orphans on partial failure | ExternalIP allocated but attachment creation fails | Standard finalizer pattern; controller retries; if permanently failed, ExternalIP is GC'd with parent |

--- a/enhancements/unified-networking/README.md
+++ b/enhancements/unified-networking/README.md
@@ -585,7 +585,7 @@ provisioning (worker nodes reach the API server via hairpin NAT). Auto
 ExternalIP solves this:
 
 1. On Cluster create with `external_ip_mode = AUTO_ALL`:
-   a. Default networking resources are resolved/created
+   a. Default networking resources are resolved (already READY)
    b. NATGateway is created if `nat_gateway_mode = AUTO`
    c. ExternalIPs are auto-selected from the best available pool
    d. ExternalIPAttachments are created in Pending state
@@ -998,7 +998,7 @@ message ComputeInstanceSpec {
 ```
 
 `network_attachments` is optional. When omitted, the system resolves
-defaults (default Subnet + default SecurityGroup for the region).
+defaults (tenant's default Subnet + default SecurityGroup).
 `external_ip_mode` and `nat_gateway_mode` are immutable after creation.
 
 **BaremetalInstance** (new — defined in the

--- a/enhancements/unified-networking/README.md
+++ b/enhancements/unified-networking/README.md
@@ -343,280 +343,6 @@ The API and flow are identical regardless of the deployment topology.
 ExternalIPPools are provider-managed and region-scoped. The fabric manager
 handles IP allocation — one pool serves all resource types.
 
-### Default Networking Resources
-
-OSAC provisions a set of default networking resources per tenant at tenant
-onboarding. This eliminates the need for tenants to understand the
-networking resource model before creating their first resource.
-
-#### What Is Auto-Created
-
-At tenant creation, the system provisions:
-
-1. **Default VirtualNetwork** — one per tenant
-2. **Default Subnet** — one within the default VN
-3. **Default SecurityGroup** — one within the default VN
-
-Default resources are created **eagerly** at tenant onboarding. By the
-time a tenant creates their first resource, defaults are already in READY
-state — no mid-request provisioning or waiting needed.
-
-#### CIDR Allocation
-
-The provider configures a `defaults` block on the NetworkClass. Two CIDR
-modes are supported:
-
-- **`shared_cidr`** (default): All tenants receive the same default CIDR
-  range. This is the natural choice for OSAC's fabric-first model — tenants
-  are already isolated at the fabric level (separate VLANs/VRFs), so
-  overlapping IPs between tenants are not a problem. Simpler, no supernet
-  carving needed.
-
-- **`isolated_cidr`**: The system carves non-overlapping CIDR slices from
-  the supernet. Each tenant gets a unique prefix (e.g., /24) from the
-  provider's supernet. Used when the provider wants IP-level uniqueness in
-  addition to fabric-level isolation.
-
-#### NetworkClass Defaults Configuration
-
-The provider configures defaults on the NetworkClass:
-
-```yaml
-apiVersion: osac.openshift.io/v1alpha1
-kind: NetworkClass
-metadata:
-  name: moc-region-1
-spec:
-  fabricManager: netris
-  k8sManager: cudn_localnet
-  defaults:
-    ipv4_cidr: "10.0.0.0/24"
-    cidr_mode: shared_cidr
-    security_group:
-      ingress:
-        - protocol: tcp
-          port_from: 22
-          port_to: 22
-          ipv4_cidr: "0.0.0.0/0"
-      egress:
-        - protocol: all
-          ipv4_cidr: "0.0.0.0/0"
-```
-
-For `isolated_cidr` mode, the provider specifies a supernet and prefix
-length instead:
-
-```yaml
-  defaults:
-    ipv4_supernet: "10.0.0.0/16"
-    tenant_prefix_length: 24
-    cidr_mode: isolated_cidr
-```
-
-When `defaults` is not set on the NetworkClass, creating a resource without
-`network_attachments` returns an error directing the tenant to specify
-networking explicitly or ask the provider to configure defaults.
-
-#### Default Resource Specs
-
-Default resources are regular OSAC resources. They appear in List/Get
-responses, can be modified by the tenant (e.g., adding SecurityGroup
-rules), and participate in standard lifecycle operations. The
-`osac.openshift.io/default: "true"` label identifies them as system-created
-defaults.
-
-**Default VirtualNetwork:**
-
-```yaml
-metadata:
-  name: default
-  tenant: <tenant-id>
-  labels:
-    osac.openshift.io/default: "true"
-spec:
-  ipv4_cidr: "10.0.0.0/24"
-```
-
-**Default Subnet:**
-
-```yaml
-metadata:
-  name: default
-  tenant: <tenant-id>
-  labels:
-    osac.openshift.io/default: "true"
-  annotations:
-    osac.openshift.io/owner-reference: <default-vn-id>
-spec:
-  virtual_network: <default-vn-id>
-  ipv4_cidr: "10.0.0.0/24"
-```
-
-**Default SecurityGroup:**
-
-```yaml
-metadata:
-  name: default
-  tenant: <tenant-id>
-  labels:
-    osac.openshift.io/default: "true"
-  annotations:
-    osac.openshift.io/owner-reference: <default-vn-id>
-spec:
-  virtual_network: <default-vn-id>
-  ingress:
-    - protocol: tcp
-      port_from: 22
-      port_to: 22
-      ipv4_cidr: "0.0.0.0/0"
-  egress:
-    - protocol: all
-      ipv4_cidr: "0.0.0.0/0"
-```
-
-#### Coexistence with Custom VNs
-
-Creating custom VirtualNetworks does not affect default resources. A tenant
-can have both default and custom VNs. Resources created
-without `network_attachments` always use the defaults. Resources created
-with explicit `network_attachments` use the specified resources — no
-defaults are applied.
-
-Default resources cannot be deleted while any resource depends on them
-(standard referential integrity).
-
-### Simplified Resource Creation
-
-Two mechanisms reduce the number of API calls needed to create a reachable
-resource from 6+ to 1:
-
-1. **Optional `network_attachments`** — omitting them resolves to defaults
-2. **Auto ExternalIP** — a field on the resource spec requests automatic
-   ExternalIP and ExternalIPAttachment creation
-
-#### Optional network_attachments
-
-When `network_attachments` is empty on a ComputeInstance, Cluster, or
-BaremetalInstance create request, the fulfillment service resolves defaults
-before persisting:
-
-1. Look up the tenant's default Subnet and default SecurityGroup (created
-   at tenant onboarding, already in READY state)
-2. Populate `network_attachments` with the default Subnet and default
-   SecurityGroup
-3. Store the resolved spec — the resource is self-describing after creation
-
-The resolved `network_attachments` are written to the spec before the
-resource is persisted. Get/List always shows the actual attachments, even if
-the tenant omitted them at creation.
-
-For BaremetalInstance with multiple physical interfaces, omitting
-`network_attachments` places the default interface on the default subnet.
-The fabric manager picks the default interface (same as existing behavior
-when `interface` is omitted).
-
-For Cluster, omitting `network_attachments` places all node sets on the
-default subnet with the default SecurityGroup.
-
-#### Auto ExternalIP
-
-A new `external_ip_mode` field on resource specs controls automatic
-ExternalIP provisioning. The system auto-selects a pool using the same
-strategy as manual ExternalIP creation: pick the READY pool with the most
-available capacity matching the requested IP family
-(defaulting to IPv4).
-
-**ComputeInstance and BaremetalInstance:**
-
-```protobuf
-enum ExternalIPMode {
-  EXTERNAL_IP_MODE_NONE = 0;   // default: no auto ExternalIP
-  EXTERNAL_IP_MODE_AUTO = 1;   // auto-provision ExternalIP + attachment
-}
-```
-
-**Cluster:**
-
-```protobuf
-enum ClusterExternalIPMode {
-  CLUSTER_EXTERNAL_IP_MODE_NONE         = 0;
-  CLUSTER_EXTERNAL_IP_MODE_AUTO_API     = 1;  // API server only
-  CLUSTER_EXTERNAL_IP_MODE_AUTO_INGRESS = 2;  // ingress only
-  CLUSTER_EXTERNAL_IP_MODE_AUTO_ALL     = 3;  // both API and ingress
-}
-```
-
-When `external_ip_mode` is set to an AUTO value:
-
-1. The fulfillment service selects the READY ExternalIPPool with the most
-   available capacity (same auto-selection logic as manual ExternalIP
-   creation)
-2. The service creates an ExternalIP from that pool, labeled with
-   `osac.openshift.io/auto-provisioned: "true"` and an owner-reference
-   annotation pointing to the parent resource
-3. Once the ExternalIP reaches ALLOCATED state, the service creates an
-   ExternalIPAttachment binding it to the parent
-4. For clusters with `AUTO_ALL`, steps 2–3 repeat for both API and ingress
-   endpoints (two ExternalIPs, two ExternalIPAttachments)
-
-#### Auto NATGateway
-
-A `nat_gateway_mode` field on all resource specs (ComputeInstance,
-BaremetalInstance, Cluster) controls automatic NATGateway provisioning:
-
-```protobuf
-enum NATGatewayMode {
-  NAT_GATEWAY_MODE_NONE = 0;   // default: no auto NATGateway
-  NAT_GATEWAY_MODE_AUTO = 1;   // auto-provision NATGateway on the VN
-}
-```
-
-When `AUTO`, the system creates a NATGateway on the resource's
-VirtualNetwork (default or explicit) with an ExternalIP auto-selected from
-the best available pool. Since the design constrains NATGateway to one per VN, auto-creation
-is idempotent — if a NATGateway already exists on the VN, no new one is
-created. The NATGateway is owned by the VirtualNetwork, not the individual
-resource.
-
-#### CaaS Prerequisite Ordering
-
-For clusters, ExternalIPs for API and ingress are prerequisites for
-provisioning (worker nodes reach the API server via hairpin NAT). Auto
-ExternalIP solves this:
-
-1. On Cluster create with `external_ip_mode = AUTO_ALL`:
-   a. Default networking resources are resolved (already READY)
-   b. NATGateway is created if `nat_gateway_mode = AUTO`
-   c. ExternalIPs are auto-selected from the best available pool
-   d. ExternalIPAttachments are created in Pending state
-   e. ExternalIP addresses are passed as template parameters
-   f. The Cluster is dispatched for provisioning
-2. Once cluster provisioning completes and VIPs are populated in
-   ClusterStatus, the ExternalIPAttachments transition to Ready
-
-This ensures ExternalIPs exist before provisioning, resolving gap #9
-without requiring the tenant to orchestrate the ordering manually.
-
-#### Ownership and Garbage Collection
-
-Auto-created resources use the existing owner-reference annotation pattern
-(`osac.openshift.io/owner-reference`):
-
-| Auto-created resource | Owner | GC behavior |
-|---|---|---|
-| Default VirtualNetwork | Tenant (no owner-ref) | Persists until tenant deletes it |
-| Default Subnet | Default VirtualNetwork | GC'd when default VN is deleted |
-| Default SecurityGroup | Default VirtualNetwork | GC'd when default VN is deleted |
-| Auto ExternalIP | Parent resource (CI/Cluster/BMI) | GC'd when parent is deleted |
-| Auto ExternalIPAttachment | Parent resource (CI/Cluster/BMI) | GC'd when parent is deleted |
-| Auto NATGateway | VirtualNetwork | Persists with VN |
-
-When a parent resource is deleted, the system deletes auto-created
-ExternalIPAttachments first, then ExternalIPs, following the standard
-finalizer pattern. Auto-created resources can be manually deleted by the
-tenant (e.g., detaching an auto ExternalIP), but the parent resource
-continues to function without it.
-
 ### End-to-End Flows
 
 This section shows how the unified networking API works from the tenant's
@@ -640,8 +366,6 @@ osac admin create externalippool \
 ```
 
 The fabric manager registers the IP range in its IPAM for allocation.
-When auto ExternalIP is requested, the system selects the READY pool in
-the region with the most available capacity matching the IP family.
 
 #### Networking Setup (Same for All Resource Types)
 
@@ -852,68 +576,6 @@ The fabric manager creates a SNAT rule for the VN: all egress traffic from
 the VN's CIDR is source-NATted to the ExternalIP. Applies to all resources
 in the VN — VMs, BM servers, cluster nodes — since all are on the fabric.
 
-#### Simplified Flows (Default Networking + Auto ExternalIP)
-
-The explicit flows above show the full manual workflow. With default
-networking and auto ExternalIP, the same outcome is achieved in a single
-call. The explicit flow remains available for tenants who need custom
-networking.
-
-**1-call VM with external IP:**
-
-```bash
-osac create computeinstance --template ocp_virt_vm \
-  --external-ip=auto --name my-vm
-```
-
-System actions:
-1. Resolve tenant's default Subnet + default SG (already READY)
-2. Populate `network_attachments`
-3. Auto-select ExternalIP from best available pool
-4. Create ExternalIPAttachment (Pending until VM IP is assigned)
-5. Dispatch VM creation
-6. On VM running: ExternalIPAttachment transitions to Ready
-
-**1-call cluster with full connectivity:**
-
-```bash
-osac create cluster --template ocp_4_17_small \
-  --external-ip=auto-all --nat-gateway=auto \
-  --node-set workers=large,size=3 --name my-cluster
-```
-
-System actions:
-1. Resolve tenant's default Subnet + default SG (already READY)
-2. Create NATGateway on default VN (or reuse existing)
-3. Auto-select 2 ExternalIPs (API + ingress) from best available pool
-4. Create 2 ExternalIPAttachments (Pending state)
-5. Populate `network_attachments`
-6. Pass ExternalIP addresses as template parameters
-7. Dispatch cluster provisioning
-8. On cluster ready: ExternalIPAttachments activate
-
-**1-call bare-metal server:**
-
-```bash
-osac create baremetalinstance --template bcm_h100 \
-  --external-ip=auto --name my-server
-```
-
-System actions follow the same pattern as ComputeInstance — default
-interface is placed on the default subnet by the fabric manager.
-
-**Mixed: explicit networking with auto ExternalIP:**
-
-```bash
-osac create computeinstance --template ocp_virt_vm \
-  --network-attachment subnet=my-subnet,security-groups=my-sg \
-  --external-ip=auto --name my-vm
-```
-
-Explicit `network_attachments` are used (no defaults). Auto ExternalIP
-still works — the system auto-selects from the best available pool and
-attaches to the resource.
-
 ### API Extensions
 
 #### VirtualNetwork
@@ -991,15 +653,9 @@ compute workers on a standard one).
 ```protobuf
 message ComputeInstanceSpec {
   // ... existing fields ...
-  repeated ComputeNetworkAttachment network_attachments = 14;  // optional
-  ExternalIPMode external_ip_mode = 18;                        // NEW: auto ExternalIP
-  NATGatewayMode nat_gateway_mode = 19;                        // NEW: auto NATGateway
+  repeated ComputeNetworkAttachment network_attachments = 14;
 }
 ```
-
-`network_attachments` is optional. When omitted, the system resolves
-defaults (tenant's default Subnet + default SecurityGroup).
-`external_ip_mode` and `nat_gateway_mode` are immutable after creation.
 
 **BaremetalInstance** (new — defined in the
 [BareMetal Instance API enhancement](/enhancements/baremetal-instance-api)):
@@ -1013,9 +669,7 @@ message BaremetalInstanceSpec {
   optional google.protobuf.Timestamp restart_requested_at = 5;
 
   // NEW: OSAC networking
-  repeated BareMetalNetworkAttachment network_attachments = 6;  // optional
-  ExternalIPMode external_ip_mode = 7;                          // NEW: auto ExternalIP
-  NATGatewayMode nat_gateway_mode = 8;                          // NEW: auto NATGateway
+  repeated BareMetalNetworkAttachment network_attachments = 6;
 }
 ```
 
@@ -1028,9 +682,7 @@ message ClusterSpec {
   map<string, ClusterNodeSet> node_sets = 3;
 
   // NEW: networking
-  repeated ClusterNetworkAttachment network_attachments = 4;    // optional
-  ClusterExternalIPMode external_ip_mode = 5;                   // NEW: auto ExternalIP
-  NATGatewayMode nat_gateway_mode = 6;                          // NEW: auto NATGateway
+  repeated ClusterNetworkAttachment network_attachments = 4;
 }
 ```
 
@@ -1038,27 +690,6 @@ message ClusterSpec {
 - The cluster's template determines whether nodes are VMs or BM. Both
   types are placed on the same subnet — VMs via the K8s overlay (already
   bridged to the fabric), BM nodes directly on the fabric.
-
-**Shared enums for simplified resource creation:**
-
-```protobuf
-enum ExternalIPMode {
-  EXTERNAL_IP_MODE_NONE = 0;   // default: no auto ExternalIP
-  EXTERNAL_IP_MODE_AUTO = 1;   // auto-provision ExternalIP + attachment
-}
-
-enum ClusterExternalIPMode {
-  CLUSTER_EXTERNAL_IP_MODE_NONE         = 0;  // default
-  CLUSTER_EXTERNAL_IP_MODE_AUTO_API     = 1;  // API server only
-  CLUSTER_EXTERNAL_IP_MODE_AUTO_INGRESS = 2;  // ingress only
-  CLUSTER_EXTERNAL_IP_MODE_AUTO_ALL     = 3;  // both API and ingress
-}
-
-enum NATGatewayMode {
-  NAT_GATEWAY_MODE_NONE = 0;   // default: no auto NATGateway
-  NAT_GATEWAY_MODE_AUTO = 1;   // auto-provision on the resource's VN
-}
-```
 
 The Cluster resource also gains two fields populated by the system
 during provisioning:
@@ -1210,21 +841,6 @@ k8sManager — there is no K8s overlay to place the VM on.
 The operator validates that Subnet CIDRs do not overlap within a
 VirtualNetwork at creation time.
 
-#### Default Resource Tracking
-
-Default networking resources are created at tenant onboarding, not
-lazily. The Tenant controller provisions the default VN, Subnet, and SG
-as part of the tenant creation flow. The tenant transitions to READY
-only after all default networking resources are also READY.
-
-#### ExternalIPPool Auto-Selection
-
-When auto ExternalIP is requested, the system selects the READY
-ExternalIPPool with the most available capacity matching the IP family
-(defaulting to IPv4) — the same auto-selection strategy used for manual
-ExternalIP creation. When no pool has available capacity, the create
-request fails with a clear error.
-
 ### Risks and Mitigations
 
 | Risk | Impact | Mitigation |
@@ -1234,10 +850,6 @@ request fails with a clear error.
 | CaaS prerequisite ordering | ExternalIPs may be needed before cluster | Pending state for attachments; template validates its own prerequisites |
 | ExternalIPAttachment target validation | Target may not exist yet (CaaS) or may be deleted | Pending state for forward references; attachment tracks target lifecycle |
 | CIDR overlap | Overlapping subnets cause routing ambiguity | Operator validates at creation time; rejected with clear error |
-| Default CIDR supernet exhaustion (isolated_cidr mode) | No more tenants can get defaults | Provider monitoring on allocation count; clear error; provider can widen supernet |
-| ExternalIPPool exhaustion | Auto ExternalIP requests fail | Pool capacity visible in status; clear error directs tenant to explicit allocation from another pool |
-| Default SecurityGroup too permissive | Security exposure for new tenants | Provider configures default rules; tenant can tighten after creation |
-| Auto ExternalIP orphans on partial failure | ExternalIP allocated but attachment creation fails | Standard finalizer pattern; controller retries; if permanently failed, ExternalIP is GC'd with parent |
 
 ### Drawbacks
 
@@ -1315,34 +927,6 @@ time. Creates ambiguous subnet state and complicates the tenant experience.
     type has a different selector concept (virtual NIC, physical interface,
     node set) — a shared type with optional fields would accumulate
     dead weight per resource type.
-
-12. **Default resource creation is eager.** Defaults are created at tenant
-    onboarding, not lazily on first use. The tenant transitions to READY
-    only after all default networking resources are also READY.
-
-13. **CIDR allocation.** In `shared_cidr` mode (default), all tenants
-    receive the same CIDR. In `isolated_cidr` mode, the system allocates
-    the next available prefix from the provider's supernet.
-
-14. **Auto ExternalIPs are owned by the parent resource.** They use the
-    standard owner-reference annotation and are garbage-collected on parent
-    deletion. They are visible and can be manually detached by the tenant.
-
-15. **Cluster ExternalIP allocation happens before provisioning dispatch.**
-    The system allocates ExternalIPs synchronously during the Cluster
-    create flow, passes the addresses to the CaaS template as parameters,
-    and creates ExternalIPAttachments in Pending state. This resolves the
-    CaaS prerequisite ordering problem (gap #9).
-
-16. **NATGateway auto-creation is per-VN, not per-resource.** Since the
-    design constrains NATGateway to one per VN, auto-creation is
-    idempotent — if a NATGateway already exists on the VN, no new one is
-    created.
-
-17. **Default CIDR mode is `shared_cidr`.** In OSAC's fabric-first model,
-    tenants are already isolated at the fabric level. Overlapping CIDRs
-    between tenants are not a problem. `isolated_cidr` is available for
-    providers who want IP-level uniqueness.
 
 ## Test Plan
 

--- a/enhancements/unified-networking/README.md
+++ b/enhancements/unified-networking/README.md
@@ -349,11 +349,6 @@ OSAC provisions a set of default networking resources per tenant on first
 use. This eliminates the need for tenants to understand the networking
 resource model before creating their first resource.
 
-Note: region is not yet a fully defined concept in OSAC. When region
-support is implemented, default networking resources will be scoped per
-tenant per region. Until then, the design assumes a single-region
-deployment.
-
 #### What Is Auto-Created
 
 For each tenant, on first use:


### PR DESCRIPTION
## Summary

Minor fixes to the unified networking PRD:

- Replace "AWS VPC or Azure VNet" with "cloud VPC or VNet" in terminology
- remove region references (region is not yet a fully defined concept in OSAC)

The default networking and auto ExternalIP content has been moved to a standalone PRD: #90

## Test plan

- [ ] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)