### PR TITLE
OSAC-1029: PRD — Simplified Resource Creation

### DIFF
--- a/enhancements/simplified-resource-creation/prd.md
+++ b/enhancements/simplified-resource-creation/prd.md
@@ -28,18 +28,44 @@ where a single create command produces a reachable instance.
 - Auto-provisioned networking resources are visible, editable, and follow
   the same lifecycle as manually created ones
 
-### 2.3 Non-Goals
+### 2.2 Non-Goals
 
-- Region-scoped default networking (region is not yet a fully defined
-  concept in OSAC — this design assumes a single-region deployment)
 - Custom default configurations per tenant (all tenants in a deployment
   receive the same default CIDR and SecurityGroup rules)
 - Auto-provisioning of VirtualNetworks or Subnets beyond the initial
   default (tenants create additional VNs manually)
 
-## 3. Requirements
+## 3. User Stories
 
-### 3.1 Functional Requirements
+### Tenant Stories
+
+- As a tenant, I want to create a resource (VM, cluster, or bare-metal
+  server) without pre-creating networking resources, so that the system
+  provides sensible defaults and I can get started quickly
+- As a tenant, I want to create a resource with `--external-ip=auto` and
+  have it externally reachable in a single API call, without manually
+  creating ExternalIP and ExternalIPAttachment resources
+- As a tenant, I want to inspect and customize my default networking
+  resources (e.g., modify SecurityGroup rules) after they are auto-created
+- As a tenant, I want auto-provisioned ExternalIPs to be automatically
+  cleaned up when I delete the parent resource, so that I do not accumulate
+  orphaned resources
+- As a tenant, I want to create a Cluster with `--external-ip=auto` and
+  have the system automatically provision ExternalIPs for both the API
+  server and ingress endpoints before cluster provisioning begins
+- As a tenant, I want to create a Cluster with `--nat-gateway=auto` and
+  have the system automatically provision a NATGateway on the VirtualNetwork
+  so that cluster nodes have outbound connectivity without manual setup
+
+### Provider Stories
+
+- As a provider, I want to configure a default CIDR range and default
+  SecurityGroup rules, so that the system can auto-create default
+  networking resources for tenants on first use
+
+## 4. Requirements
+
+### 4.1 Functional Requirements
 
 #### Default Networking
 
@@ -101,7 +127,7 @@ where a single create command produces a reachable instance.
   VirtualNetwork using that ExternalIP as the SNAT source. If a NATGateway
   already exists on the VN, it is reused. [User]
 
-## 4. Acceptance Criteria
+## 5. Acceptance Criteria
 
 - [ ] A tenant can create a ComputeInstance with `--external-ip=auto` and
   no `network_attachments` — the VM is created on the default subnet with

--- a/enhancements/simplified-resource-creation/prd.md
+++ b/enhancements/simplified-resource-creation/prd.md
@@ -37,31 +37,37 @@ where a single create command produces a reachable instance.
 
 ## 3. User Stories
 
-### Tenant Stories
+### Tenant User Stories
 
-- As a tenant, I want to create a resource (VM, cluster, or bare-metal
-  server) without pre-creating networking resources, so that the system
-  provides sensible defaults and I can get started quickly
-- As a tenant, I want to create a resource with `--external-ip=auto` and
-  have it externally reachable in a single API call, without manually
+- As a Tenant User, I want to create a resource (VM, cluster, or
+  bare-metal server) without pre-creating networking resources, so that
+  the system provides sensible defaults and I can get started quickly
+- As a Tenant User, I want to create a resource with `--external-ip=auto`
+  and have it externally reachable in a single API call, without manually
   creating ExternalIP and ExternalIPAttachment resources
-- As a tenant, I want to inspect and customize my default networking
+- As a Tenant User, I want auto-provisioned ExternalIPs to be
+  automatically cleaned up when I delete the parent resource, so that I do
+  not accumulate orphaned resources
+- As a Tenant User, I want to create a Cluster with
+  `--external-ip=auto-all` and have the system automatically provision
+  ExternalIPs for both the API server and ingress endpoints before cluster
+  provisioning begins
+- As a Tenant User, I want to create a Cluster with `--nat-gateway=auto`
+  and have the system automatically provision a NATGateway on the
+  VirtualNetwork so that cluster nodes have outbound connectivity without
+  manual setup
+
+### Tenant Admin Stories
+
+- As a Tenant Admin, I want to inspect and customize my default networking
   resources (e.g., modify SecurityGroup rules) after they are auto-created
