### PR TITLE
OSAC-2145: always post new review comment, review only changed files

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -62,13 +62,11 @@ class EPHooks:
         if self.reviewed_label in labels:
             head = ticket.get("headRefOid", "")
             pr_number = ticket_key.replace("EP-", "")
-            skill = ticket.get("_skill_name", "")
-            marker = "AI EP Review:" if skill == "prd-review" else "AI Design Review:"
             existing = self._gh([
                 "api", f"repos/{self.repo}/issues/{pr_number}/comments",
                 "--jq",
                 f'[.[] | select(.user.login == "{self.bot_login}") '
-                f'| select(.body | contains("{marker}"))][0].body // empty'
+                f'| select(.body | contains("AI EP Review:") or contains("AI Design Review:"))][0].body // empty'
             ]).strip()
             if existing and head and head[:8] in existing:
                 return f"Already reviewed at SHA {head[:8]}"
@@ -280,27 +278,14 @@ class EPHooks:
             print(f"  [{ticket_key}] SHADOW: score {total}/{max_total} ({pass_fail})")
             return
 
-        existing_id = self._gh([
-            "api", f"repos/{self.repo}/issues/{pr_number}/comments",
-            "--jq",
-            f'[.[] | select(.user.login == "{self.bot_login}") '
-            f'| select(.body | startswith("## {marker}"))][0].id // empty'
-        ]).strip()
-
         with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
             f.write(comment)
             comment_file = f.name
 
-        if existing_id:
-            self._gh(["api", f"repos/{self.repo}/issues/comments/{existing_id}",
-                       "--method", "PATCH", "--field", f"body=@{comment_file}"],
-                      check=True)
-            print(f"  [{ticket_key}] Updated review comment")
-        else:
-            self._gh(["pr", "comment", pr_number, "--repo", self.repo,
-                       "--body-file", comment_file],
-                      check=True)
-            print(f"  [{ticket_key}] Posted new review comment")
+        self._gh(["pr", "comment", pr_number, "--repo", self.repo,
+                   "--body-file", comment_file],
+                  check=True)
+        print(f"  [{ticket_key}] Posted new review comment")
 
         os.unlink(comment_file)
 

--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -62,11 +62,13 @@ class EPHooks:
         if self.reviewed_label in labels:
             head = ticket.get("headRefOid", "")
             pr_number = ticket_key.replace("EP-", "")
+            skill = ticket.get("_skill_name", "")
+            marker = "AI EP Review:" if skill == "prd-review" else "AI Design Review:"
             existing = self._gh([
                 "api", f"repos/{self.repo}/issues/{pr_number}/comments",
                 "--jq",
                 f'[.[] | select(.user.login == "{self.bot_login}") '
-                f'| select(.body | contains("AI EP Review:") or contains("AI Design Review:"))][0].body // empty'
+                f'| select(.body | contains("{marker}"))][0].body // empty'
             ]).strip()
             if existing and head and head[:8] in existing:
                 return f"Already reviewed at SHA {head[:8]}"
@@ -282,7 +284,7 @@ class EPHooks:
             "api", f"repos/{self.repo}/issues/{pr_number}/comments",
             "--jq",
             f'[.[] | select(.user.login == "{self.bot_login}") '
-            f'| select(.body | startswith("## AI EP Review:") or startswith("## AI Design Review:"))][0].id // empty'
+            f'| select(.body | startswith("## {marker}"))][0].id // empty'
         ]).strip()
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:

--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -40,6 +40,12 @@ def get_changed_files(pr_number):
     return json.loads(raw) if raw.strip() else []
 
 
+def get_incremental_files(before_sha, head_sha):
+    raw = gh(["api", f"repos/{REPO}/compare/{before_sha}...{head_sha}",
+              "--jq", "[.files[].filename]"])
+    return json.loads(raw) if raw.strip() else []
+
+
 def detect_skills(files):
     skills = []
     has_prd = any(f.lower().endswith("prd.md") for f in files)
@@ -112,18 +118,28 @@ def main():
     if shadow:
         print("SHADOW MODE: review will run but no comment will be posted")
 
-    files = get_changed_files(pr_number)
+    event_name = os.environ.get("EVENT_NAME", "")
+    event_action = os.environ.get("EVENT_ACTION", "")
+    before_sha = os.environ.get("EVENT_BEFORE_SHA", "")
+
+    # For synchronize events, only review files changed in the latest push
+    if event_action == "synchronize" and before_sha and head_sha:
+        files = get_incremental_files(before_sha, head_sha)
+        print(f"Synchronize: checking incremental diff ({before_sha[:8]}..{head_sha[:8]})")
+    else:
+        files = get_changed_files(pr_number)
+
     if not files:
-        print("No files changed in PR")
+        print("No files changed")
         return
 
     skills = detect_skills(files)
     if not skills:
-        print("No prd.md or design.md found in changed files — skipping")
+        print("No reviewable docs found in changed files — skipping")
         return
 
     print(f"Detected: {', '.join(s[0] for s in skills)} "
-          f"(from {', '.join(f for f in files if f.endswith('.md'))})")
+          f"(from {', '.join(f for f in files if f.lower().endswith('.md'))})")
 
     pr_raw = gh(["pr", "view", str(pr_number), "--repo", REPO,
                   "--json", "number,title,body,author,labels,headRefOid"])

--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -101,4 +101,7 @@ jobs:
           EP_REVIEW_SHADOW: ${{ vars.EP_REVIEW_SHADOW || 'true' }}
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
           PR_HEAD_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_BEFORE_SHA: ${{ github.event.before }}
         run: python .github/scripts/ep_review.py


### PR DESCRIPTION
## Summary
- Always post a new comment instead of updating existing ones — preserves review history
- For synchronize events, only review files changed in the latest push — updating prd.md won't re-trigger the design review
- Each review type (PRD/design) operates independently on dual PRs

## Test plan
- [x] Initial PR with both prd.md + design.md → 2 separate comments
- [x] Update only prd.md → 1 new PRD comment, no design comment
- [x] Update both files → 2 new comments

## Test evidence
https://github.com/ItzikEzra-rh/enhancement-proposals/pull/14

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review checks now focus on only the files changed in the latest push for updated pull requests, making feedback faster and more relevant.
* **Bug Fixes**
  * Review comments are now posted as a fresh comment instead of trying to update an older one.
  * Log and status messages were refined to better reflect what was reviewed and why something was skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->