### PR TITLE
OSAC-2050: fix resolve-pr job permissions for PR comment reactions

### DIFF
--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
     outputs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}


### PR DESCRIPTION
## Summary

The `resolve-pr` job in `ep-review.yml` had `pull-requests: read` but needs `pull-requests: write` to add the :eyes: reaction on PR comments. GitHub treats PR comments as part of the pulls API, so `issues: write` alone is insufficient.

The `Acknowledge comment` step was failing with HTTP 403, which killed the entire `resolve-pr` job and skipped the `review` job downstream.

**Root cause:** Two issues compounded:
1. The org workflow permissions were set to read-only, overriding all job-level permissions (fixed via org settings)
2. The `resolve-pr` job declared `pull-requests: read` instead of `pull-requests: write`

## Fix

- Change `resolve-pr` permissions from `pull-requests: read` to `pull-requests: write`

## Test plan

- [ ] Comment `/review-ep` on a PR with a `prd.md` or `design.md` change — the :eyes: reaction should appear and the review job should proceed

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an automated workflow to allow it to make changes to pull request records when resolving PR context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->