-- As a tenant, I want auto-provisioned ExternalIPs to be automatically
-  cleaned up when I delete the parent resource, so that I do not accumulate
-  orphaned resources
-- As a tenant, I want to create a Cluster with `--external-ip=auto` and
-  have the system automatically provision ExternalIPs for both the API
-  server and ingress endpoints before cluster provisioning begins
-- As a tenant, I want to create a Cluster with `--nat-gateway=auto` and
-  have the system automatically provision a NATGateway on the VirtualNetwork
-  so that cluster nodes have outbound connectivity without manual setup
 
-### Provider Stories
+### Cloud Infrastructure Admin Stories
 
-- As a provider, I want to configure a default CIDR range and default
-  SecurityGroup rules, so that the system can auto-create default
-  networking resources for tenants on first use
+- As a Cloud Infrastructure Admin, I want to configure a default CIDR
+  range and default SecurityGroup rules on the NetworkClass, so that the
+  system can auto-create default networking resources for tenants at
+  onboarding
 
 ## 4. Requirements
 
@@ -73,18 +79,19 @@ where a single create command produces a reachable instance.
   VirtualNetwork, Subnet, and SecurityGroup for the tenant. The tenant
   transitions to READY only after all default networking resources are
   also READY. [User]
-- **FR-2:** The provider configures default networking parameters (CIDR,
-  SecurityGroup rules, CIDR mode) on the NetworkClass. When defaults are
-  not configured, creating a resource without explicit `network_attachments`
-  fails with a clear error. [User]
-- **FR-3:** Two CIDR modes are supported: `shared_cidr` (default — all
-  tenants receive the same CIDR, isolated at the fabric level) and
-  `isolated_cidr` (each tenant gets a unique CIDR slice from the
-  provider's supernet). [User]
+- **FR-2:** The Cloud Infrastructure Admin configures default networking
+  parameters (CIDR, SecurityGroup rules) on the NetworkClass. When
+  defaults are not configured, creating a resource without explicit
+  `network_attachments` fails with a clear error. [User]
+- **FR-3:** All tenants receive the same default CIDR range as configured
+  on the NetworkClass. Tenants are isolated at the fabric level — the
+  unified networking API provides VirtualNetworks with any IP subnet, and
+  the fabric manager enforces isolation regardless of overlapping CIDRs
+  between tenants. [User]
 - **FR-4:** Default resources are labeled `osac.openshift.io/default:
-  "true"`, visible in list and detail views, and editable by the tenant
-  (e.g., adding SecurityGroup rules). Default resources cannot be deleted
-  while any resource depends on them. [User]
+  "true"`, visible in list and detail views, and editable by the Tenant
+  Admin (e.g., adding SecurityGroup rules). Default resources cannot be
+  deleted while any resource depends on them. [User]
 - **FR-5:** Creating custom VirtualNetworks does not affect default
   resources — both coexist. [User]
 
@@ -108,15 +115,18 @@ where a single create command produces a reachable instance.
 - **FR-9:** Cluster supports a `external_ip_mode` field with values
   `NONE` (default), `AUTO_API` (API server only), `AUTO_INGRESS` (ingress
   only), and `AUTO_ALL` (both). For `AUTO_ALL`, two ExternalIPs and two
-  ExternalIPAttachments are created. [User]
+  ExternalIPAttachments are created. The CLI maps `--external-ip=auto-all`
+  to `AUTO_ALL`, `--external-ip=auto-api` to `AUTO_API`, and
+  `--external-ip=auto-ingress` to `AUTO_INGRESS`. [User]
 - **FR-10:** For clusters, ExternalIPs are allocated before provisioning
   is dispatched and passed as template parameters, resolving the CaaS
   prerequisite ordering requirement. ExternalIPAttachments are created in
   Pending state and activate once VIPs are discovered. [User]
 - **FR-11:** Auto-created ExternalIP and ExternalIPAttachment resources
-  are labeled `osac.openshift.io/auto-provisioned: "true"` and have an
-  owner-reference annotation pointing to the parent resource. When the
-  parent is deleted, auto-created resources are garbage-collected. [User]
+  are labeled `osac.openshift.io/auto-provisioned: "true"`. When the
+  parent resource is deleted, the parent's finalizer deletes the
+  auto-created ExternalIPAttachments first, then ExternalIPs, before the
+  parent resource is removed. [User]
 
 #### Auto NATGateway
 
@@ -129,25 +139,25 @@ where a single create command produces a reachable instance.
 
 ## 5. Acceptance Criteria
 
-- [ ] A tenant can create a ComputeInstance with `--external-ip=auto` and
-  no `network_attachments` — the VM is created on the default subnet with
-  an auto-provisioned ExternalIP for inbound access
-- [ ] A tenant can create a Cluster with `--external-ip=auto-all
+- [ ] A Tenant User can create a ComputeInstance with `--external-ip=auto`
+  and no `network_attachments` — the VM is created on the default subnet
+  with an auto-provisioned ExternalIP for inbound access
+- [ ] A Tenant User can create a Cluster with `--external-ip=auto-all
   --nat-gateway=auto` and no `network_attachments` — the cluster is
   provisioned with ExternalIPs for API and ingress plus a NATGateway for
   outbound, all resolved automatically
-- [ ] A tenant can create a BaremetalInstance with `--external-ip=auto`
-  and no `network_attachments` — the server is placed on the default
-  subnet with an auto-provisioned ExternalIP
+- [ ] A Tenant User can create a BaremetalInstance with
+  `--external-ip=auto` and no `network_attachments` — the server is
+  placed on the default subnet with an auto-provisioned ExternalIP
 - [ ] Default VN, Subnet, and SG exist and are READY before the tenant's
   first resource creation
 - [ ] Default resources appear in list views with the
   `osac.openshift.io/default: "true"` label
-- [ ] A tenant can modify default SecurityGroup rules (e.g., add ingress
-  rules) and the changes take effect
+- [ ] A Tenant Admin can modify default SecurityGroup rules (e.g., add
+  ingress rules) and the changes take effect
 - [ ] Deleting a resource with auto-provisioned ExternalIP causes the
-  auto-created ExternalIP and ExternalIPAttachment to be
-  garbage-collected
+  auto-created ExternalIP and ExternalIPAttachment to be cleaned up via
+  the parent's finalizer
 - [ ] Creating a resource with explicit `network_attachments` bypasses
   defaults entirely — no default resources are referenced
 - [ ] When no ExternalIPPool has available capacity, resource creation
@@ -169,26 +179,21 @@ where a single create command produces a reachable instance.
 
 ## 7. Risks
 
-### 7.1 Default CIDR supernet exhaustion (isolated_cidr mode)
+### 7.1 ExternalIPPool exhaustion
 
-- **Owner:** Provider
-- **Mitigation:** Provider monitors allocation count; clear error on
-  exhaustion; provider can widen supernet
-
-### 7.2 ExternalIPPool exhaustion
-
-- **Owner:** Provider
+- **Owner:** Cloud Provider Admin
 - **Mitigation:** Pool capacity visible in status; clear error directs
   tenant to explicit allocation from another pool
 
-### 7.3 Default SecurityGroup too permissive
+### 7.2 Default SecurityGroup too permissive
 
-- **Owner:** Provider
-- **Mitigation:** Provider configures default rules on NetworkClass;
-  tenant can tighten rules after creation
+- **Owner:** Cloud Infrastructure Admin
+- **Mitigation:** Cloud Infrastructure Admin configures default rules on
+  NetworkClass; Tenant Admin can tighten rules after creation
 
-### 7.4 Auto ExternalIP orphans on partial failure
+### 7.3 Auto ExternalIP orphans on partial failure
 
 - **Owner:** Platform
-- **Mitigation:** Standard finalizer pattern; controller retries; if
-  permanently failed, ExternalIP is GC'd with parent resource
+- **Mitigation:** Parent resource finalizer handles cleanup; controller
+  retries on transient failures; if permanently failed, ExternalIP is
+  cleaned up when the parent resource is deleted

--- a/enhancements/simplified-resource-creation/prd.md
+++ b/enhancements/simplified-resource-creation/prd.md
@@ -1,0 +1,168 @@
+# Simplified Resource Creation — Default Networking and Auto ExternalIP
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | Dan Manor |
+| Jira        | https://redhat.atlassian.net/browse/OSAC-1029 |
+| Date        | 2026-07-02 |
+
+## 1. Problem Statement
+
+Creating a reachable resource in OSAC requires 6+ sequential API calls:
+VirtualNetwork, Subnet, SecurityGroup, the resource itself, ExternalIP,
+and ExternalIPAttachment. Every tenant must understand the full networking
+resource model before provisioning their first VM, cluster, or bare-metal
+server. This friction slows onboarding, increases the chance of
+misconfiguration, and makes OSAC harder to adopt compared to platforms
+where a single create command produces a reachable instance.
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+- A tenant can create a fully connected VM, bare-metal server, or cluster
+  (inbound + outbound) with a single API call, without pre-creating any
+  networking resources
+- Tenants who need custom networking retain the full explicit workflow —
+  simplified creation is additive, not a replacement
+- Auto-provisioned networking resources are visible, editable, and follow
+  the same lifecycle as manually created ones
+
+### 2.3 Non-Goals
+
+- Region-scoped default networking (region is not yet a fully defined
+  concept in OSAC — this design assumes a single-region deployment)
+- Custom default configurations per tenant (all tenants in a deployment
+  receive the same default CIDR and SecurityGroup rules)
+- Auto-provisioning of VirtualNetworks or Subnets beyond the initial
+  default (tenants create additional VNs manually)
+
+## 3. Requirements
+
+### 3.1 Functional Requirements
+
+#### Default Networking
+
+- **FR-1:** At tenant onboarding, the system provisions a default
+  VirtualNetwork, Subnet, and SecurityGroup for the tenant. The tenant
+  transitions to READY only after all default networking resources are
+  also READY. [User]
+- **FR-2:** The provider configures default networking parameters (CIDR,
+  SecurityGroup rules, CIDR mode) on the NetworkClass. When defaults are
+  not configured, creating a resource without explicit `network_attachments`
+  fails with a clear error. [User]
+- **FR-3:** Two CIDR modes are supported: `shared_cidr` (default — all
+  tenants receive the same CIDR, isolated at the fabric level) and
+  `isolated_cidr` (each tenant gets a unique CIDR slice from the
+  provider's supernet). [User]
+- **FR-4:** Default resources are labeled `osac.openshift.io/default:
+  "true"`, visible in list and detail views, and editable by the tenant
+  (e.g., adding SecurityGroup rules). Default resources cannot be deleted
+  while any resource depends on them. [User]
+- **FR-5:** Creating custom VirtualNetworks does not affect default
+  resources — both coexist. [User]
+
+#### Optional Network Attachments
+
+- **FR-6:** The `network_attachments` field on ComputeInstance, Cluster,
+  and BaremetalInstance is optional. When omitted, the system populates it
+  with the tenant's default Subnet and default SecurityGroup. The resolved
+  attachments are stored in the resource spec so the resource is
+  self-describing after creation. [User]
+- **FR-7:** When a resource is created with explicit `network_attachments`,
+  no defaults are applied. [User]
+
+#### Auto ExternalIP
+
+- **FR-8:** ComputeInstance and BaremetalInstance support an
+  `external_ip_mode` field with values `NONE` (default) and `AUTO`. When
+  `AUTO`, the system auto-selects the READY ExternalIPPool with the most
+  available capacity, creates an ExternalIP, and creates an
+  ExternalIPAttachment binding it to the resource. [User]
+- **FR-9:** Cluster supports a `external_ip_mode` field with values
+  `NONE` (default), `AUTO_API` (API server only), `AUTO_INGRESS` (ingress
+  only), and `AUTO_ALL` (both). For `AUTO_ALL`, two ExternalIPs and two
+  ExternalIPAttachments are created. [User]
+- **FR-10:** For clusters, ExternalIPs are allocated before provisioning
+  is dispatched and passed as template parameters, resolving the CaaS
+  prerequisite ordering requirement. ExternalIPAttachments are created in
+  Pending state and activate once VIPs are discovered. [User]
+- **FR-11:** Auto-created ExternalIP and ExternalIPAttachment resources
+  are labeled `osac.openshift.io/auto-provisioned: "true"` and have an
+  owner-reference annotation pointing to the parent resource. When the
+  parent is deleted, auto-created resources are garbage-collected. [User]
+
+#### Auto NATGateway
+
+- **FR-12:** All resource types (ComputeInstance, BaremetalInstance,
+  Cluster) support a `nat_gateway_mode` field with values `NONE` (default)
+  and `AUTO`. When `AUTO`, the system auto-selects an ExternalIP from the
+  best available pool and creates a NATGateway on the resource's
+  VirtualNetwork using that ExternalIP as the SNAT source. If a NATGateway
+  already exists on the VN, it is reused. [User]
+
+## 4. Acceptance Criteria
+
+- [ ] A tenant can create a ComputeInstance with `--external-ip=auto` and
+  no `network_attachments` — the VM is created on the default subnet with
+  an auto-provisioned ExternalIP for inbound access
+- [ ] A tenant can create a Cluster with `--external-ip=auto-all
+  --nat-gateway=auto` and no `network_attachments` — the cluster is
+  provisioned with ExternalIPs for API and ingress plus a NATGateway for
+  outbound, all resolved automatically
+- [ ] A tenant can create a BaremetalInstance with `--external-ip=auto`
+  and no `network_attachments` — the server is placed on the default
+  subnet with an auto-provisioned ExternalIP
+- [ ] Default VN, Subnet, and SG exist and are READY before the tenant's
+  first resource creation
+- [ ] Default resources appear in list views with the
+  `osac.openshift.io/default: "true"` label
+- [ ] A tenant can modify default SecurityGroup rules (e.g., add ingress
+  rules) and the changes take effect
+- [ ] Deleting a resource with auto-provisioned ExternalIP causes the
+  auto-created ExternalIP and ExternalIPAttachment to be
+  garbage-collected
+- [ ] Creating a resource with explicit `network_attachments` bypasses
+  defaults entirely — no default resources are referenced
+- [ ] When no ExternalIPPool has available capacity, resource creation
+  with `external_ip_mode=AUTO` fails with a clear error
+- [ ] A resource created without `network_attachments` shows the resolved
+  default attachments in its spec when retrieved via Get
+
+## 6. Dependencies
+
+- **Unified Networking EP** — this PRD builds on the unified networking
+  resource model (VirtualNetwork, Subnet, SecurityGroup, ExternalIP,
+  ExternalIPAttachment, NATGateway) defined in the
+  [Unified Networking EP](/enhancements/unified-networking)
+- **OSAC-1712 (automatic pool selection)** — the auto ExternalIP pool
+  selection reuses the same strategy: pick the READY pool with the most
+  available capacity matching the IP family
+- **Tenant onboarding flow** — default resource creation hooks into the
+  existing Tenant controller lifecycle
+
+## 7. Risks
+
+### 7.1 Default CIDR supernet exhaustion (isolated_cidr mode)
+
+- **Owner:** Provider
+- **Mitigation:** Provider monitors allocation count; clear error on
+  exhaustion; provider can widen supernet
+
+### 7.2 ExternalIPPool exhaustion
+
+- **Owner:** Provider
+- **Mitigation:** Pool capacity visible in status; clear error directs
+  tenant to explicit allocation from another pool
+
+### 7.3 Default SecurityGroup too permissive
+
+- **Owner:** Provider
+- **Mitigation:** Provider configures default rules on NetworkClass;
+  tenant can tighten rules after creation
+
+### 7.4 Auto ExternalIP orphans on partial failure
+
+- **Owner:** Platform
+- **Mitigation:** Standard finalizer pattern; controller retries; if
+  permanently failed, ExternalIP is GC'd with parent resource

--- a/enhancements/simplified-resource-creation/prd.md
+++ b/enhancements/simplified-resource-creation/prd.md
@@ -34,6 +34,7 @@ where a single create command produces a reachable instance.
   receive the same default CIDR and SecurityGroup rules)
 - Auto-provisioning of VirtualNetworks or Subnets beyond the initial
   default (tenants create additional VNs manually)
+- UI support for simplified creation (deferred — API and CLI only for now)
 
 ## 3. User Stories
 
@@ -69,6 +70,12 @@ where a single create command produces a reachable instance.
   system can auto-create default networking resources for tenants at
   onboarding
 
+### Cloud Provider Admin Stories
+
+- As a Cloud Provider Admin, I want visibility into whether a tenant's
+  default networking resources were successfully provisioned, so I can
+  troubleshoot onboarding failures
+
 ## 4. Requirements
 
 ### 4.1 Functional Requirements
@@ -78,7 +85,10 @@ where a single create command produces a reachable instance.
 - **FR-1:** At tenant onboarding, the system provisions a default
   VirtualNetwork, Subnet, and SecurityGroup for the tenant. The tenant
   transitions to READY only after all default networking resources are
-  also READY. [User]
+  also READY. If default networking provisioning fails, the tenant
+  remains in a non-READY state with a status condition describing the
+  failure. The Cloud Provider Admin can inspect the failure and retry
+  by deleting and re-creating the tenant. [User]
 - **FR-2:** The Cloud Infrastructure Admin configures default networking
   parameters (CIDR, SecurityGroup rules) on the NetworkClass. When
   defaults are not configured, creating a resource without explicit
@@ -111,7 +121,11 @@ where a single create command produces a reachable instance.
   `external_ip_mode` field with values `NONE` (default) and `AUTO`. When
   `AUTO`, the system auto-selects the READY ExternalIPPool with the most
   available capacity, creates an ExternalIP, and creates an
-  ExternalIPAttachment binding it to the resource. [User]
+  ExternalIPAttachment binding it to the resource. The auto-selection
+  algorithm is identical to OSAC-1712: pick the READY pool with the most
+  available capacity matching the requested IP family (defaulting to
+  IPv4). When multiple pools have equal capacity, selection is
+  deterministic but implementation-defined. [User]
 - **FR-9:** Cluster supports a `external_ip_mode` field with values
   `NONE` (default), `AUTO_API` (API server only), `AUTO_INGRESS` (ingress
   only), and `AUTO_ALL` (both). For `AUTO_ALL`, two ExternalIPs and two
@@ -126,7 +140,10 @@ where a single create command produces a reachable instance.
   are labeled `osac.openshift.io/auto-provisioned: "true"`. When the
   parent resource is deleted, the parent's finalizer deletes the
   auto-created ExternalIPAttachments first, then ExternalIPs, before the
-  parent resource is removed. [User]
+  parent resource is removed. If cleanup of auto-created resources fails
+  permanently, the finalizer is removed and the parent resource is deleted
+  — orphaned ExternalIPs remain and must be cleaned up manually by the
+  Tenant Admin or Cloud Provider Admin. [User]
 
 #### Auto NATGateway
 
@@ -135,7 +152,9 @@ where a single create command produces a reachable instance.
   and `AUTO`. When `AUTO`, the system auto-selects an ExternalIP from the
   best available pool and creates a NATGateway on the resource's
   VirtualNetwork using that ExternalIP as the SNAT source. If a NATGateway
-  already exists on the VN, it is reused. [User]
+  already exists on the VN, it is reused regardless of which ExternalIP it
+  uses, its current state, or whether it was manually or auto-created.
+  [User]
 
 ## 5. Acceptance Criteria
 
@@ -160,8 +179,8 @@ where a single create command produces a reachable instance.
   the parent's finalizer
 - [ ] Creating a resource with explicit `network_attachments` bypasses
   defaults entirely — no default resources are referenced
-- [ ] When no ExternalIPPool has available capacity, resource creation
-  with `external_ip_mode=AUTO` fails with a clear error
+- [ ] When no ExternalIPPool has available capacity, the create API call
+  returns an error and the resource is not persisted
 - [ ] A resource created without `network_attachments` shows the resolved
   default attachments in its spec when retrieved via Get
 
@@ -172,10 +191,12 @@ where a single create command produces a reachable instance.
   ExternalIPAttachment, NATGateway) defined in the
   [Unified Networking EP](/enhancements/unified-networking)
 - **OSAC-1712 (automatic pool selection)** — the auto ExternalIP pool
