### PR TITLE
OSAC-2136: trigger design review on README.md and case-insensitive filenames

### DIFF
--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -42,8 +42,12 @@ def get_changed_files(pr_number):
 
 def detect_skills(files):
     skills = []
-    has_prd = any(f.endswith("prd.md") for f in files)
-    has_design = any(f.endswith("design.md") for f in files)
+    has_prd = any(f.lower().endswith("prd.md") for f in files)
+    has_design = any(
+        f.lower().endswith("design.md") or
+        (f.lower().endswith("readme.md") and "enhancements/" in f.lower())
+        for f in files
+    )
 
     if has_prd:
         skills.append(("prd-review", "skills/prd-review/SKILL.md"))

--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - '**/prd.md'
       - '**/design.md'
+      - '**/DESIGN.md'
+      - '**/Design.md'
+      - 'enhancements/**/README.md'
 
   issue_comment:
     types: [created]


### PR DESCRIPTION
## Summary
- The enhancement template tells authors to name design docs `README.md`, but the EP Review Action only triggered on lowercase `design.md`
- 21 out of 25 design docs in the repo use `README.md` — all invisible to the review system
- Now handles `Design.md`, `DESIGN.md`, and `README.md` inside `enhancements/` directories
- Made `detect_skills` case-insensitive for `prd.md` and `design.md`

## Test plan
- [x] Tested on fork: PR #10 with `README.md` change triggered design review, posted `## AI Design Review:` comment with design scores
- [x] `enhancements/` scoping prevents triggering on root README.md

## Test evidence
https://github.com/ItzikEzra-rh/enhancement-proposals/pull/10

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR review detection now recognizes more documentation file name variants, including additional capitalization patterns.
  * Reviews also trigger for README files in enhancement-related folders.

* **Bug Fixes**
  * Improved consistency in file detection so relevant documentation changes are less likely to be missed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->