### PR TITLE
OSAC-1269: Design: Managed Versions for Cluster Provisioning

### DIFF
--- a/enhancements/cluster-version-api/README.md
+++ b/enhancements/cluster-version-api/README.md
@@ -1,0 +1,644 @@
+---
+title: cluster-version
+authors:
+  - iskornya@redhat.com
+creation-date: 2026-06-29
+last-updated: 2026-07-01
+tracking-link:
+  - https://redhat.atlassian.net/browse/OSAC-1269
+prd:
+  - "prd.md"
+see-also:
+  - ../../enhancements/catalog-items/README.md
+replaces:
+  - "N/A"
+superseded-by:
+  - "N/A"
+---
+
+# ClusterVersion
+
+## Summary
+
+This enhancement introduces a `ClusterVersion` resource that lets OSAC expose OpenShift versions as managed catalog entries instead of asking users to provide raw release-image pullspecs. The fulfillment-service stores the catalog as the source of truth, projects it to hub clusters as a `ClusterVersion` CRD, validates version selection during cluster creation, and lets the operator surface lifecycle changes such as deprecation on existing clusters. See [PRD](prd.md) for detailed requirements.
+
+## Motivation
+
+Cluster creation currently requires a caller to know an exact OpenShift release image URL. That exposes implementation details, makes validation weaker than it should be, and provides no platform-level way to discover which versions are supported, deprecated, or obsolete. OSAC also lacks a shared version identity that later features, especially upgrade workflows, can reference.
+
+Introducing a managed version catalog fixes those gaps. It gives admins a place to manage version availability and lifecycle, gives tenants a stable version identifier to select, and gives the platform a way to propagate lifecycle signals to already-created clusters without embedding release-image details in the user-facing API.
+
+### Goals
+
+- Keep semantic version selection in the API layer and defer release-image resolution to provisioning.
+- Reuse existing all-hubs reconciliation and feedback patterns for cross-component propagation where possible.
+- Carry version identity and channel metadata end-to-end without storing resolved release images on `Cluster` objects.
+- Support future multi-architecture expansion without introducing a second version-to-image schema.
+- Preserve an upgrade-compatible version identity model for later work such as OSAC-1415.
+
+### Non-Goals
+
+- Implement cluster upgrades, rollback, or upgrade orchestration. That remains the responsibility of OSAC-1415.
+- Automatically import or synchronize versions from ACM `ClusterImageSet` resources in `v0.2`.
+- Extend this design to VM image management; that remains separate work under `ComputeImage`.
+- Add architecture-aware scheduling or NodePool-specific image selection in `v0.2`.
+- Require the operator to resolve release images; image resolution remains a provisioning-layer responsibility.
+- Guarantee catalog-item authoring-time validation in the first cut if the catalog-items work has not landed yet.
+
+## Proposal
+
+OSAC adds a new platform-global `ClusterVersion` resource. Each entry represents one OpenShift version and includes:
+
+- the semantic version identifier exposed to users
+- one or more release images, keyed by architecture
+- lifecycle state such as active, deprecated, or obsolete
+- optional update-channel metadata
+- an optional replacement version for deprecated entries
+- flags for availability to new clusters and default selection
+
+The fulfillment-service remains the source of truth for this data. It reconciles the catalog to hub clusters as a `ClusterVersion` CRD so that downstream components can consume version identity and lifecycle changes locally. The operator uses the hub CRD to react to lifecycle changes on existing clusters. AAP uses the same hub CRD to resolve the actual release image during provisioning.
+
+The cluster API stops accepting raw `release_image` input and instead uses:
+
+- `cluster_version` as the selected version identifier
+- `channel` as optional update-channel metadata
+
+`ClusterTemplate` gains:
+
+- `spec_defaults.cluster_version` for template-level defaulting
+- `supported_architectures` to declare which architectures its provisioning implementation can handle
+
+The initial milestone is `v0.2` and is focused on CaaS. The main affected components are:
+
+- `fulfillment-service`
+- `osac-operator`
+- `osac-aap`
+- `osac-installer`
+- `osac-test-infra`
+
+### Workflow Description
+
+#### Actors
+
+- **Cloud Provider Admin** manages the version catalog.
+- **Tenant User** creates clusters using a selected version.
+- **Fulfillment Service** validates requests and projects catalog data to hubs.
+- **OSAC Operator** reacts to version lifecycle changes on existing cluster resources.
+- **AAP** resolves the final release image during provisioning.
+
+#### Admin workflow: manage the version catalog
+
+1. A Cloud Provider Admin creates a `ClusterVersion` entry with a version identifier, at least one release image, and optional channel and lifecycle metadata. If `enabled` is not set explicitly, the server defaults it to `true` so the version is usable for new cluster creation by default.
+2. The fulfillment-service validates the entry, persists it, and enforces catalog invariants such as unique version identity and at most one default version.
+3. The fulfillment-service reconciles the entry to all hub clusters as a `ClusterVersion` CRD.
+4. The admin can later mark the version as deprecated or obsolete, set a replacement version, disable it for new cluster creation, or change which version is the default.
+
+#### Tenant workflow: create a cluster with a managed version
+
+```mermaid
+sequenceDiagram
+    actor User as Tenant User
+    participant FS as Fulfillment Service API
+    participant DB as PostgreSQL
+    participant Rec as FS Reconciler
+    participant Hub as Hub Cluster API
+    participant Op as OSAC Operator
+    participant AAP as AAP
+    participant HC as HostedCluster
+
+    User->>FS: CreateCluster(cluster_version, channel)
+    FS->>FS: Apply request, template, or system defaults
+    FS->>DB: Validate selected ClusterVersion
+    DB-->>FS: Version metadata and release-image catalog
+    FS->>DB: Persist Cluster with cluster_version and channel
+    FS-->>User: Cluster accepted
+    Rec->>Hub: Reconcile ClusterOrder and ClusterVersion projection
+    Op->>Hub: Watch new ClusterOrder
+    Op-->>AAP: Trigger provisioning workflow
+    AAP->>Hub: Read ClusterVersion CRD
+    AAP->>AAP: Resolve release image for supported architecture
+    AAP->>HC: Provision HostedCluster with resolved image
+```
+
+1. A Tenant User creates a cluster and may specify `cluster_version` and `channel`.
+2. Resolution precedence for `cluster_version` is: explicit user input, then the default from the active request path (template or catalog item, but never both), then the system default version. If the request omits `cluster_version`, the server starts at the highest remaining source in that order.
+3. The fulfillment-service validates that the selected version exists, is still available for new clusters, is not obsolete, and is compatible with the selected template.
+4. The fulfillment-service stores `cluster_version` and `channel` on the cluster and reconciles them to the hub-facing `ClusterOrder`.
+5. AAP resolves the release image from the hub `ClusterVersion` CRD and uses that resolved image for provisioning.
+
+#### Error handling
+
+| Scenario | API behavior | gRPC code |
+| ---- | ---- | ---- |
+| Referenced version does not exist | Reject the request before cluster creation. | `InvalidArgument` |
+| Referenced version is disabled | Reject the request for new cluster creation. | `InvalidArgument` |
+| Referenced version is obsolete | Reject the request for new cluster creation. | `InvalidArgument` |
+| No version can be resolved through input or defaults | Reject the request until a caller or admin supplies one. | `InvalidArgument` |
+| Provided channel is not valid for the selected version | Reject the request before persistence. | `InvalidArgument` |
+| Selected version has no release image compatible with the template's supported architectures | Reject the request before persistence. | `InvalidArgument` |
+| `cluster_version` or `channel` is changed after create | Reject the update because both fields are immutable. | `InvalidArgument` |
+| A referenced version is still in use during deletion | Reject the deletion until references are removed. | `FailedPrecondition` |
+| Two concurrent requests try to set different defaults | Allow one winner and reject the other update. | `FailedPrecondition` |
+
+#### Lifecycle workflow: propagate deprecation or obsolescence
+
+```mermaid
+sequenceDiagram
+    actor Admin as Cloud Provider Admin
+    participant FS as Fulfillment Service API
+    participant DB as PostgreSQL
+    participant Rec as FS Reconciler
+    participant Hub as Hub Cluster API
+    participant Op as OSAC Operator
+    participant Sync as Feedback Sync
+
+    Admin->>FS: Update ClusterVersion lifecycle state
+    FS->>DB: Persist updated state
+    Rec->>Hub: Update ClusterVersion CRD projection
+    Hub-->>Op: Watch ClusterVersion change
+    Op->>Hub: Find affected ClusterOrders
+    Op->>Hub: Set or clear lifecycle conditions
+    Sync->>FS: Sync conditions back to cluster status
+    FS-->>Admin: Future Get/List shows lifecycle signal
+```
+
+1. An admin updates a `ClusterVersion` lifecycle state in the fulfillment-service.
+2. The reconciler updates the corresponding hub `ClusterVersion` CRD.
+3. The operator detects the change, finds affected `ClusterOrder` resources, and sets or clears lifecycle conditions.
+4. Those conditions are synced back to the fulfillment-service so that cluster `Get` and `List` responses expose the lifecycle signal.
+
+`enabled` is treated as admission policy for new cluster creation, not as a lifecycle signal for already-created clusters. Changing `enabled` blocks new use of a version but does not add conditions to existing clusters.
+
+### API Extensions
+
+This enhancement adds or changes the following API surfaces:
+
+- **Fulfillment gRPC/REST APIs**
+  - New `ClusterVersions` API for managing and listing version catalog entries.
+  - `Clusters` API replaces `release_image` input with `cluster_version` and `channel`.
+  - `ClusterTemplates` gain version-default and architecture-capability fields relevant to cluster creation.
+  - Public `ClusterVersions/List` hides disabled and obsolete versions by default unless the caller explicitly filters on lifecycle or availability fields.
+  - The fulfillment-service event payload gains a `ClusterVersion` entry so create, update, and delete operations participate in change notifications and event-driven reconciliation.
+- **OSAC CRDs**
+  - New namespaced hub `ClusterVersion` CRD as a projection of the fulfillment-service catalog.
+  - `ClusterOrder` gains `clusterVersion` and `channel`.
+- **Lifecycle signaling**
+  - Clusters receive lifecycle conditions such as deprecated or obsolete when their referenced version changes state.
+  - The fulfillment-service cluster API surface gains matching lifecycle condition types `CLUSTER_CONDITION_TYPE_VERSION_DEPRECATED` and `CLUSTER_CONDITION_TYPE_VERSION_OBSOLETE` so those signals are visible on cluster `Get` and `List` responses.
+
+The public API does not expose release-image URLs. Tenant-facing clients see semantic version information and lifecycle state, while release-image resolution stays internal.
+
+#### Public `ClusterVersion` schema
+
+The public API contract for `ClusterVersion` is intentionally small and safe for tenant-facing consumers:
+
+```protobuf
+message ClusterVersion {
+  string id = 1;
+  Metadata metadata = 2;
+  ClusterVersionSpec spec = 3;
+  ClusterVersionStatus status = 4;
+}
+
+message ClusterVersionSpec {
+  optional bool enabled = 2;
+  optional bool is_default = 3;
+  repeated string available_channels = 4;
+  ClusterVersionState state = 5;
+  ClusterVersionDeprecation deprecation = 6;
+  string version = 7;
+}
+
+enum ClusterVersionState {
+  CLUSTER_VERSION_STATE_UNSPECIFIED = 0;
+  CLUSTER_VERSION_STATE_ACTIVE = 1;
+  CLUSTER_VERSION_STATE_DEPRECATED = 2;
+  CLUSTER_VERSION_STATE_OBSOLETE = 3;
+}
+
+message ClusterVersionDeprecation {
+  string replacement = 1;
+  google.protobuf.Timestamp deprecation_timestamp = 2;
+  google.protobuf.Timestamp obsolescence_timestamp = 3;
+}
+```
+
+- **Stable identifier:** dependent features should reference `spec.version`.
+- **Primary UI fields:** `spec.version`, `spec.state`, `spec.enabled`, `spec.is_default`, `spec.available_channels`, and `spec.deprecation.replacement`.
+- **Timestamp semantics:** deprecation timestamps are system-managed lifecycle metadata rather than admin-supplied inputs.
+
+#### Private-only fields
+
+The private and internal form of `ClusterVersion` carries release-image metadata that is not exposed in the public API:
+
+```protobuf
+message ClusterVersionReleaseImage {
+  string architecture = 1;
+  string url = 2;
+}
+```
+
+- **Visibility split:** private `ClusterVersionSpec` includes `release_images[]`; public `ClusterVersionSpec` does not.
+- **Reason:** the platform can validate and resolve release images without exposing raw pullspecs to tenant-facing clients.
+- **Naming model:** in the fulfillment-service, `metadata.name` may be a DNS-safe slug such as `ocp-4-17-0`; on the hub CRD, `metadata.name` is the semantic version string from `spec.version`, such as `4.17.0`.
+- **Uniqueness key:** uniqueness is enforced on `spec.version`, not on `metadata.name`.
+
+#### Changes to existing resource schemas
+
+Dependent features are more likely to interact with the changes to existing schemas than with the new catalog resource itself:
+
+```protobuf
+message ClusterSpec {
+  optional string cluster_version = 9;
+  optional string channel = 10;
+  // release_image is removed from the API contract.
+}
+
+message ClusterTemplateSpecDefaults {
+  optional string cluster_version = 5;
+  // release_image defaults are removed from this contract in favor of cluster_version.
+}
+```
+
+```protobuf
+message ClusterTemplate {
+  repeated string supported_architectures = 8;
+}
+```
+
+- **Template version defaults:** `spec_defaults.cluster_version` is set by the admin via the private API after template publication. The publish pipeline preserves admin-set values across re-publication.
+- **ClusterOrder CRD:** gains `clusterVersion` and `channel`; it carries semantic version identity and channel metadata, not a resolved release image.
+- **Cluster lifecycle API:** cluster responses gain matching lifecycle condition types for version deprecation and obsolescence so downstream features and UI flows can render durable warnings from cluster state.
+- **Template migration:** `spec_defaults.release_image` is no longer part of the cluster-creation contract. Templates that previously relied on that field must migrate to `spec_defaults.cluster_version`.
+
+#### UI-facing behavior
+
+The public API behavior that matters most to UI consumers is:
+
+- default `ClusterVersions/List` calls hide disabled and obsolete versions unless the caller explicitly filters for them
+- create-time warnings are visible to gRPC callers, but REST callers should rely on cluster lifecycle conditions returned by later `Get` and `List` requests
+- `enabled=false` blocks new cluster creation with a version but does not add a lifecycle condition to existing clusters
+- `spec.deprecation.replacement` is the field UI flows can use to suggest a newer version when the current one is deprecated
+
+Example public payload shape:
+
+```json
+{
+  "id": "uuid",
+  "metadata": {
+    "name": "ocp-4-17-0"
+  },
+  "spec": {
+    "version": "4.17.0",
+    "enabled": true,
+    "isDefault": true,
+    "state": "DEPRECATED",
+    "availableChannels": ["stable-4.17", "fast-4.17"],
+    "deprecation": {
+      "replacement": "4.18.0"
+    }
+  },
+  "status": {}
+}
+```
+
+#### CLI surface
+
+- **Tenant flow:** `osac create cluster` accepts `--cluster-version` and `--channel`.
+- **Admin flow:** the version catalog is managed with:
+  - `osac create cluster-version`
+  - `osac get cluster-version`
+  - `osac get cluster-versions`
+  - `osac update cluster-version`
+  - `osac delete cluster-version`
+- **Lookup behavior:** admin lookup should resolve by semantic version as well as object identity so commands such as `osac get cluster-version 4.17.0` are natural to use.
+- **Rendered fields:** CLI output should expose the same user-facing fields as the public API: version, lifecycle state, enabled/default status, available channels, and replacement version when present.
+
+### Implementation Details/Notes/Constraints
+
+#### Design overview
+
+- **Semantic version selection:** happens at the API layer.
+- **Release-image resolution:** happens at provisioning time.
+- **Why:** this separation keeps the user-facing cluster API stable and future-proofs the design for multi-architecture support and upgrade workflows.
+
+#### Data model
+
+The concise schema shape below keeps the fields that matter to the design and omits boilerplate:
+
+```protobuf
+message ClusterVersionSpec {
+  repeated ClusterVersionReleaseImage release_images = 1;
+  // Release images are stored per architecture so the model can grow into
+  // multi-architecture support without introducing a second schema later.
+
+  optional bool enabled = 2;
+  // Controls whether new clusters may select this version.
+
+  optional bool is_default = 3;
+  // At most one active ClusterVersion may be default.
+
+  repeated string available_channels = 4;
+  // Carried now so later upgrade work can reuse the same version identity.
+
+  ClusterVersionState state = 5;
+  ClusterVersionDeprecation deprecation = 6;
+
+  string version = 7;
+  // This is the stable semantic version identifier.
+}
+```
+
+```protobuf
+message ClusterVersionDeprecation {
+  string replacement = 1;
+  // Must reference an existing, non-deleted ClusterVersion by spec.version.
+
+  google.protobuf.Timestamp deprecation_timestamp = 2;
+  // Set by the system when state transitions to DEPRECATED.
+
+  google.protobuf.Timestamp obsolescence_timestamp = 3;
+  // Set by the system when state transitions to OBSOLETE.
+  // Both timestamps are cleared if the version returns to ACTIVE.
+}
+```
+
+```go
+type ClusterVersionSpec struct {
+    ReleaseImages []ClusterVersionReleaseImage `json:"releaseImages"`
+    State ClusterVersionState `json:"state,omitempty"`
+    AvailableChannels []string `json:"availableChannels,omitempty"`
+    Enabled bool `json:"enabled"`
+    IsDefault bool `json:"isDefault,omitempty"`
+    Deprecation *ClusterVersionDeprecation `json:"deprecation,omitempty"`
+}
+
+type ClusterVersionStatus struct{}
+```
+
+The hub projection is intentionally small: it carries version identity, lifecycle state, availability, and release-image metadata, but no provisioning status. `ClusterVersion` is reference data, not a provisionable resource, so it does not follow the usual AAP-backed Phase / Job-history pattern used by workload-facing OSAC resources. OSAC uses `osac.openshift.io/v1alpha1`, so this resource does not conflict with OpenShift's built-in `ClusterVersion` in `config.openshift.io/v1`. Using a short name such as `cver` or the fully qualified resource name avoids CLI ambiguity.
+
+```protobuf
+message ClusterSpec {
+  optional string cluster_version = 9;
+  // Replaces raw release_image selection in the user-facing API.
+
+  optional string channel = 10;
+  // Optional channel metadata validated against ClusterVersion.
+}
+
+message ClusterTemplateSpecDefaults {
+  optional string cluster_version = 5;
+  // Lets templates provide a default managed version.
+}
+
+message ClusterTemplate {
+  repeated string supported_architectures = 8;
+  // Declares what the provisioning implementation can actually handle.
+}
+```
+
+`ClusterOrderSpec` carries `clusterVersion` and `channel` to the hub.
+
+#### Core invariants
+
+- A version identifier is unique among active `ClusterVersion` entries, and that uniqueness is enforced on `spec.version` rather than `metadata.name`.
+- At most one version can be marked as the default.
+- Setting `is_default=true` on one version clears the previous default within the same transaction.
+- Obsolete versions cannot be used for new clusters.
+- An obsolete or disabled version cannot be set as the default.
+- If a default version transitions to `OBSOLETE` or is disabled (`enabled=false`), the server clears `is_default` as part of the same change.
+- `spec.version` is immutable after creation.
+- `cluster_version` and `channel` are immutable after cluster creation.
+- Versions referenced by clusters or templates cannot be removed while still in use.
+- Public APIs expose version identity and lifecycle state, but not release-image URLs.
+
+#### Validation model
+
+- **Create-time checks:** existence of the referenced version, availability for new cluster creation, lifecycle state, channel membership when provided, compatibility between the template's supported architectures and the version's available release images, and version format using a Kubernetes-safe semver subset because the version string becomes the hub `ClusterVersion` resource name.
+- **Reference checks:** `deprecation.replacement`, when set, must point at an existing non-deleted `ClusterVersion`.
+- **Template default checks:** `ClusterTemplate` create and update validate `spec_defaults.cluster_version` in the server layer so admins get descriptive errors; database triggers remain the race-safety backstop.
+- **State transitions:** lifecycle state transitions are allowed in any direction.
+- **Default guard:** if an admin attempts to set `is_default=true` on a version that is `OBSOLETE` or disabled, the request is rejected.
+- **Deprecation signaling:** if a deprecated version is still allowed for new clusters, creation succeeds but the user receives a deprecation warning.
+- **Client behavior:** gRPC callers can receive immediate create-time warnings. REST callers do not receive those sibling `warnings` fields because the gateway response body is the embedded `object`; for REST, the durable notification path is the cluster lifecycle conditions returned by later `Get` and `List` calls.
+
+#### Database considerations
+
+- **Persistence model:** the fulfillment-service needs new live and archived storage for `ClusterVersion`.
+- **Uniqueness:** a partial unique index enforces unique active `spec.version`.
+- **Single default:** a partial unique index enforces a single active default.
+- **Reference integrity:** validation triggers reject clusters or templates that point at missing or deleted versions.
+- **Delete protection:** soft deletion is rejected while references still exist.
+- **Performance:** an index on `clusters.spec.cluster_version` keeps reference checks efficient.
+- **Enforcement split:** these database checks complement, rather than replace, server-side validation. `spec.version` immutability is enforced in the server layer because generic immutable-column triggers cannot protect JSON payload fields.
+- **Error mapping:** reference-validation failures translate to `InvalidArgument`, while delete-in-use failures translate to `FailedPrecondition`.
+
+#### Reconciliation model
+
+The fulfillment-service is the source of truth for `ClusterVersion` data and projects that data to hub-scoped consumers.
+
+##### Projection
+
+The fulfillment-service reconciles every `ClusterVersion` entry to a namespaced hub `ClusterVersion` CRD. This gives downstream components a local hub-scoped representation of version identity, lifecycle state, and release-image metadata without making the hub the source of truth. [[tenant_reconciler_function.go](https://github.com/osac-project/fulfillment-service/blob/737af8524e73674ee7b93434ee70d69f5b01fc9a/internal/controllers/onboarding/tenant_reconciler_function.go)]
+
+The existing cluster reconciler is also modified to copy `spec.cluster_version` and `spec.channel` from the fulfillment-service `Cluster` into the hub `ClusterOrder`. That handoff is what lets operator and AAP logic consume semantic version identity from the hub-facing resource instead of a resolved image.
+
+##### Triggers
+
+Reconciler registration reacts both to `ClusterVersion` change events and to new-hub registration events. The new-hub trigger ensures that when a hub is added, existing `ClusterVersion` entries are reconciled to it immediately rather than waiting for the periodic full sync.
+
+##### Operator ordering
+
+On the operator side, lifecycle condition handling runs after the existing `ClusterOrder` reconciliation path. That ordering ensures version-state signaling augments normal provisioning reconciliation rather than replacing or short-circuiting it.
+
+##### Current limitation
+
+The reconciler inherits the all-hubs iteration behavior of the onboarding tenant reconciler: with multiple hubs, one unreachable hub can block progress to later hubs in the same pass. This is acceptable for the single-hub `v0.2` deployment model, but a future multi-hub design would likely need best-effort iteration and aggregated error reporting.
+
+#### Provisioning model
+
+AAP consumes the hub projection rather than relying on the user-facing cluster API to carry a resolved image.
+
+##### Resolution point
+
+AAP reads the namespaced hub `ClusterVersion` CRD during provisioning and resolves the final release image there rather than on the user-facing cluster API. This keeps the API contract semantic while allowing the provisioning layer to choose the concrete image it needs. In `v0.2`, existing templates use the `multi` architecture entry.
+
+##### Failure behavior
+
+Provisioning fails closed if the expected hub `ClusterVersion` CRD is missing. The design intentionally avoids silently falling back to a template-default release image because that would decouple actual provisioning behavior from the admin-managed version catalog and could provision the wrong OpenShift version.
+
+##### Template version defaults
+
+- `supported_architectures` is declared in template roles via `meta/osac.yaml` and published to the fulfillment-service through the AAP template pipeline.
+- `spec_defaults.cluster_version` is set by the admin via the private API after template publication. The template author cannot know which `ClusterVersion` catalog entries exist in a given deployment, so this value is a deployment-specific choice rather than a template capability.
+
+#### Event and feedback plumbing
+
+This design has a forward event path for projection and a reverse feedback path for lifecycle visibility.
+
+##### Forward path
+
+`ClusterVersion` must participate in the fulfillment-service event payload flow so create, update, and delete operations emit change notifications. The event proto therefore needs a `ClusterVersion` entry in its payload `oneof`. Without that payload support, event-driven reconciliation does not happen. Without generic-server payload mapping for `ClusterVersion`, CRUD operations fail instead of committing because event emission rolls the transaction back.
+
+##### Reverse path
+
+Version lifecycle conditions set on `ClusterOrder` resources must be mirrored back into the fulfillment-service cluster status surface so API clients can see the same lifecycle signal the operator applies on the hub. This extends the existing `ClusterOrder` feedback path rather than introducing a `ClusterVersion`-specific feedback controller. The [feedback controller's condition switch](https://github.com/osac-project/osac-operator/blob/4ad2b2da0cdcdca69e4a9ed47e9f92f6267e4a2c/internal/controller/feedback_controller.go#L182-L199), the `ClusterOrder` condition type enum, and the fulfillment-service cluster condition enums must all be extended to handle the new lifecycle condition types.
+
+##### `v0.2` scope
+
+`v0.2` does not introduce a dedicated `ClusterVersion` feedback controller. `ClusterVersionStatus` is empty, so there is no resource-specific status to sync back. The fulfillment-service reconciler remains responsible for projecting, updating, and deleting the hub `ClusterVersion` CRD, while the operator's existing `ClusterOrder` controller watches `ClusterVersion` changes to set lifecycle conditions on affected orders.
+
+#### Scope notes for `v0.2`
+
+- The design supports channels now mainly so later upgrade work can reuse the same identity and metadata.
+- Multi-architecture support is enabled by the schema shape, but `v0.2` still assumes existing templates resolve the `multi` image.
+- Catalog-item authoring-time validation may be deferred if the catalog-items work lands later than this enhancement.
+- Catalog-item consumption-time resolution needs no special path-resolution change: existing field-definition application already handles `spec.cluster_version`, so the added work is validation rather than a new substitution mechanism.
+- `supported_architectures` must not be published before the fulfillment-service schema accepts the field; producer and consumer rollout order matters.
+
+### Security Considerations
+
+- **Authentication and authorization:** this enhancement inherits the existing OSAC security model. The fulfillment-service continues to use the current JWT-based request authentication chain, and write operations for the version catalog remain restricted through existing OPA-based admin authorization.
+- **Data exposure:** `release_images[].url` remains private to admin-facing and internal flows; tenant-facing APIs expose semantic version identity and lifecycle metadata, but not raw image pullspecs.
+- **Input validation:** version strings, channels, and template compatibility are validated before persistence so invalid references do not leak into downstream provisioning.
+
+### Failure Handling and Recovery
+
+| Failure mode | What happens | Recovery | User observes |
+| ---- | ---- | ---- | ---- |
+| Database error during create or update | The request transaction rolls back. | Retry the request after the backend recovers. | The API returns an internal error and no partial object is created. |
+| Two requests race to set different default versions | One request succeeds and the other loses the uniqueness race. | Retry the losing request if needed after reviewing the current default. | The loser receives `FailedPrecondition`. |
+| A referenced version is deleted between validation and persistence | Database-side reference checks reject the write. | Retry with a valid version after reconciliation settles. | The create or update fails with `InvalidArgument`. |
+| The hub projection is temporarily missing or stale | Lifecycle conditions may not appear yet, or provisioning may fail closed if it depends on the missing projection. | Event-driven reconciliation or periodic full sync recreates the projection; retries then succeed. | Status may lag, or provisioning may fail and retry rather than silently using the wrong image. |
+| AAP cannot resolve the hub `ClusterVersion` CRD | Provisioning stops before using an unmanaged fallback image. | Retry after the projection exists. | The cluster remains unprovisioned until reconciliation catches up. |
+| `ClusterOrder` lifecycle-condition feedback sync back to fulfillment-service is unavailable | Hub-side lifecycle conditions still exist, but API-side cluster status may lag. | Controller retries continue until the sync path is healthy again. | Cluster `Get` and `List` may temporarily miss a lifecycle condition already visible on the hub. |
+| A controller restarts mid-reconciliation | Reconciliation restarts from persisted state. | Normal controller retry behavior resumes the work. | At worst, propagation is delayed; the design relies on idempotent reconciliation rather than one-shot execution. |
+
+### RBAC / Tenancy
+
+- **Resource model:** `ClusterVersion` is a platform-global resource, not a tenant-owned one.
+- **Visibility:** authenticated users may read tenant-safe version metadata, while create, update, and delete remain Cloud Provider Admin operations through OPA enforcement.
+- **Tenant metadata:** no tenant isolation annotations such as `osac.openshift.io/tenant` or `osac.openshift.io/owner-reference` are required on `ClusterVersion` because it is not a tenant-scoped resource. Tenant isolation still applies at the consuming-resource level, where clusters and cluster orders remain tenant-owned.
+- **Hub RBAC:** hub-access RBAC must allow the fulfillment-service reconciler to manage `ClusterVersion` CRDs on hub clusters, while the operator and AAP need read access to consume those projections.
+
+### Observability and Monitoring
+
+No new observability changes. Existing monitoring mechanisms apply.
+
+- **API visibility:** `ClusterVersions` API requests use the existing fulfillment-service gRPC metrics and structured logging.
+- **Controller visibility:** lifecycle propagation continues to surface through existing operator reconciliation logs and Kubernetes events.
+- **Provisioning visibility:** AAP job output remains the primary signal for provisioning behavior and failure diagnosis.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| No catalog entries exist when the feature is deployed. | Ship seeded versions as part of the deployment story and document the admin setup flow. |
+| The public cluster API changes from raw release-image input to version selection. | Treat this as a coordinated API change for a fresh-deployment milestone and update dependent components together. |
+| Cross-component skew causes one component to expect fields another component does not yet support. | Deploy fulfillment-service schema changes and hub CRD support before enabling downstream publisher or provisioning changes. |
+| The hub `ClusterVersion` projection lags behind the fulfillment-service source of truth. | Use event-driven reconciliation plus periodic full sync; treat hub state as eventually consistent but self-healing. |
+| A selected version is incompatible with a template's provisioning implementation. | Validate architecture compatibility before provisioning begins. |
+| Catalog-item integration lands later than this feature. | Keep the core version-catalog flow independent and phase catalog-item authoring validation separately if needed. |
+| AAP receives a `ClusterOrder` before the corresponding hub `ClusterVersion` projection exists. | Fail provisioning explicitly, then rely on reconciliation and retry rather than falling back to an unmanaged image source. |
+
+### Drawbacks
+
+This design adds an administrative catalog-management step before tenants can create clusters. That is more operational overhead than allowing users to pass arbitrary release-image URLs directly.
+
+The proposal also adds a new synchronization surface between the fulfillment-service and hub clusters. That increases cross-component complexity compared with a fulfillment-service-only design.
+
+Finally, using a release-image array now is slightly more complex than a single string field, even though `v0.2` primarily uses one `multi` entry. The trade-off is that future architecture-specific support does not require a schema redesign.
+
+## Alternatives (Not Implemented)
+
+### Keep a single `release_image` string on the cluster API
+
+This keeps the current API shape and avoids a new resource.
+
+It was rejected because it preserves the current usability and validation problems, exposes infrastructure details to tenants, and does not create a reusable version identity for lifecycle or upgrade workflows.
+
+### Add a `ClusterVersion` catalog but keep it only in the fulfillment-service
+
+This avoids a new hub CRD and reduces synchronization work.
+
+It was rejected because the operator would lose a local version resource to watch for lifecycle changes, and AAP would still need another way to resolve version data during provisioning. The hub projection gives both consumers a shared local representation.
+
+### Model release images as a single field instead of an array
+
+This simplifies the first implementation.
+
+It was rejected because the design already needs to preserve a path to multi-architecture support. An array avoids a second schema migration and keeps the version-to-image relationship extensible from the start.
+
+## Open Questions
+
+- Should templates eventually be able to constrain version selection beyond architecture, for example by allowed channels or explicit version ranges?
+- Should the system-managed deprecation timestamps remain in `spec.deprecation`, or should they move to a status-oriented surface to better match the usual rule that the system does not mutate object spec?
+
+## Test Plan
+
+The test strategy focuses on validating the catalog model at each layer rather than enumerating every test case in the design:
+
+- **Unit tests:** version validation, default selection, immutability, lifecycle-state handling, and template compatibility checks in the fulfillment-service.
+- **Operator tests:** propagation of deprecated and obsolete states to `ClusterOrder` conditions and sync of those conditions back to cluster status.
+- **Integration tests:** end-to-end flow from version creation through cluster reconciliation, including delete protection and default fallback.
+- **AAP tests:** release-image resolution from the hub `ClusterVersion` CRD and failure behavior when the projection is missing.
+- **E2E tests:** admin catalog management plus tenant cluster creation using managed versions.
+
+## Graduation Criteria
+
+This enhancement should graduate by showing:
+
+- stable creation of clusters through managed version selection instead of raw release-image input
+- reliable propagation of version lifecycle state to existing clusters
+- successful operation across the fulfillment-service, operator, and AAP integration points
+- documented operational guidance for seeding versions and diagnosing failures
+
+## Upgrade / Downgrade Strategy
+
+OSAC `v0.2` assumes coordinated fresh deployment rather than in-place upgrades. No data migration is required for existing persisted version catalog data because the resource is new.
+
+If later rollout scenarios require mixed-version operation, the safe order is to deploy fulfillment-service schema and hub projection support before enabling downstream publishing, operator consumption, or AAP resolution changes.
+
+## Version Skew Strategy
+
+The initial milestone assumes coordinated deployment of all affected components. Even with that assumption, the design expects a practical rollout order:
+
+1. fulfillment-service API and reconciliation support
+2. hub CRD support in the operator
+3. template publication changes that emit architecture metadata
+4. AAP changes that resolve release images from the hub `ClusterVersion`
+
+This order prevents downstream components from depending on fields or resources that upstream components have not started producing yet.
+
+## Support Procedures
+
+### Detection
+
+- ClusterVersion API failures appear in fulfillment-service logs and metrics.
+- Cluster creation failures identify invalid, missing, disabled, or obsolete versions at request time.
+- Lifecycle propagation failures appear as reconciliation failures on affected `ClusterOrder` resources.
+- Provisioning failures caused by a missing hub projection appear in AAP job output.
+
+### Diagnosis
+
+- List `ClusterVersion` entries from the API to verify state, default selection, and channel metadata.
+- Inspect hub `ClusterVersion` CRDs to confirm the fulfillment-service projection is current.
+- Inspect `ClusterOrder` conditions to confirm lifecycle propagation.
+- Inspect operator and AAP logs when hub state and provisioning behavior diverge.
+
+- If CLI diagnostics are used, query the OSAC `ClusterVersion` resource by fully qualified name or by a short name such as `cver` to avoid confusion with OpenShift's built-in `ClusterVersion` resource.
+
+### Recovery
+
+- Recreate or fix a missing `ClusterVersion` entry, then allow reconciliation to repopulate the hub projection.
+- Change cluster or template references before attempting to remove a version that is still in use. If catalog-item integration is enabled for the milestone, those references must also be cleared.
+- Retry provisioning after the hub projection becomes available if AAP failed because the version was not yet reconciled.
+
+### Disabling
+
+This feature cannot be disabled independently without removing the new API and hub projection surfaces. The supported operational control is to disable specific versions by setting `enabled=false`, which blocks new cluster creation with those versions while leaving existing clusters unchanged.
+
+## Infrastructure Needed
+
+None beyond the normal component changes already described. If seeded default versions are treated as part of the milestone deliverable, they should be provided through the existing deployment workflow rather than through new project infrastructure.

--- a/enhancements/cluster-version-api/README.md
+++ b/enhancements/cluster-version-api/README.md
@@ -9,7 +9,7 @@ tracking-link:
 prd:
   - "prd.md"
 see-also:
-  - ../../enhancements/catalog-items/README.md
+  - "../catalog-items/README.md"
 replaces:
   - "N/A"
 superseded-by:
@@ -20,177 +20,131 @@ superseded-by:
 
 ## Summary
 
-This enhancement introduces a `ClusterVersion` resource that lets OSAC expose OpenShift versions as managed catalog entries instead of asking users to provide raw release-image pullspecs. The fulfillment-service stores the catalog as the source of truth, projects it to hub clusters as a `ClusterVersion` CRD, validates version selection during cluster creation, and lets the operator surface lifecycle changes such as deprecation on existing clusters. See [PRD](prd.md) for detailed requirements.
+This enhancement introduces a `ClusterVersion` resource that replaces raw release-image input with managed version entries for cluster creation. See [PRD](prd.md) for detailed requirements.
 
 ## Motivation
 
 Cluster creation currently requires a caller to know an exact OpenShift release image URL. That exposes implementation details, makes validation weaker than it should be, and provides no platform-level way to discover which versions are supported, deprecated, or obsolete. OSAC also lacks a shared version identity that later features, especially upgrade workflows, can reference.
 
-Introducing a managed version catalog fixes those gaps. It gives admins a place to manage version availability and lifecycle, gives tenants a stable version identifier to select, and gives the platform a way to propagate lifecycle signals to already-created clusters without embedding release-image details in the user-facing API.
+Introducing managed versions fixes those gaps. It gives admins a place to manage version availability and lifecycle, gives tenants a stable version identifier to select, and gives the platform a foundation for future upgrade workflows without embedding release-image details in the user-facing API.
 
 ### Goals
 
-- Keep semantic version selection in the API layer and defer release-image resolution to provisioning.
-- Reuse existing all-hubs reconciliation and feedback patterns for cross-component propagation where possible.
-- Carry version identity and channel metadata end-to-end without storing resolved release images on `Cluster` objects.
-- Support future multi-architecture expansion without introducing a second version-to-image schema.
-- Preserve an upgrade-compatible version identity model for later work such as OSAC-1415.
+- Replace raw release-image input on the cluster API with a managed version reference.
+- Resolve release images at reconciliation time, keeping the downstream provisioning flow unchanged.
+- Preserve an upgrade-compatible version identity model for OSAC-1415.
 
 ### Non-Goals
 
-- Implement cluster upgrades, rollback, or upgrade orchestration. That remains the responsibility of OSAC-1415.
+- Full upgrade orchestration, progress tracking, rollback, or channel-based upgrade selection (including channel metadata). [User]
 - Automatically import or synchronize versions from ACM `ClusterImageSet` resources in `v0.2`.
 - Extend this design to VM image management; that remains separate work under `ComputeImage`.
-- Add architecture-aware scheduling or NodePool-specific image selection in `v0.2`.
-- Require the operator to resolve release images; image resolution remains a provisioning-layer responsibility.
-- Guarantee catalog-item authoring-time validation in the first cut if the catalog-items work has not landed yet.
+- Hub-projected ClusterVersion CRD, operator lifecycle watches, or AAP-side version resolution.
+- Add architecture-aware scheduling, multi-architecture release-image arrays, or NodePool-specific image selection in `v0.2`.
 
 ## Proposal
 
-OSAC adds a new platform-global `ClusterVersion` resource. Each entry represents one OpenShift version and includes:
+OSAC adds a new platform-global `ClusterVersion` resource in the fulfillment-service. Each entry represents one OpenShift version and includes:
 
-- the semantic version identifier exposed to users
-- one or more release images, keyed by architecture
+- the semantic version identifier exposed to users (`spec.version`)
+- the release image URL (`spec.image`)
 - lifecycle state such as active, deprecated, or obsolete
-- optional update-channel metadata
-- an optional replacement version for deprecated entries
-- flags for availability to new clusters and default selection
+- whether it is enabled for new cluster creation and whether it is the system default version
+- an optional list of allowed target versions [User]
 
-The fulfillment-service remains the source of truth for this data. It reconciles the catalog to hub clusters as a `ClusterVersion` CRD so that downstream components can consume version identity and lifecycle changes locally. The operator uses the hub CRD to react to lifecycle changes on existing clusters. AAP uses the same hub CRD to resolve the actual release image during provisioning.
+The fulfillment-service is the sole owner of this data. At cluster creation time, the server validates the selected version. The cluster controller resolves the release image from the ClusterVersion when building the ClusterOrder — the Cluster object itself stores only the `version_name`, not the release image.
 
-The cluster API stops accepting raw `release_image` input and instead uses:
-
-- `cluster_version` as the selected version identifier
-- `channel` as optional update-channel metadata
-
-`ClusterTemplate` gains:
-
-- `spec_defaults.cluster_version` for template-level defaulting
-- `supported_architectures` to declare which architectures its provisioning implementation can handle
-
-The initial milestone is `v0.2` and is focused on CaaS. The main affected components are:
-
-- `fulfillment-service`
-- `osac-operator`
-- `osac-aap`
-- `osac-installer`
-- `osac-test-infra`
+The cluster API stops accepting raw `release_image` input and instead uses `version_name` as the selected version identifier. Basic validated version changes — where the caller explicitly sets a new `version_name` and the change is validated against `allowed_upgrades` — are in scope. [User]
 
 ### Workflow Description
 
 #### Actors
 
-- **Cloud Provider Admin** manages the version catalog.
+- **Cloud Provider Admin** manages available versions.
 - **Tenant User** creates clusters using a selected version.
-- **Fulfillment Service** validates requests and projects catalog data to hubs.
-- **OSAC Operator** reacts to version lifecycle changes on existing cluster resources.
-- **AAP** resolves the final release image during provisioning.
+- **Fulfillment Service** validates version selection and resolves release images.
 
-#### Admin workflow: manage the version catalog
+#### Admin workflow: manage versions
 
-1. A Cloud Provider Admin creates a `ClusterVersion` entry with a version identifier, at least one release image, and optional channel and lifecycle metadata. If `enabled` is not set explicitly, the server defaults it to `true` so the version is usable for new cluster creation by default.
-2. The fulfillment-service validates the entry, persists it, and enforces catalog invariants such as unique version identity and at most one default version.
-3. The fulfillment-service reconciles the entry to all hub clusters as a `ClusterVersion` CRD.
-4. The admin can later mark the version as deprecated or obsolete, set a replacement version, disable it for new cluster creation, or change which version is the default.
+1. A Cloud Provider Admin creates a `ClusterVersion` entry with a version identifier, a release image URL, and optional lifecycle metadata. If `enabled` is not set explicitly, the server defaults it to `true`. If `state` is not set, the server defaults it to `ACTIVE`.
+2. The fulfillment-service validates the entry, persists it, and enforces version invariants such as at most one default version.
+3. The admin can later mark the version as deprecated or obsolete, disable it for new cluster creation, or change which version is the default.
 
 #### Tenant workflow: create a cluster with a managed version
 
 ```mermaid
 sequenceDiagram
     actor User as Tenant User
-    participant FS as Fulfillment Service API
+    participant API as Fulfillment Service API
     participant DB as PostgreSQL
-    participant Rec as FS Reconciler
-    participant Hub as Hub Cluster API
-    participant Op as OSAC Operator
-    participant AAP as AAP
-    participant HC as HostedCluster
+    participant Ctrl as Cluster Controller
 
-    User->>FS: CreateCluster(cluster_version, channel)
-    FS->>FS: Apply request, template, or system defaults
-    FS->>DB: Validate selected ClusterVersion
-    DB-->>FS: Version metadata and release-image catalog
-    FS->>DB: Persist Cluster with cluster_version and channel
-    FS-->>User: Cluster accepted
-    Rec->>Hub: Reconcile ClusterOrder and ClusterVersion projection
-    Op->>Hub: Watch new ClusterOrder
-    Op-->>AAP: Trigger provisioning workflow
-    AAP->>Hub: Read ClusterVersion CRD
-    AAP->>AAP: Resolve release image for supported architecture
-    AAP->>HC: Provision HostedCluster with resolved image
+    User->>API: CreateCluster(version_name)
+    API->>API: Apply request, template, or system defaults
+    API->>DB: Lookup ClusterVersion by name
+    DB-->>API: Version metadata
+    API->>API: Validate: exists, enabled, not obsolete
+    API->>DB: Persist Cluster with version_name
+    API-->>User: Cluster accepted
+
+    Note over Ctrl: Reconciliation loop
+    Ctrl->>API: GetCluster (version_name)
+    Ctrl->>API: GetClusterVersion by name
+    API-->>Ctrl: spec.image
+    Ctrl->>Ctrl: Build ClusterOrder with release_image
+    Note over Ctrl: Existing provisioning flow unchanged
 ```
 
-1. A Tenant User creates a cluster and may specify `cluster_version` and `channel`.
-2. Resolution precedence for `cluster_version` is: explicit user input, then the default from the active request path (template or catalog item, but never both), then the system default version. If the request omits `cluster_version`, the server starts at the highest remaining source in that order.
-3. The fulfillment-service validates that the selected version exists, is still available for new clusters, is not obsolete, and is compatible with the selected template.
-4. The fulfillment-service stores `cluster_version` and `channel` on the cluster and reconciles them to the hub-facing `ClusterOrder`.
-5. AAP resolves the release image from the hub `ClusterVersion` CRD and uses that resolved image for provisioning.
+1. A Tenant User creates a cluster and may specify `version_name`.
+2. Resolution precedence for `version_name` is: explicit user input, then the template default (`spec_defaults.version_name`), then the system default version (`is_default=true`).
+3. The fulfillment-service validates that the selected version exists, is enabled, and is not obsolete. Deprecated versions are allowed. [User]
+4. The cluster is persisted with `version_name`; the controller resolves the release image at reconciliation time.
+
+On the catalog-item path, `version_name` comes from the catalog item's field definitions instead of template `spec_defaults`. Version validation (step 3) applies on both paths.
 
 #### Error handling
 
 | Scenario | API behavior | gRPC code |
 | ---- | ---- | ---- |
+| `spec.version` format is invalid | Reject the request. | `InvalidArgument` |
 | Referenced version does not exist | Reject the request before cluster creation. | `InvalidArgument` |
-| Referenced version is disabled | Reject the request for new cluster creation. | `InvalidArgument` |
-| Referenced version is obsolete | Reject the request for new cluster creation. | `InvalidArgument` |
-| No version can be resolved through input or defaults | Reject the request until a caller or admin supplies one. | `InvalidArgument` |
-| Provided channel is not valid for the selected version | Reject the request before persistence. | `InvalidArgument` |
-| Selected version has no release image compatible with the template's supported architectures | Reject the request before persistence. | `InvalidArgument` |
-| `cluster_version` or `channel` is changed after create | Reject the update because both fields are immutable. | `InvalidArgument` |
-| A referenced version is still in use during deletion | Reject the deletion until references are removed. | `FailedPrecondition` |
-| Two concurrent requests try to set different defaults | Allow one winner and reject the other update. | `FailedPrecondition` |
-
-#### Lifecycle workflow: propagate deprecation or obsolescence
-
-```mermaid
-sequenceDiagram
-    actor Admin as Cloud Provider Admin
-    participant FS as Fulfillment Service API
-    participant DB as PostgreSQL
-    participant Rec as FS Reconciler
-    participant Hub as Hub Cluster API
-    participant Op as OSAC Operator
-    participant Sync as Feedback Sync
-
-    Admin->>FS: Update ClusterVersion lifecycle state
-    FS->>DB: Persist updated state
-    Rec->>Hub: Update ClusterVersion CRD projection
-    Hub-->>Op: Watch ClusterVersion change
-    Op->>Hub: Find affected ClusterOrders
-    Op->>Hub: Set or clear lifecycle conditions
-    Sync->>FS: Sync conditions back to cluster status
-    FS-->>Admin: Future Get/List shows lifecycle signal
-```
-
-1. An admin updates a `ClusterVersion` lifecycle state in the fulfillment-service.
-2. The reconciler updates the corresponding hub `ClusterVersion` CRD.
-3. The operator detects the change, finds affected `ClusterOrder` resources, and sets or clears lifecycle conditions.
-4. Those conditions are synced back to the fulfillment-service so that cluster `Get` and `List` responses expose the lifecycle signal.
-
-`enabled` is treated as admission policy for new cluster creation, not as a lifecycle signal for already-created clusters. Changing `enabled` blocks new use of a version but does not add conditions to existing clusters.
+| Referenced version is disabled or obsolete | Reject the request. | `InvalidArgument` |
+| No version can be resolved through input or defaults | Reject the request. | `InvalidArgument` |
+| A referenced version is still in use during deletion | Reject the deletion until references are removed. [PRD: FR-11] | `FailedPrecondition` |
+| `version_name` changed to a version not in `allowed_upgrades`, or target is disabled/obsolete | Reject the update. Same admission checks as cluster creation. [User] | `InvalidArgument` |
+| `allowed_upgrades.version_names` references a non-existent or deleted version on create, or a newly added entry references a non-existent, deleted, disabled, or obsolete version on update | Reject the create or update. | `InvalidArgument` |
+| Two concurrent requests try to set different defaults | Allow one winner and reject the other update. | `AlreadyExists` |
 
 ### API Extensions
 
 This enhancement adds or changes the following API surfaces:
 
 - **Fulfillment gRPC/REST APIs**
-  - New `ClusterVersions` API for managing and listing version catalog entries.
-  - `Clusters` API replaces `release_image` input with `cluster_version` and `channel`.
-  - `ClusterTemplates` gain version-default and architecture-capability fields relevant to cluster creation.
+  - New `ClusterVersions` API for managing and listing version entries.
+  - `Clusters` API replaces `release_image` input with `version_name`. The server validates the version at creation time.
+  - `ClusterTemplates` gain a `spec_defaults.version_name` field for template-level version defaulting.
   - Public `ClusterVersions/List` hides disabled and obsolete versions by default unless the caller explicitly filters on lifecycle or availability fields.
-  - The fulfillment-service event payload gains a `ClusterVersion` entry so create, update, and delete operations participate in change notifications and event-driven reconciliation.
-- **OSAC CRDs**
-  - New namespaced hub `ClusterVersion` CRD as a projection of the fulfillment-service catalog.
-  - `ClusterOrder` gains `clusterVersion` and `channel`.
-- **Lifecycle signaling**
-  - Clusters receive lifecycle conditions such as deprecated or obsolete when their referenced version changes state.
-  - The fulfillment-service cluster API surface gains matching lifecycle condition types `CLUSTER_CONDITION_TYPE_VERSION_DEPRECATED` and `CLUSTER_CONDITION_TYPE_VERSION_OBSOLETE` so those signals are visible on cluster `Get` and `List` responses.
+  - The fulfillment-service event payload gains a `ClusterVersion` entry so create, update, and delete operations participate in change notifications.
+- **OSAC CRDs** — no change. The existing `ClusterOrder` continues to carry `releaseImage`.
 
-The public API does not expose release-image URLs. Tenant-facing clients see semantic version information and lifecycle state, while release-image resolution stays internal.
+#### Visibility split
 
-#### Public `ClusterVersion` schema
+Private `ClusterVersionSpec` includes `spec.image` (the release-image pullspec); public `ClusterVersionSpec` does not. All other fields are present on both. See Data model for proto definitions.
 
-The public API contract for `ClusterVersion` is intentionally small and safe for tenant-facing consumers:
+#### Changes to existing resource schemas
+
+- `ClusterSpec` replaces `release_image` with `optional string version_name = 9`, referencing a ClusterVersion by `metadata.name`.
+- `ClusterTemplateSpecDefaults` gains `optional string version_name = 5`, replacing `release_image` for template-level version defaulting.
+
+- `ClusterCatalogItem` field definitions replace `path: "release_image"` with `path: "version_name"`. The field definition default changes from a release-image URL to a ClusterVersion `metadata.name` (e.g., `"4-17-0"`). The [`applyFieldDefinitions()`](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/servers/catalog_item_validation.go#L73) mechanism is unchanged. On catalog item create and update, the server validates that the `version_name` default references an existing, enabled, non-obsolete ClusterVersion — following the same pattern as `ComputeInstanceCatalogItem` validates `instance_type` defaults. See [catalog-items EP](../../../enhancement-proposals/enhancements/catalog-items/README.md).
+
+Template republication (via AAP [`publish_templates`](https://github.com/osac-project/osac-aap/blob/8789215d26d0fd12e814665b055eeafeb1fb97f5/collections/ansible_collections/osac/service/playbooks/publish_templates.yaml#L1)) preserves admin-set `spec_defaults` — the publish payload does not include `spec_defaults`, so [FieldMask auto-inference](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/servers/field_mask.go#L30) leaves it unchanged.
+
+### Implementation Details/Notes/Constraints
+
+#### Data model
+
+##### ClusterVersion
 
 ```protobuf
 message ClusterVersion {
@@ -201,12 +155,35 @@ message ClusterVersion {
 }
 
 message ClusterVersionSpec {
+  string image = 1;
+  // OCI release image pullspec (private-only, not exposed in public API).
+
   optional bool enabled = 2;
+  // Controls whether new clusters may select this version.
+  // Server sets to true on Create when not explicitly provided.
+
   optional bool is_default = 3;
-  repeated string available_channels = 4;
-  ClusterVersionState state = 5;
-  ClusterVersionDeprecation deprecation = 6;
-  string version = 7;
+  // At most one active ClusterVersion may be default.
+
+  ClusterVersionState state = 4;
+  // Server defaults UNSPECIFIED to ACTIVE on Create.
+
+  ClusterVersionDeprecation deprecation = 5;
+
+  string version = 6;
+  // Stable version identifier (e.g., "4.17.0", "4.17.0-rc.1").
+
+  ClusterVersionAllowedUpgrades allowed_upgrades = 7;
+  // Constrains which versions clusters on this version may upgrade to.
+  // Message absent: no path constraint (target must still be enabled and not obsolete).
+  // Message present with empty version_names: no valid targets — version change is rejected.
+  // Message present with version_names: only listed versions are accepted.
+}
+
+message ClusterVersionAllowedUpgrades {
+  repeated string version_names = 1;
+  // ClusterVersion names (metadata.name). Must reference existing, non-deleted ClusterVersions.
+  // When a target version is deleted, it is automatically removed.
 }
 
 enum ClusterVersionState {
@@ -217,338 +194,200 @@ enum ClusterVersionState {
 }
 
 message ClusterVersionDeprecation {
-  string replacement = 1;
-  google.protobuf.Timestamp deprecation_timestamp = 2;
-  google.protobuf.Timestamp obsolescence_timestamp = 3;
+  google.protobuf.Timestamp deprecation_timestamp = 1;
+  // Set by the system when state transitions to DEPRECATED.
+
+  google.protobuf.Timestamp obsolescence_timestamp = 2;
+  // Set by the system when state transitions to OBSOLETE.
+  // Both timestamps are cleared if the version returns to ACTIVE.
 }
+
+message ClusterVersionStatus {}
 ```
 
-- **Stable identifier:** dependent features should reference `spec.version`.
-- **Primary UI fields:** `spec.version`, `spec.state`, `spec.enabled`, `spec.is_default`, `spec.available_channels`, and `spec.deprecation.replacement`.
-- **Timestamp semantics:** deprecation timestamps are system-managed lifecycle metadata rather than admin-supplied inputs.
-
-#### Private-only fields
-
-The private and internal form of `ClusterVersion` carries release-image metadata that is not exposed in the public API:
-
-```protobuf
-message ClusterVersionReleaseImage {
-  string architecture = 1;
-  string url = 2;
-}
-```
-
-- **Visibility split:** private `ClusterVersionSpec` includes `release_images[]`; public `ClusterVersionSpec` does not.
-- **Reason:** the platform can validate and resolve release images without exposing raw pullspecs to tenant-facing clients.
-- **Naming model:** in the fulfillment-service, `metadata.name` may be a DNS-safe slug such as `ocp-4-17-0`; on the hub CRD, `metadata.name` is the semantic version string from `spec.version`, such as `4.17.0`.
-- **Uniqueness key:** uniqueness is enforced on `spec.version`, not on `metadata.name`.
-
-#### Changes to existing resource schemas
-
-Dependent features are more likely to interact with the changes to existing schemas than with the new catalog resource itself:
-
-```protobuf
-message ClusterSpec {
-  optional string cluster_version = 9;
-  optional string channel = 10;
-  // release_image is removed from the API contract.
-}
-
-message ClusterTemplateSpecDefaults {
-  optional string cluster_version = 5;
-  // release_image defaults are removed from this contract in favor of cluster_version.
-}
-```
-
-```protobuf
-message ClusterTemplate {
-  repeated string supported_architectures = 8;
-}
-```
-
-- **Template version defaults:** `spec_defaults.cluster_version` is set by the admin via the private API after template publication. The publish pipeline preserves admin-set values across re-publication.
-- **ClusterOrder CRD:** gains `clusterVersion` and `channel`; it carries semantic version identity and channel metadata, not a resolved release image.
-- **Cluster lifecycle API:** cluster responses gain matching lifecycle condition types for version deprecation and obsolescence so downstream features and UI flows can render durable warnings from cluster state.
-- **Template migration:** `spec_defaults.release_image` is no longer part of the cluster-creation contract. Templates that previously relied on that field must migrate to `spec_defaults.cluster_version`.
-
-#### UI-facing behavior
-
-The public API behavior that matters most to UI consumers is:
-
-- default `ClusterVersions/List` calls hide disabled and obsolete versions unless the caller explicitly filters for them
-- create-time warnings are visible to gRPC callers, but REST callers should rely on cluster lifecycle conditions returned by later `Get` and `List` requests
-- `enabled=false` blocks new cluster creation with a version but does not add a lifecycle condition to existing clusters
-- `spec.deprecation.replacement` is the field UI flows can use to suggest a newer version when the current one is deprecated
-
-Example public payload shape:
+**Example public payload shape:**
 
 ```json
 {
   "id": "uuid",
   "metadata": {
-    "name": "ocp-4-17-0"
+    "name": "4-17-0"
   },
   "spec": {
     "version": "4.17.0",
     "enabled": true,
     "isDefault": true,
     "state": "DEPRECATED",
-    "availableChannels": ["stable-4.17", "fast-4.17"],
     "deprecation": {
-      "replacement": "4.18.0"
+      "deprecationTimestamp": "2026-06-15T00:00:00Z"
+    },
+    "allowedUpgrades": {
+      "versionNames": ["4-17-1", "4-18-0"]
     }
   },
   "status": {}
 }
 ```
 
-#### CLI surface
-
-- **Tenant flow:** `osac create cluster` accepts `--cluster-version` and `--channel`.
-- **Admin flow:** the version catalog is managed with:
-  - `osac create cluster-version`
-  - `osac get cluster-version`
-  - `osac get cluster-versions`
-  - `osac update cluster-version`
-  - `osac delete cluster-version`
-- **Lookup behavior:** admin lookup should resolve by semantic version as well as object identity so commands such as `osac get cluster-version 4.17.0` are natural to use.
-- **Rendered fields:** CLI output should expose the same user-facing fields as the public API: version, lifecycle state, enabled/default status, available channels, and replacement version when present.
-
-### Implementation Details/Notes/Constraints
-
-#### Design overview
-
-- **Semantic version selection:** happens at the API layer.
-- **Release-image resolution:** happens at provisioning time.
-- **Why:** this separation keeps the user-facing cluster API stable and future-proofs the design for multi-architecture support and upgrade workflows.
-
-#### Data model
-
-The concise schema shape below keeps the fields that matter to the design and omits boilerplate:
-
-```protobuf
-message ClusterVersionSpec {
-  repeated ClusterVersionReleaseImage release_images = 1;
-  // Release images are stored per architecture so the model can grow into
-  // multi-architecture support without introducing a second schema later.
-
-  optional bool enabled = 2;
-  // Controls whether new clusters may select this version.
-
-  optional bool is_default = 3;
-  // At most one active ClusterVersion may be default.
-
-  repeated string available_channels = 4;
-  // Carried now so later upgrade work can reuse the same version identity.
-
-  ClusterVersionState state = 5;
-  ClusterVersionDeprecation deprecation = 6;
-
-  string version = 7;
-  // This is the stable semantic version identifier.
-}
-```
-
-```protobuf
-message ClusterVersionDeprecation {
-  string replacement = 1;
-  // Must reference an existing, non-deleted ClusterVersion by spec.version.
-
-  google.protobuf.Timestamp deprecation_timestamp = 2;
-  // Set by the system when state transitions to DEPRECATED.
-
-  google.protobuf.Timestamp obsolescence_timestamp = 3;
-  // Set by the system when state transitions to OBSOLETE.
-  // Both timestamps are cleared if the version returns to ACTIVE.
-}
-```
-
-```go
-type ClusterVersionSpec struct {
-    ReleaseImages []ClusterVersionReleaseImage `json:"releaseImages"`
-    State ClusterVersionState `json:"state,omitempty"`
-    AvailableChannels []string `json:"availableChannels,omitempty"`
-    Enabled bool `json:"enabled"`
-    IsDefault bool `json:"isDefault,omitempty"`
-    Deprecation *ClusterVersionDeprecation `json:"deprecation,omitempty"`
-}
-
-type ClusterVersionStatus struct{}
-```
-
-The hub projection is intentionally small: it carries version identity, lifecycle state, availability, and release-image metadata, but no provisioning status. `ClusterVersion` is reference data, not a provisionable resource, so it does not follow the usual AAP-backed Phase / Job-history pattern used by workload-facing OSAC resources. OSAC uses `osac.openshift.io/v1alpha1`, so this resource does not conflict with OpenShift's built-in `ClusterVersion` in `config.openshift.io/v1`. Using a short name such as `cver` or the fully qualified resource name avoids CLI ambiguity.
+##### Changes to existing schemas
 
 ```protobuf
 message ClusterSpec {
-  optional string cluster_version = 9;
-  // Replaces raw release_image selection in the user-facing API.
+  // Field 6 was release_image — removed.
 
-  optional string channel = 10;
-  // Optional channel metadata validated against ClusterVersion.
+  optional string version_name = 9;
+  // References a ClusterVersion by metadata.name.
 }
 
 message ClusterTemplateSpecDefaults {
-  optional string cluster_version = 5;
+  optional string version_name = 5;
   // Lets templates provide a default managed version.
-}
-
-message ClusterTemplate {
-  repeated string supported_architectures = 8;
-  // Declares what the provisioning implementation can actually handle.
 }
 ```
 
-`ClusterOrderSpec` carries `clusterVersion` and `channel` to the hub.
+#### Lifecycle state machine
 
-#### Core invariants
+```mermaid
+stateDiagram-v2
+    [*] --> ACTIVE
+    ACTIVE --> DEPRECATED: sets deprecation_timestamp
+    DEPRECATED --> OBSOLETE: sets obsolescence_timestamp
+    OBSOLETE --> ACTIVE: clears both timestamps
+    DEPRECATED --> ACTIVE: clears deprecation_timestamp
+    OBSOLETE --> DEPRECATED: clears obsolescence_timestamp,<br/>sets deprecation_timestamp
+    note right of OBSOLETE: Clears is_default if set
+    note right of ACTIVE: is_default allowed
+    note right of DEPRECATED: is_default allowed
+```
 
-- A version identifier is unique among active `ClusterVersion` entries, and that uniqueness is enforced on `spec.version` rather than `metadata.name`.
-- At most one version can be marked as the default.
-- Setting `is_default=true` on one version clears the previous default within the same transaction.
-- Obsolete versions cannot be used for new clusters.
-- An obsolete or disabled version cannot be set as the default.
+All state transitions are allowed. [PRD: FR-13] Timestamps are system-managed: set on entry to DEPRECATED or OBSOLETE, cleared on return to ACTIVE. OBSOLETE → DEPRECATED clears `obsolescence_timestamp` and sets `deprecation_timestamp`. If a version is default when it transitions to OBSOLETE or is disabled, `is_default` is auto-cleared. No automatic propagation of lifecycle conditions to existing clusters.
+
+#### Invariants and validation
+
+**Identity and naming:**
+- `metadata.name` is optional. If not provided, it is auto-generated from `spec.version` by lowercasing and replacing all characters outside `[a-z0-9-]` with dashes (e.g., `4.17.0` → `4-17-0`, `4.17.0+build.1` → `4-17-0-build-1`). If the result exceeds 63 characters (the DNS label limit), it is truncated to 58 characters with a 4-character hex suffix appended (`-XXXX`), keeping the total at 63. On name collision the server appends the same style of hex suffix.
+- `spec.version` must be a valid [Semantic Version 2.0.0](https://semver.org/) string. Maximum length is 256 characters.
+- `spec.version` must be unique among active (non-deleted) ClusterVersions.
+- `spec.version` and `spec.image` are immutable after creation. The server rejects updates that change either field. A database trigger enforces the same constraint as a race-safety backstop. [PRD: FR-14]
+
+**Default version:**
+- At most one version can be marked as the default. Setting `is_default=true` clears the previous default within the same transaction.
+- Obsolete or disabled versions cannot be set as the default.
 - If a default version transitions to `OBSOLETE` or is disabled (`enabled=false`), the server clears `is_default` as part of the same change.
-- `spec.version` is immutable after creation.
-- `cluster_version` and `channel` are immutable after cluster creation.
-- Versions referenced by clusters or templates cannot be removed while still in use.
-- Public APIs expose version identity and lifecycle state, but not release-image URLs.
 
-#### Validation model
+**Lifecycle:**
+- Obsolete or disabled versions cannot be used for new clusters or as version-change targets. `enabled` is admission policy, not lifecycle state — changing it does not affect existing clusters.
 
-- **Create-time checks:** existence of the referenced version, availability for new cluster creation, lifecycle state, channel membership when provided, compatibility between the template's supported architectures and the version's available release images, and version format using a Kubernetes-safe semver subset because the version string becomes the hub `ClusterVersion` resource name.
-- **Reference checks:** `deprecation.replacement`, when set, must point at an existing non-deleted `ClusterVersion`.
-- **Template default checks:** `ClusterTemplate` create and update validate `spec_defaults.cluster_version` in the server layer so admins get descriptive errors; database triggers remain the race-safety backstop.
-- **State transitions:** lifecycle state transitions are allowed in any direction.
-- **Default guard:** if an admin attempts to set `is_default=true` on a version that is `OBSOLETE` or disabled, the request is rejected.
-- **Deprecation signaling:** if a deprecated version is still allowed for new clusters, creation succeeds but the user receives a deprecation warning.
-- **Client behavior:** gRPC callers can receive immediate create-time warnings. REST callers do not receive those sibling `warnings` fields because the gateway response body is the embedded `object`; for REST, the durable notification path is the cluster lifecycle conditions returned by later `Get` and `List` calls.
+**References and delete protection:**
+- Versions referenced by active clusters, templates, or catalog item field definitions cannot be deleted. [PRD: FR-11]
+- `ClusterTemplate` create and update validate `spec_defaults.version_name` in the server layer; database triggers are the race-safety backstop.
+
+**Cluster version-change validation:**
+- When `allowed_upgrades` is set on the source version, cluster updates that change `version_name` are validated against the list. The target version must pass the same admission checks as cluster creation (exists, enabled, not obsolete). When `allowed_upgrades` is not set, any version change is allowed but the target must still pass those checks. [User]
+
+**Upgrade target management:**
+- `allowed_upgrades.version_names` entries must reference existing, non-deleted ClusterVersions. On create, the server validates that all entries are also enabled and non-obsolete. On update, only newly added entries are validated against enabled and non-obsolete. A database trigger enforces the existence constraint as a race-safety backstop for concurrent deletions.
+- When a target version is soft-deleted, it is automatically removed from all other versions' `allowed_upgrades` lists within the same transaction. Disabling or marking a version obsolete does not remove it — the entry stays and becomes available again when the target is re-enabled or returned to a non-obsolete state.
+- If deletion cleanup removes all entries, the empty `allowed_upgrades` message is preserved.
 
 #### Database considerations
 
-- **Persistence model:** the fulfillment-service needs new live and archived storage for `ClusterVersion`.
-- **Uniqueness:** a partial unique index enforces unique active `spec.version`.
-- **Single default:** a partial unique index enforces a single active default.
-- **Reference integrity:** validation triggers reject clusters or templates that point at missing or deleted versions.
-- **Delete protection:** soft deletion is rejected while references still exist.
-- **Performance:** an index on `clusters.spec.cluster_version` keeps reference checks efficient.
-- **Enforcement split:** these database checks complement, rather than replace, server-side validation. `spec.version` immutability is enforced in the server layer because generic immutable-column triggers cannot protect JSON payload fields.
-- **Error mapping:** reference-validation failures translate to `InvalidArgument`, while delete-in-use failures translate to `FailedPrecondition`.
+**Key model.** `tenant` is `"shared"` (platform-global resource convention); `project` is the default empty value. `id` is the primary key.
 
-#### Reconciliation model
+**Tables.** Two tables following the standard DAO schema: `cluster_versions` (live) and `archived_cluster_versions` (archive).
 
-The fulfillment-service is the source of truth for `ClusterVersion` data and projects that data to hub-scoped consumers.
+**Uniqueness constraints.** Three partial unique indexes, all excluding soft-deleted rows (`WHERE deletion_timestamp = 'epoch'`):
 
-##### Projection
+- `(name, tenant, project)` — enforces unique active `metadata.name` within a tenant and project.
+- `(data->'spec'->>'version', tenant, project)` — enforces unique active `spec.version` within a tenant and project.
+- `(tenant, project)` with partial predicate `is_default = true` — enforces at most one default within a tenant and project.
 
-The fulfillment-service reconciles every `ClusterVersion` entry to a namespaced hub `ClusterVersion` CRD. This gives downstream components a local hub-scoped representation of version identity, lifecycle state, and release-image metadata without making the hub the source of truth. [[tenant_reconciler_function.go](https://github.com/osac-project/fulfillment-service/blob/737af8524e73674ee7b93434ee70d69f5b01fc9a/internal/controllers/onboarding/tenant_reconciler_function.go)]
+**JSONB field immutability.** A trigger on `cluster_versions` fires before UPDATE and compares `old.data->'spec'->>'version'` and `old.data->'spec'->>'image'` against the new values. If either differs, it raises SQLSTATE `Z0001` (`ErrImmutable`). This complements the existing [`check_immutable_columns`](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/database/migrations/46_add_immutable_column_trigger.up.sql#L19) trigger (which protects table columns) and the server-side validation (which provides descriptive error messages).
 
-The existing cluster reconciler is also modified to copy `spec.cluster_version` and `spec.channel` from the fulfillment-service `Cluster` into the hub `ClusterOrder`. That handoff is what lets operator and AAP logic consume semantic version identity from the hub-facing resource instead of a resolved image.
+**Reference integrity.**
 
-##### Triggers
+*Database triggers:*
 
-Reconciler registration reacts both to `ClusterVersion` change events and to new-hub registration events. The new-hub trigger ensures that when a hub is added, existing `ClusterVersion` entries are reconciled to it immediately rather than waiting for the periodic full sync.
+- **Outbound (delete protection):** fires before UPDATE on `cluster_versions` when `deletion_timestamp` transitions from epoch (soft deletion). Checks that no active cluster, cluster template, or cluster catalog item references this version by `version_name`. For catalog items, the trigger scans `field_definitions` for entries with `path = 'version_name'` whose `default` matches the version's `metadata.name`. Raises SQLSTATE `Z0003` (`ErrInUse`).
+- **Inbound (resource → version):** fires before INSERT or UPDATE (only active rows: `WHEN new.deletion_timestamp = 'epoch'`). On INSERT, or when the reference changes on UPDATE, validates that the referenced ClusterVersion exists, is enabled, and is not obsolete using `SELECT ... FOR SHARE` on the referenced row. Raises SQLSTATE `Z0002` (`ErrReference`). Three source tables, same validation logic:
+  - `clusters` and `cluster_templates` — scalar field `data->'spec'->>'version_name'`.
+  - `cluster_catalog_items` — loops over `data->'field_definitions'`, filters entries with `path = 'version_name'`, and validates each entry's `default` value.
+- **Inbound (version → version via allowed_upgrades):** fires before INSERT or UPDATE on `cluster_versions` (only active rows). On INSERT, or when `allowed_upgrades` changes on UPDATE, loops over `version_names` and validates each entry against an existing, non-deleted ClusterVersion using `SELECT ... FOR SHARE`. Raises SQLSTATE `Z0002` (`ErrReference`).
 
-##### Operator ordering
+Inbound triggers use `FOR SHARE` on the referenced row to serialize against concurrent deletes and lifecycle changes, following the established pattern across all existing reference triggers.
 
-On the operator side, lifecycle condition handling runs after the existing `ClusterOrder` reconciliation path. That ordering ensures version-state signaling augments normal provisioning reconciliation rather than replacing or short-circuiting it.
+*Server-side cleanup (Go layer):*
 
-##### Current limitation
+- **Upgrade target cleanup:** when a ClusterVersion is soft-deleted, the server removes its `metadata.name` from all other active versions' `allowed_upgrades.version_names` arrays within the same transaction. The cleanup UPDATE increments `version` on each affected row to preserve optimistic concurrency. The private server's Delete method runs this after the DAO operation, sharing the same transaction via [`database.TxFromContext(ctx)`](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/database/database_context.go#L46).
 
-The reconciler inherits the all-hubs iteration behavior of the onboarding tenant reconciler: with multiple hubs, one unreachable hub can block progress to later hubs in the same pass. This is acceptable for the single-hub `v0.2` deployment model, but a future multi-hub design would likely need best-effort iteration and aggregated error reporting.
+**Performance.** A JSONB index on `data->'spec'->>'version_name'` in the `clusters` table keeps the outbound trigger's reference scan efficient. The trigger also scans `cluster_templates` and `cluster_catalog_items` field definitions; template and catalog item volume is low enough that separate indexes are not warranted.
 
-#### Provisioning model
+**Error mapping.** Trigger SQLSTATE codes translate to gRPC status codes: `Z0001` → `InvalidArgument` (immutable field changed), `Z0002` → `InvalidArgument` (invalid reference), `Z0003` → `FailedPrecondition` (delete blocked by references). `Z0001` already exists for [`check_immutable_columns`](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/database/migrations/46_add_immutable_column_trigger.up.sql#L19); no new error constant is needed.
 
-AAP consumes the hub projection rather than relying on the user-facing cluster API to carry a resolved image.
+**Implementation prerequisite.** The DAO update path ([`translateError` in `generic_dao_update.go`](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/database/dao/generic_dao_update.go#L207)) does not currently translate `Z0002` or `Z0003` — these codes are handled on the create and delete paths but were not added to the update path's `translateError` switch. This must be fixed before inbound triggers that fire on UPDATE can return proper gRPC errors. This is a pre-existing gap ([migration 56](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/database/migrations/56_add_instance_type_ref_triggers.up.sql#L20) already has `BEFORE INSERT OR UPDATE` triggers raising `Z0002`), not specific to ClusterVersion.
 
-##### Resolution point
+#### Event plumbing
 
-AAP reads the namespaced hub `ClusterVersion` CRD during provisioning and resolves the final release image there rather than on the user-facing cluster API. This keeps the API contract semantic while allowing the provisioning layer to choose the concrete image it needs. In `v0.2`, existing templates use the `multi` architecture entry.
+`ClusterVersion` needs an entry in the `oneof payload` of both the private and public event type protos so that create, update, and delete operations emit change notifications with the resource attached. The [`GenericServer`](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/servers/generic_server.go#L58) discovers the payload field automatically via protobuf reflection — no Go code changes are needed beyond `buf generate`. Without the oneof entries, CRUD operations still succeed, but emitted events carry no payload and are silently dropped by the event server.
 
-##### Failure behavior
+#### CLI and UI rendering
 
-Provisioning fails closed if the expected hub `ClusterVersion` CRD is missing. The design intentionally avoids silently falling back to a template-default release image because that would decouple actual provisioning behavior from the admin-managed version catalog and could provision the wrong OpenShift version.
+**ClusterVersion commands:**
 
-##### Template version defaults
+- `osac create clusterversion` — create from flags or YAML.
+- `osac get clusterversion <id-or-name>` — get by ID or metadata.name (e.g., `4-17-0`).
+- `osac get clusterversions` — list versions. Use `--filter 'this.spec.version == "4.17.0"'` to filter by version string.
+- `osac describe clusterversion <id-or-name>` — describe by ID or metadata.name.
+- `osac edit clusterversion <id-or-name>` — edit by ID or metadata.name.
+- `osac delete clusterversion <id-or-name>` — delete by ID or metadata.name.
 
-- `supported_architectures` is declared in template roles via `meta/osac.yaml` and published to the fulfillment-service through the AAP template pipeline.
-- `spec_defaults.cluster_version` is set by the admin via the private API after template publication. The template author cannot know which `ClusterVersion` catalog entries exist in a given deployment, so this value is a deployment-specific choice rather than a template capability.
+**Cluster creation:**
 
-#### Event and feedback plumbing
+`osac create cluster` replaces `--release-image` with `--version`. The flag accepts a version string (`4.17.0`) or a metadata.name (`4-17-0`). The CLI resolves the input to a ClusterVersion and sets the resolved `metadata.name` as `version_name` on the ClusterSpec. If the input matches multiple ClusterVersions, `metadata.name` takes precedence (this requires a `spec.version` that is itself a valid DNS label matching another version's `metadata.name` — unlikely in practice).
 
-This design has a forward event path for projection and a reverse feedback path for lifecycle visibility.
+**Table rendering:**
 
-##### Forward path
+- **ClusterVersion table:** columns are NAME, VERSION, STATE, ENABLED, DEFAULT (public); private adds IMAGE. NAME shows `metadata.name` so users can discover the value needed for API references and other CLI commands.
+- **Cluster table:** a VERSION column shows the `version_name` value (metadata.name, e.g., `4-17-0`).
 
-`ClusterVersion` must participate in the fulfillment-service event payload flow so create, update, and delete operations emit change notifications. The event proto therefore needs a `ClusterVersion` entry in its payload `oneof`. Without that payload support, event-driven reconciliation does not happen. Without generic-server payload mapping for `ClusterVersion`, CRUD operations fail instead of committing because event emission rolls the transaction back.
+**`describe cluster`:** makes a second gRPC call to fetch the `ClusterVersion` by name and renders its version string, state, and timestamps. [PRD: FR-6]
 
-##### Reverse path
-
-Version lifecycle conditions set on `ClusterOrder` resources must be mirrored back into the fulfillment-service cluster status surface so API clients can see the same lifecycle signal the operator applies on the hub. This extends the existing `ClusterOrder` feedback path rather than introducing a `ClusterVersion`-specific feedback controller. The [feedback controller's condition switch](https://github.com/osac-project/osac-operator/blob/4ad2b2da0cdcdca69e4a9ed47e9f92f6267e4a2c/internal/controller/feedback_controller.go#L182-L199), the `ClusterOrder` condition type enum, and the fulfillment-service cluster condition enums must all be extended to handle the new lifecycle condition types.
-
-##### `v0.2` scope
-
-`v0.2` does not introduce a dedicated `ClusterVersion` feedback controller. `ClusterVersionStatus` is empty, so there is no resource-specific status to sync back. The fulfillment-service reconciler remains responsible for projecting, updating, and deleting the hub `ClusterVersion` CRD, while the operator's existing `ClusterOrder` controller watches `ClusterVersion` changes to set lifecycle conditions on affected orders.
-
-#### Scope notes for `v0.2`
-
-- The design supports channels now mainly so later upgrade work can reuse the same identity and metadata.
-- Multi-architecture support is enabled by the schema shape, but `v0.2` still assumes existing templates resolve the `multi` image.
-- Catalog-item authoring-time validation may be deferred if the catalog-items work lands later than this enhancement.
-- Catalog-item consumption-time resolution needs no special path-resolution change: existing field-definition application already handles `spec.cluster_version`, so the added work is validation rather than a new substitution mechanism.
-- `supported_architectures` must not be published before the fulfillment-service schema accepts the field; producer and consumer rollout order matters.
+**UI rendering:** two API calls (cluster + version), client-side join for lifecycle display.
 
 ### Security Considerations
 
-- **Authentication and authorization:** this enhancement inherits the existing OSAC security model. The fulfillment-service continues to use the current JWT-based request authentication chain, and write operations for the version catalog remain restricted through existing OPA-based admin authorization.
-- **Data exposure:** `release_images[].url` remains private to admin-facing and internal flows; tenant-facing APIs expose semantic version identity and lifecycle metadata, but not raw image pullspecs.
-- **Input validation:** version strings, channels, and template compatibility are validated before persistence so invalid references do not leak into downstream provisioning.
+- **Authentication and authorization:** this enhancement inherits the existing OSAC security model. The fulfillment-service continues to use the current JWT-based request authentication chain, and write operations for version management remain restricted through existing OPA-based admin authorization.
+- **Data exposure:** `spec.image` remains private to admin-facing and internal flows.
+- **Input validation:** version references are validated before persistence.
 
 ### Failure Handling and Recovery
 
 | Failure mode | What happens | Recovery | User observes |
 | ---- | ---- | ---- | ---- |
 | Database error during create or update | The request transaction rolls back. | Retry the request after the backend recovers. | The API returns an internal error and no partial object is created. |
-| Two requests race to set different default versions | One request succeeds and the other loses the uniqueness race. | Retry the losing request if needed after reviewing the current default. | The loser receives `FailedPrecondition`. |
-| A referenced version is deleted between validation and persistence | Database-side reference checks reject the write. | Retry with a valid version after reconciliation settles. | The create or update fails with `InvalidArgument`. |
-| The hub projection is temporarily missing or stale | Lifecycle conditions may not appear yet, or provisioning may fail closed if it depends on the missing projection. | Event-driven reconciliation or periodic full sync recreates the projection; retries then succeed. | Status may lag, or provisioning may fail and retry rather than silently using the wrong image. |
-| AAP cannot resolve the hub `ClusterVersion` CRD | Provisioning stops before using an unmanaged fallback image. | Retry after the projection exists. | The cluster remains unprovisioned until reconciliation catches up. |
-| `ClusterOrder` lifecycle-condition feedback sync back to fulfillment-service is unavailable | Hub-side lifecycle conditions still exist, but API-side cluster status may lag. | Controller retries continue until the sync path is healthy again. | Cluster `Get` and `List` may temporarily miss a lifecycle condition already visible on the hub. |
-| A controller restarts mid-reconciliation | Reconciliation restarts from persisted state. | Normal controller retry behavior resumes the work. | At worst, propagation is delayed; the design relies on idempotent reconciliation rather than one-shot execution. |
+| Two requests race to set different default versions | One request succeeds and the other loses the uniqueness race. | Retry the losing request if needed after reviewing the current default. | The loser receives `AlreadyExists`. |
+| A referenced version is deleted between validation and persistence | Database-side reference checks reject the write. | Retry with a valid version. | The create or update fails with `InvalidArgument`. |
+| Controller cannot resolve ClusterVersion during reconciliation (transient API error) | ClusterOrder is not created or updated. The controller retries with exponential backoff. | Resolve the underlying issue. Delete protection guarantees the version still exists. | Cluster creation is delayed; the cluster remains in a pending state until reconciliation succeeds. |
 
 ### RBAC / Tenancy
 
-- **Resource model:** `ClusterVersion` is a platform-global resource, not a tenant-owned one.
-- **Visibility:** authenticated users may read tenant-safe version metadata, while create, update, and delete remain Cloud Provider Admin operations through OPA enforcement.
-- **Tenant metadata:** no tenant isolation annotations such as `osac.openshift.io/tenant` or `osac.openshift.io/owner-reference` are required on `ClusterVersion` because it is not a tenant-scoped resource. Tenant isolation still applies at the consuming-resource level, where clusters and cluster orders remain tenant-owned.
-- **Hub RBAC:** hub-access RBAC must allow the fulfillment-service reconciler to manage `ClusterVersion` CRDs on hub clusters, while the operator and AAP need read access to consume those projections.
+- **Visibility:** authenticated users may read version metadata, while create, update, and delete remain Cloud Provider Admin operations through OPA enforcement. All authenticated users see ClusterVersions — [`DetermineVisibleTenants()`](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/auth/default_tenancy_logic.go#L98) always includes `"shared"` in the visible tenant set.
+- **Tenant metadata:** ClusterVersion is not a tenant-scoped resource, so no tenant isolation annotations (`osac.openshift.io/tenant`, `osac.openshift.io/owner-reference`) are required. Tenant isolation still applies at the consuming-resource level, where clusters and cluster orders remain tenant-owned.
 
 ### Observability and Monitoring
 
-No new observability changes. Existing monitoring mechanisms apply.
-
-- **API visibility:** `ClusterVersions` API requests use the existing fulfillment-service gRPC metrics and structured logging.
-- **Controller visibility:** lifecycle propagation continues to surface through existing operator reconciliation logs and Kubernetes events.
-- **Provisioning visibility:** AAP job output remains the primary signal for provisioning behavior and failure diagnosis.
+`ClusterVersions` API requests use the existing fulfillment-service gRPC metrics and structured logging. No new alerts or dashboards are needed.
 
 ### Risks and Mitigations
 
 | Risk | Mitigation |
 | ---- | ---------- |
-| No catalog entries exist when the feature is deployed. | Ship seeded versions as part of the deployment story and document the admin setup flow. |
-| The public cluster API changes from raw release-image input to version selection. | Treat this as a coordinated API change for a fresh-deployment milestone and update dependent components together. |
-| Cross-component skew causes one component to expect fields another component does not yet support. | Deploy fulfillment-service schema changes and hub CRD support before enabling downstream publisher or provisioning changes. |
-| The hub `ClusterVersion` projection lags behind the fulfillment-service source of truth. | Use event-driven reconciliation plus periodic full sync; treat hub state as eventually consistent but self-healing. |
-| A selected version is incompatible with a template's provisioning implementation. | Validate architecture compatibility before provisioning begins. |
-| Catalog-item integration lands later than this feature. | Keep the core version-catalog flow independent and phase catalog-item authoring validation separately if needed. |
-| AAP receives a `ClusterOrder` before the corresponding hub `ClusterVersion` projection exists. | Fail provisioning explicitly, then rely on reconciliation and retry rather than falling back to an unmanaged image source. |
+| No version entries exist when the feature is deployed. | Ship seeded versions as part of the deployment story and document the admin setup flow. |
+| The public cluster API changes from raw release-image input to version selection. | Treat this as a coordinated API change for a fresh-deployment milestone. The fulfillment-service and osac-ui are affected; both ship in v0.2. |
 
 ### Drawbacks
 
-This design adds an administrative catalog-management step before tenants can create clusters. That is more operational overhead than allowing users to pass arbitrary release-image URLs directly.
-
-The proposal also adds a new synchronization surface between the fulfillment-service and hub clusters. That increases cross-component complexity compared with a fulfillment-service-only design.
-
-Finally, using a release-image array now is slightly more complex than a single string field, even though `v0.2` primarily uses one `multi` entry. The trade-off is that future architecture-specific support does not require a schema redesign.
+This design adds an administrative version-management step before tenants can create clusters. That is more operational overhead than allowing users to pass arbitrary release-image URLs directly. Additionally, `spec.version` and `spec.image` are immutable — an admin who enters an incorrect image URL must delete and recreate the entry, and deletion is blocked while any cluster or template references it.
 
 ## Alternatives (Not Implemented)
 
@@ -558,58 +397,41 @@ This keeps the current API shape and avoids a new resource.
 
 It was rejected because it preserves the current usability and validation problems, exposes infrastructure details to tenants, and does not create a reusable version identity for lifecycle or upgrade workflows.
 
-### Add a `ClusterVersion` catalog but keep it only in the fulfillment-service
+### Project ClusterVersion to hub clusters as a CRD
 
-This avoids a new hub CRD and reduces synchronization work.
+This adds a hub `ClusterVersion` CRD, operator lifecycle watches, and AAP resolution from the CRD. It enables reactive lifecycle propagation (conditions on `ClusterOrder`) and lets AAP resolve images from a local CRD instead of receiving a resolved URL.
 
-It was rejected because the operator would lose a local version resource to watch for lifecycle changes, and AAP would still need another way to resolve version data during provisioning. The hub projection gives both consumers a shared local representation.
+Deferred. The fulfillment-service-only approach is simpler, touches only one component, and delivers the core value (managed versions, validation, resolution). Hub projection can be added later if reactive lifecycle propagation is needed.
 
-### Model release images as a single field instead of an array
+### Model release images as an architecture-keyed array
 
-This simplifies the first implementation.
+This uses `repeated ClusterVersionReleaseImage release_images` with `architecture` and `url` fields instead of a single `image` string. It enables multi-architecture support without schema migration.
 
-It was rejected because the design already needs to preserve a path to multi-architecture support. An array avoids a second schema migration and keeps the version-to-image relationship extensible from the start.
-
-## Open Questions
-
-- Should templates eventually be able to constrain version selection beyond architecture, for example by allowed channels or explicit version ranges?
-- Should the system-managed deprecation timestamps remain in `spec.deprecation`, or should they move to a status-oriented surface to better match the usual rule that the system does not mutate object spec?
+Not needed for `v0.2`. A single `spec.image` is sufficient for the current `multi`-only deployment. The array can be introduced when multi-architecture support is needed.
 
 ## Test Plan
 
-The test strategy focuses on validating the catalog model at each layer rather than enumerating every test case in the design:
+The test strategy focuses on validating the version model in the fulfillment-service:
 
-- **Unit tests:** version validation, default selection, immutability, lifecycle-state handling, and template compatibility checks in the fulfillment-service.
-- **Operator tests:** propagation of deprecated and obsolete states to `ClusterOrder` conditions and sync of those conditions back to cluster status.
-- **Integration tests:** end-to-end flow from version creation through cluster reconciliation, including delete protection and default fallback.
-- **AAP tests:** release-image resolution from the hub `ClusterVersion` CRD and failure behavior when the projection is missing.
-- **E2E tests:** admin catalog management plus tenant cluster creation using managed versions.
+- **Unit tests:** version validation, default selection, lifecycle-state handling, image resolution, version-change validation, and template default checks.
+- **Integration tests:** end-to-end flow from version creation through cluster creation and reconciliation, including delete protection, default fallback, and release-image population on the `ClusterOrder`.
+- **E2E tests:** admin version management plus tenant cluster creation using managed versions.
 
 ## Graduation Criteria
 
 This enhancement should graduate by showing:
 
-- stable creation of clusters through managed version selection instead of raw release-image input
-- reliable propagation of version lifecycle state to existing clusters
-- successful operation across the fulfillment-service, operator, and AAP integration points
+- stable creation of clusters through managed version selection
+- correct resolution of release images from available versions
 - documented operational guidance for seeding versions and diagnosing failures
 
 ## Upgrade / Downgrade Strategy
 
-OSAC `v0.2` assumes coordinated fresh deployment rather than in-place upgrades. No data migration is required for existing persisted version catalog data because the resource is new.
-
-If later rollout scenarios require mixed-version operation, the safe order is to deploy fulfillment-service schema and hub projection support before enabling downstream publishing, operator consumption, or AAP resolution changes.
+OSAC `v0.2` assumes coordinated fresh deployment rather than in-place upgrades. No data migration is required.
 
 ## Version Skew Strategy
 
-The initial milestone assumes coordinated deployment of all affected components. Even with that assumption, the design expects a practical rollout order:
-
-1. fulfillment-service API and reconciliation support
-2. hub CRD support in the operator
-3. template publication changes that emit architecture metadata
-4. AAP changes that resolve release images from the hub `ClusterVersion`
-
-This order prevents downstream components from depending on fields or resources that upstream components have not started producing yet.
+The fulfillment-service and osac-ui are affected. The UI generates types from the same protos — removing `release_image` breaks the generated types and the components that render it. Both ship in the same coordinated v0.2 deployment, so no version skew concern.
 
 ## Support Procedures
 
@@ -617,28 +439,21 @@ This order prevents downstream components from depending on fields or resources 
 
 - ClusterVersion API failures appear in fulfillment-service logs and metrics.
 - Cluster creation failures identify invalid, missing, disabled, or obsolete versions at request time.
-- Lifecycle propagation failures appear as reconciliation failures on affected `ClusterOrder` resources.
-- Provisioning failures caused by a missing hub projection appear in AAP job output.
 
 ### Diagnosis
 
-- List `ClusterVersion` entries from the API to verify state, default selection, and channel metadata.
-- Inspect hub `ClusterVersion` CRDs to confirm the fulfillment-service projection is current.
-- Inspect `ClusterOrder` conditions to confirm lifecycle propagation.
-- Inspect operator and AAP logs when hub state and provisioning behavior diverge.
-
-- If CLI diagnostics are used, query the OSAC `ClusterVersion` resource by fully qualified name or by a short name such as `cver` to avoid confusion with OpenShift's built-in `ClusterVersion` resource.
+- List `ClusterVersion` entries from the API to verify state, default selection, and image URL.
+- Inspect fulfillment-service logs for version validation errors during cluster creation or resolution errors during reconciliation.
 
 ### Recovery
 
-- Recreate or fix a missing `ClusterVersion` entry, then allow reconciliation to repopulate the hub projection.
-- Change cluster or template references before attempting to remove a version that is still in use. If catalog-item integration is enabled for the milestone, those references must also be cleared.
-- Retry provisioning after the hub projection becomes available if AAP failed because the version was not yet reconciled.
+- Recreate or fix a missing `ClusterVersion` entry.
+- Change cluster or template references before attempting to remove a version that is still in use.
 
 ### Disabling
 
-This feature cannot be disabled independently without removing the new API and hub projection surfaces. The supported operational control is to disable specific versions by setting `enabled=false`, which blocks new cluster creation with those versions while leaving existing clusters unchanged.
+Disable specific versions by setting `enabled=false`. The recommended path for retiring a version is OBSOLETE + `enabled=false` — this blocks new cluster creation and hides the entry from default listings while preserving the record for audit. Deletion is a cleanup mechanism for entries never referenced by clusters or templates.
 
 ## Infrastructure Needed
 
-None beyond the normal component changes already described. If seeded default versions are treated as part of the milestone deliverable, they should be provided through the existing deployment workflow rather than through new project infrastructure.
+None beyond the fulfillment-service changes already described. Seeded default versions ship through the existing deployment workflow.

--- a/enhancements/cluster-version-api/prd.md
+++ b/enhancements/cluster-version-api/prd.md
@@ -46,13 +46,13 @@ A managed version catalog provides that missing abstraction. Users select from a
 
 - **FR-4:** Users specify a version number (e.g., "4.17.0") when creating a cluster. [Clarify: R1.Q2, R1.Q5, R2.Q1, R2.Q4, R3.Q3, R3.Q4]
 
-- **FR-5:** Templates can specify a default version (e.g., "4.17.0"). Any version can be used with any template; templates provide defaults but do not constrain version selection. [Clarify: R2.Q1]
+- **FR-5:** Templates can specify a default version (e.g., "4.17.0"). [Clarify: R2.Q1]
 
 - **FR-6:** A cluster's version and its current lifecycle state are visible when viewing or listing clusters. If the version is deprecated or obsolete, the state is surfaced so users can identify clusters that need attention.
 
 #### Validation
 
-- **FR-7:** Version is validated at creation time with descriptive error messages. Validation covers: version not found, version obsolete, and no version resolvable (no explicit version, no template default, and no system default). Creating a cluster with a deprecated version succeeds but includes a warning identifying the replacement version, if one is set. [Clarify: R2.Q3, R3.Q6]
+- **FR-7:** Version is validated at creation time with descriptive error messages. Validation covers: version not found, version obsolete, and no version resolvable (no explicit version, no template default, and no system default). Creating a cluster with a deprecated version succeeds. The deprecation is surfaced with the replacement version, if one is set. [Clarify: R2.Q3, R3.Q6]
 
 #### User Interfaces
 
@@ -83,7 +83,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 ## 4. Acceptance Criteria
 
 - [ ] A user can create a cluster by specifying a version number (e.g., 4.17.0) instead of a release image URL. The server resolves the version to the correct release image internally. Release image URLs are not exposed to users — neither in the version catalog nor in cluster responses. Version is immutable after creation. The version's current lifecycle state is visible when viewing or listing clusters.
-- [ ] Specifying a non-existent, deleted, or obsolete version is rejected with a descriptive error indicating the reason and identifying the replacement if one is set. Deprecated versions allow creation with a warning. Validation applies to both cluster creation and template defaults.
+- [ ] Specifying a non-existent, deleted, or obsolete version is rejected with a descriptive error indicating the reason and identifying the replacement if one is set. Deprecated versions allow creation; the deprecation is surfaced to the user. Validation applies to both cluster creation and template defaults.
 - [ ] Admins can create, update, and delete version catalog entries. Deleting a version referenced by an active cluster or template defaults is rejected with a message identifying the referencing resource.
 - [ ] Admins can transition a version between active, deprecated, and obsolete in any direction, even when referenced by active clusters or templates. Listing versions returns active and deprecated entries by default; obsolete versions are hidden unless explicitly filtered. Deprecation and obsolescence timestamps are recorded automatically on each transition.
 - [ ] At most one version is marked as default at any time — setting a new default clears the previous one. An obsolete version cannot be marked as default. When a user omits the version and template defaults do not supply one, the server uses the default version. Templates can specify a default version, and the server resolves it to a release image.
@@ -139,7 +139,7 @@ Version resolution occurs during cluster creation. The provisioning flow for the
 | Surface | Impact |
 |---------|--------|
 | Fulfillment API (gRPC/REST) | New version catalog resource. Cluster creation uses version instead of release image URL. Template defaults updated. Deletion protection when referenced. |
-| OSAC CRDs | No change. |
+| OSAC CRDs | New ClusterVersion CRD. ClusterOrder gains version and channel fields. |
 | UI Console | Version catalog management for admins. Version selection in the cluster creation wizard. |
 | Catalog Items | Support version selection. |
 

--- a/enhancements/cluster-version-api/prd.md
+++ b/enhancements/cluster-version-api/prd.md
@@ -25,7 +25,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 
 ### 2.2 Non-Goals
 
-- Cluster upgrade operations and channel propagation to the hosted cluster — triggering, tracking, or rolling back upgrades, and propagating the version's channel to the hosted cluster. Owned by OSAC-1415. Channels are stored as version catalog metadata but not propagated to the cluster in v0.2. [Clarify: R1.Q3, R2.Q2]
+- Cluster upgrade operations — triggering, tracking, or rolling back upgrades. Owned by OSAC-1415. [Clarify: R1.Q3, R2.Q2]
 - ACM ClusterImageSet auto-sync — automatic discovery and population of version catalog entries from ACM. Versions are admin-managed in v0.2. [Clarify: R1.Q7]
 - VM image management — the VM image catalog (OSAC-979) uses a separate resource. Both features share the same architectural pattern (raw URL to managed catalog with server-side resolution) but are distinct resources. [Clarify: R1.Q4]
 - In-place upgrade migration — OSAC does not support in-place upgrades. This feature assumes fresh deployment. [Clarify: R2.Q4]
@@ -36,9 +36,9 @@ A managed version catalog provides that missing abstraction. Users select from a
 
 #### Version Catalog Management
 
-- **FR-1:** Admins can create, update, and delete version catalog entries. Each entry requires a version number (e.g., "4.17.0") and release image URL; lifecycle state, channels (e.g., "stable-4.17", "fast-4.17"), and default flag are optional. Channels are informational metadata in v0.2; channel-based selection and propagation are deferred to OSAC-1415. [Clarify: R1.Q1, R1.Q6, R1.Q8, R3.Q1]
+- **FR-1:** Admins can create, update, and delete version catalog entries. Each entry requires a version number (e.g., "4.17.0") and release image URL; lifecycle state and default flag are optional. [Clarify: R1.Q1, R1.Q6, R1.Q8, R3.Q1]
 
-- **FR-2:** Users can browse and view available versions. Release image URLs are not exposed to users — they see version number, lifecycle state, and channels. Listings return active and deprecated versions by default; obsolete versions require an explicit filter. A specific version can be viewed regardless of its state, so users can inspect versions referenced by their existing clusters. [Clarify: R1.Q6, R3.Q1]
+- **FR-2:** Users can browse and view available versions. Release image URLs are not exposed to users — they see version number and lifecycle state. Listings return active and deprecated versions by default; obsolete versions require an explicit filter. A specific version can be viewed regardless of its state, so users can inspect versions referenced by their existing clusters. [Clarify: R1.Q6, R3.Q1]
 
 - **FR-3:** At most one version can be marked as default. An obsolete version cannot be marked as default. The default is used when no version is specified by the user or template. [Clarify: R1.Q1]
 
@@ -52,7 +52,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 
 #### Validation
 
-- **FR-7:** Version is validated at creation time with descriptive error messages. Validation covers: version not found, version obsolete, and no version resolvable (no explicit version, no template default, and no system default). Creating a cluster with a deprecated version succeeds. The deprecation is surfaced with the replacement version, if one is set. [Clarify: R2.Q3, R3.Q6]
+- **FR-7:** Version is validated at creation time with descriptive error messages. Validation covers: version not found, version obsolete, and no version resolvable (no explicit version, no template default, and no system default). Creating a cluster with a deprecated version succeeds. The deprecation is surfaced to the user. [Clarify: R2.Q3, R3.Q6]
 
 #### User Interfaces
 
@@ -70,20 +70,20 @@ A managed version catalog provides that missing abstraction. Users select from a
 
 - **FR-13:** Lifecycle state transitions (active, deprecated, obsolete) are always allowed regardless of references. Existing clusters and templates referencing a deprecated or obsolete version are not affected. Admins can transition a version between any states in any direction. [Clarify: R3.Q5]
 
-- **FR-14:** Version is immutable after cluster creation. [Clarify: R2.Q3]
+- **FR-14:** A version entry cannot be redefined after creation. Its version number and release image always refer to the same release. [Clarify: R2.Q3]
 
-- **FR-15:** A version can be marked as deprecated with an optional replacement version. Deprecated versions remain available for new cluster creation but include a warning identifying the replacement, if one is set. Obsolete versions are blocked for new cluster creation. Deprecation and obsolescence timestamps are recorded automatically when the version enters each state.
+- **FR-15:** A version can be marked as deprecated. Deprecated versions remain available for new cluster creation but include a deprecation warning. Obsolete versions are blocked for new cluster creation. Deprecation and obsolescence timestamps are recorded automatically when the version enters each state.
 
 ### 3.2 Non-Functional Requirements
 
 - **NFR-1:** Admins manage the version catalog using the same patterns they already know from other admin-managed resources — consistent commands, access model, lifecycle states (active/deprecated/obsolete), and visibility rules with no new interaction model to learn. [Clarify: R1.Q6, R3.Q1]
 
-- **NFR-2:** Future additions to the version catalog (e.g., upgrade paths, channel-based selection) must not break existing cluster creation workflows. [Clarify: R2.Q2]
+- **NFR-2:** Future additions to the version catalog (e.g., upgrade paths, channel metadata, channel-based selection) must not break existing cluster creation workflows. [Clarify: R2.Q2]
 
 ## 4. Acceptance Criteria
 
-- [ ] A user can create a cluster by specifying a version number (e.g., 4.17.0) instead of a release image URL. The server resolves the version to the correct release image internally. Release image URLs are not exposed to users — neither in the version catalog nor in cluster responses. Version is immutable after creation. The version's current lifecycle state is visible when viewing or listing clusters.
-- [ ] Specifying a non-existent, deleted, or obsolete version is rejected with a descriptive error indicating the reason and identifying the replacement if one is set. Deprecated versions allow creation; the deprecation is surfaced to the user. Validation applies to both cluster creation and template defaults.
+- [ ] A user can create a cluster by specifying a version number (e.g., 4.17.0) instead of a release image URL. The server resolves the version to the correct release image internally. Release image URLs are not exposed to users — neither in the version catalog nor in cluster responses. A version entry's version number and release image cannot be changed after creation. The version's current lifecycle state is visible when viewing or listing clusters.
+- [ ] Specifying a non-existent, deleted, or obsolete version is rejected with a descriptive error indicating the reason. Deprecated versions allow creation; the deprecation is surfaced to the user. Validation applies to both cluster creation and template defaults.
 - [ ] Admins can create, update, and delete version catalog entries. Deleting a version referenced by an active cluster or template defaults is rejected with a message identifying the referencing resource.
 - [ ] Admins can transition a version between active, deprecated, and obsolete in any direction, even when referenced by active clusters or templates. Listing versions returns active and deprecated entries by default; obsolete versions are hidden unless explicitly filtered. Deprecation and obsolescence timestamps are recorded automatically on each transition.
 - [ ] At most one version is marked as default at any time — setting a new default clears the previous one. An obsolete version cannot be marked as default. When a user omits the version and template defaults do not supply one, the server uses the default version. Templates can specify a default version, and the server resolves it to a release image.
@@ -97,7 +97,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 ## 6. Dependencies
 
 - **OSAC-1531 (Default Catalog Items)** — Default version catalog entries should ship alongside default catalog items. Version catalog population is a prerequisite for catalog items that reference version-based clusters.
-- **OSAC-1415 (Cluster Upgrade)** — The version catalog is designed as an extension point. OSAC-1415 is expected to add upgrade capabilities, channel-based version selection, and channel propagation to the hosted cluster. This PRD does not constrain OSAC-1415's design. [Clarify: R2.Q2]
+- **OSAC-1415 (Cluster Upgrade)** — The version catalog is designed as an extension point. OSAC-1415 is expected to add upgrade capabilities and channel-based version selection. This PRD does not constrain OSAC-1415's design. [Clarify: R2.Q2]
 
 ## 7. Risks
 
@@ -125,28 +125,28 @@ This feature applies to **CaaS** (Cluster as a Service) only. VMaaS has an analo
 
 | Persona | Interaction |
 |---------|-------------|
-| Cloud Provider Admin | Creates version entries by providing version number, release image URL, channels, and lifecycle state. Manages the catalog via CLI, API, and UI. Sets the default version. |
-| Tenant User | Browses available versions (version number, state, channels — no release image URLs). Selects a version when creating a cluster via CLI, UI wizard, or catalog items. |
+| Cloud Provider Admin | Creates version entries by providing version number, release image URL, and lifecycle state. Manages the catalog via CLI, API, and UI. Sets the default version. |
+| Tenant User | Browses available versions (version number, state — no release image URLs). Selects a version when creating a cluster via CLI, UI wizard, or catalog items. |
 | Cloud Infrastructure Admin | Not affected. |
 | Tenant Admin | Same as Tenant User. May also reference versions when authoring org-specific catalog items. |
 
 ### Provisioning
 
-Version resolution occurs during cluster creation. The provisioning flow for the cluster itself is unchanged — this feature adds version selection and validation, not new provisioning steps.
+Version resolution occurs during cluster creation: the fulfillment-service validates the selected version and stores the version reference on the cluster. The provisioning flow for the cluster itself is unchanged — this feature adds version selection and validation, not new provisioning steps.
 
 ### User-Facing API
 
 | Surface | Impact |
 |---------|--------|
 | Fulfillment API (gRPC/REST) | New version catalog resource. Cluster creation uses version instead of release image URL. Template defaults updated. Deletion protection when referenced. |
-| OSAC CRDs | New ClusterVersion CRD. ClusterOrder gains version and channel fields. |
+| OSAC CRDs | No change. |
 | UI Console | Version catalog management for admins. Version selection in the cluster creation wizard. |
 | Catalog Items | Support version selection. |
 
 ### Milestone Scoping
 
 - **Target milestone:** v0.2
-- **Deferred:** Cluster upgrades (OSAC-1415), ACM version auto-sync, channel-based version selection, channel propagation to hosted cluster, in-place migration of existing data.
+- **Deferred:** Cluster upgrades (OSAC-1415), ACM version auto-sync, channel metadata and channel-based version selection, in-place migration of existing data.
 - **Upgrades:** OSAC does not support in-place upgrades. No data migration is in scope.
 
 ### Installation


### PR DESCRIPTION
## Summary

- Design document for the ClusterVersion managed version list
- Minor PRD updates to reflect implementation details identified during design

## Requesting Review On

- Architecture: fulfillment-service catalog, hub CRD projection, operator lifecycle propagation, AAP release-image resolution
- Cross-component data flow and reconciliation model
- Public/private API split and admin workflow
- Open questions

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting cluster versions from a managed version catalog during cluster creation.
  * Introduced a new version-management API and a cluster version resource to control and display available versions.

* **Bug Fixes**
  * Improved cluster creation validation for version availability and lifecycle compatibility (including template constraints).
  * Deprecated-version cluster creation now succeeds while surfacing deprecation and replacement guidance.

* **Documentation**
  * Added a full design specification for the ClusterVersion capability and updated the related PRD to refine lifecycle and template semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->