### PR TITLE
OSAC-2094: Fix design review post-gate rejecting valid design scores

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -181,9 +181,14 @@ class EPHooks:
         errors = []
         scores = verdict.get("scores", {})
 
-        skill = (ticket or {}).get("_skill_name", "")
-        expected_keys = DESIGN_KEYS if skill == "ep-review" else PRD_KEYS
         actual_keys = set(scores.keys())
+        if actual_keys & DESIGN_KEYS and not (actual_keys & PRD_KEYS):
+            expected_keys = DESIGN_KEYS
+        elif actual_keys & PRD_KEYS and not (actual_keys & DESIGN_KEYS):
+            expected_keys = PRD_KEYS
+        else:
+            skill = (ticket or {}).get("_skill_name", "")
+            expected_keys = DESIGN_KEYS if skill == "ep-review" else PRD_KEYS
         unexpected = actual_keys - expected_keys
         missing = expected_keys - actual_keys
         if unexpected:


### PR DESCRIPTION
## Summary
- The `validate_scores` post-gate always validated against PRD keys because the `ticket` argument wasn't passed by the agentic-ci framework
- Auto-detect review type from actual score keys instead, matching what `apply_labels` already does
- PRD keys (`what/why/how/task/size`) and design keys (`feasibility/testability/scope/architecture`) don't overlap, so detection is unambiguous

## Test plan
- [x] Triggered design review on fork PR — posted `## AI Design Review:` comment with correct design scores (6/8 PASS)
- [x] Previous PRD reviews unaffected (PRD keys still detected correctly)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved score validation so the app more reliably recognizes whether design or PRD scores are expected.
  * Added a fallback check to keep validation working when score categories are mixed or unclear.
  * Continued to verify score completeness, value ranges, and total calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->