-  selection reuses the same strategy: pick the READY pool with the most
-  available capacity matching the IP family
+  selection reuses the identical algorithm: pick the READY pool with the
+  most available capacity matching the IP family
 - **Tenant onboarding flow** — default resource creation hooks into the
   existing Tenant controller lifecycle
+- **osac-installer** — NetworkClass default configuration must be included
+  in setup.sh and installation overlays
 
 ## 7. Risks
 
@@ -195,5 +216,31 @@ where a single create command produces a reachable instance.
 
 - **Owner:** Platform
 - **Mitigation:** Parent resource finalizer handles cleanup; controller
-  retries on transient failures; if permanently failed, ExternalIP is
-  cleaned up when the parent resource is deleted
+  retries on transient failures. If cleanup permanently fails, the
+  finalizer is removed and the parent is deleted — orphaned ExternalIPs
+  must be cleaned up manually
+
+### 7.4 Deployment misconfiguration
+
+- **Owner:** Cloud Infrastructure Admin
+- **Mitigation:** If NetworkClass defaults are not configured, tenant
+  onboarding still succeeds but resource creation without explicit
+  `network_attachments` fails with a clear error directing the tenant to
+  use explicit networking or contact the admin. This is a deployment
+  issue, not a runtime failure
+
+## 8. Open Questions
+
+### 8.1 Should capacity exhaustion return an API error or create a Failed resource?
+
+- **Owner:** API design team
+- **Impact:** Affects FR-8 and acceptance criteria. Returning an error
+  (resource not persisted) is simpler but gives no audit trail. Creating
+  a Failed resource provides visibility but adds cleanup burden.
+
+### 8.2 E2E test coverage for simplified creation
+
+- **Owner:** QE / osac-test-infra
+- **Impact:** Which user journeys (1-call VM, 1-call cluster, explicit
+  bypass) must be covered by E2E tests at milestone boundary? Deferred
+  to design phase.


