### PR TITLE
OSAC-2067: fix slash command detection for /review-ep

### DIFF
--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -16,7 +16,7 @@ jobs:
       github.event_name == 'pull_request_target'
       || (github.event_name == 'issue_comment'
           && github.event.issue.pull_request
-          && startsWith(github.event.comment.body, '/review-ep')
+          && contains(github.event.comment.body, '/review-ep')
           && contains(fromJSON('["MEMBER","COLLABORATOR","OWNER"]'),
                       github.event.comment.author_association))
     runs-on: ubuntu-latest
@@ -28,6 +28,19 @@ jobs:
       head_sha: ${{ steps.resolve.outputs.head_sha }}
       base_ref: ${{ steps.resolve.outputs.base_ref }}
     steps:
+      - name: Validate slash command
+        if: github.event_name == 'issue_comment'
+        id: validate
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if echo "$COMMENT_BODY" | grep -qP '(?m)^\s*/review-ep'; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Comment contains '/review-ep' but not as a line-starting command"
+            exit 1
+          fi
+
       - name: Acknowledge comment
         if: github.event_name == 'issue_comment'
         env:


### PR DESCRIPTION
## Summary
- Replace `startsWith` with `contains` in the job-level filter to avoid rejecting `/review-ep` commands with leading whitespace (common from mobile/browser GitHub clients)
- Add a "Validate slash command" step with a line-anchored regex (`^\s*/review-ep`) to prevent false positives from mid-sentence mentions

## Test plan
- [x] Tested on fork PR https://github.com/ItzikEzra-rh/enhancement-proposals/pull/6 — slash command triggers workflow correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `/review-ep` comment handling so the command is recognized even when it appears later in the comment body.
  * Added validation to reject comments that do not include `/review-ep` at the start of a line, preventing unintended workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->