### PR DESCRIPTION
## Summary

Standalone PRD for simplified resource creation — default networking per tenant and automatic ExternalIP/NATGateway provisioning. Builds on the unified networking EP as a follow-on enhancement.

Reduces creating a reachable resource from 6+ API calls to 1:

```bash
osac create computeinstance --template ocp_virt_vm --external-ip=auto --name my-vm
```

### What's in the PRD

- **Default networking per tenant** — system creates default VN, Subnet, SG at tenant onboarding (FR-1 through FR-5)
- **Optional network_attachments** — omit to use defaults (FR-6, FR-7)
- **Auto ExternalIP** — `external_ip_mode` with pool auto-selection (FR-8 through FR-11)
- **Auto NATGateway** — `nat_gateway_mode` with idempotent VN-level creation (FR-12)
- 10 acceptance criteria, 4 risks, dependencies on unified networking EP and [OSAC-1712](https://redhat.atlassian.net/browse/OSAC-1712)

### Relationship to unified networking EP

This PRD is a continuation of the unified networking work ([OSAC-1029](https://redhat.atlassian.net/browse/OSAC-1029)). The unified networking EP defines the resource model (VirtualNetwork, Subnet, SecurityGroup, ExternalIP, etc.); this PRD adds the UX layer that makes those resources optional for simple use cases.

See-also: [Unified Networking EP](/enhancements/unified-networking)

## Test plan

- [ ] Review PRD for completeness against unified networking EP
- [ ] Verify acceptance criteria are testable
- [ ] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a PRD for simplified resource creation with default networking and automatic External IP support.
  * Defined a tenant-facing single-call workflow, including default network provisioning and optional network attachment behavior.
  * Documented readiness gating, default labeling and edit/delete expectations, capacity failure handling, and cleanup/orphan behavior for auto-provisioned connectivity resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->