### PR TITLE
OSAC-2028: wire cost and token tracking into EP review bot

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -350,26 +350,23 @@ class EPHooks:
                 cache_read = tokens.get("cacheRead", 0)
                 cost = cost_totals.get(model, 0)
 
-                parts = [
-                    f"**Model:** {model}",
-                    f"**Cost:** ${cost:.4f}",
+                lines.append(f"**Model:** {model}")
+                lines.append(f"**Cost:** ${cost:.4f}")
+                lines.append(
                     f"**Tokens:** {EPHooks._format_tokens(input_t)} in / "
-                    f"{EPHooks._format_tokens(output_t)} out",
-                ]
+                    f"{EPHooks._format_tokens(output_t)} out"
+                )
                 if cache_read:
-                    parts.append(
+                    lines.append(
                         f"**Cache:** {EPHooks._format_tokens(cache_read)} read"
                     )
-                lines.append(" | ".join(parts))
 
             total_secs = sum(active_time.values())
             if total_secs:
                 mins, secs = divmod(int(total_secs), 60)
                 time_str = f"{mins}m {secs}s" if mins else f"{secs}s"
-                lines.append(
-                    f"**Active time:** {time_str} | "
-                    f"**API calls:** {len(api_requests)}"
-                )
+                lines.append(f"**Active time:** {time_str}")
+            lines.append(f"**API calls:** {len(api_requests)}")
 
             return "\n".join(lines) if lines else None
         except (TypeError, ValueError, AttributeError):

--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -55,6 +55,13 @@ class EPHooks:
                        '[link removed]', text)
         return text.strip()[:max_len]
 
+    @staticmethod
+    def _write_step_summary(ticket_key, cost_summary):
+        summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_file and cost_summary:
+            with open(summary_file, "a") as f:
+                f.write(f"\n### Review Cost — {ticket_key}\n{cost_summary}\n")
+
     # ── Pre-gate ──
 
     def check_pr_state(self, ticket_key, ticket, mode, work_dir, **kw):
@@ -271,11 +278,24 @@ class EPHooks:
             else:
                 lines.append("None.")
 
+        cost_summary = verdict.get("_cost_summary")
+        if cost_summary:
+            lines.append("")
+            lines.append("---")
+            lines.append(
+                f"<details><summary>Review cost</summary>\n\n"
+                f"{cost_summary}\n</details>"
+            )
+
         comment = "\n".join(lines)
+
+        self._write_step_summary(ticket_key, cost_summary)
 
         if self.shadow:
             print(f"  [{ticket_key}] SHADOW: would post comment ({len(comment)} chars)")
             print(f"  [{ticket_key}] SHADOW: score {total}/{max_total} ({pass_fail})")
+            if cost_summary:
+                print(f"  [{ticket_key}] SHADOW cost: {cost_summary}")
             return
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
@@ -298,10 +318,59 @@ class EPHooks:
     # ── Cost formatter ──
 
     @staticmethod
+    def _format_tokens(count):
+        if count >= 1_000_000:
+            return f"{count / 1_000_000:.1f}M"
+        if count >= 1_000:
+            return f"{count / 1_000:.1f}k"
+        return str(int(count))
+
+    @staticmethod
     def format_cost(cost_data):
         if not cost_data:
             return None
         try:
-            return json.dumps(cost_data, indent=2, default=str)
-        except (TypeError, ValueError):
-            return str(cost_data)
+            token_totals = cost_data.get("token_totals", {})
+            cost_totals = cost_data.get("cost_totals", {})
+            api_requests = cost_data.get("api_requests", [])
+            active_time = cost_data.get("active_time", {})
+
+            by_model = {}
+            for key, count in token_totals.items():
+                if isinstance(key, (list, tuple)) and len(key) == 2:
+                    model, token_type = key
+                else:
+                    continue
+                by_model.setdefault(model, {})[token_type] = count
+
+            lines = []
+            for model, tokens in by_model.items():
+                input_t = tokens.get("input", 0)
+                output_t = tokens.get("output", 0)
+                cache_read = tokens.get("cacheRead", 0)
+                cost = cost_totals.get(model, 0)
+
+                parts = [
+                    f"**Model:** {model}",
+                    f"**Cost:** ${cost:.4f}",
+                    f"**Tokens:** {EPHooks._format_tokens(input_t)} in / "
+                    f"{EPHooks._format_tokens(output_t)} out",
+                ]
+                if cache_read:
+                    parts.append(
+                        f"**Cache:** {EPHooks._format_tokens(cache_read)} read"
+                    )
+                lines.append(" | ".join(parts))
+
+            total_secs = sum(active_time.values())
+            if total_secs:
+                mins, secs = divmod(int(total_secs), 60)
+                time_str = f"{mins}m {secs}s" if mins else f"{secs}s"
+                lines.append(
+                    f"**Active time:** {time_str} | "
+                    f"**API calls:** {len(api_requests)}"
+                )
+
+            return "\n".join(lines) if lines else None
+        except (TypeError, ValueError, AttributeError):
+            return None

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,4 +1,4 @@
-agentic-ci>=0.3.11
+agentic-ci>=0.3.15
 PyJWT>=2.8.0
 cryptography>=42.0.0
 requests>=2.31.0

--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -118,3 +118,12 @@ jobs:
           EVENT_ACTION: ${{ github.event.action }}
           EVENT_BEFORE_SHA: ${{ github.event.before }}
         run: python .github/scripts/ep_review.py
+
+      - name: Upload OTEL metrics
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4
+        with:
+          name: ep-review-otel-pr${{ needs.resolve-pr.outputs.pr_number }}-run${{ github.run_id }}
+          path: workdir-*/_run/claude-otel.jsonl
+          retention-days: 90
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- Bump agentic-ci>=0.3.15 to pick up OTEL chunked transfer fix (opendatahub-io/agentic-ci#191)
- Rewrite `format_cost()` to produce readable per-field markdown output
- Surface cost summary in PR review comments via collapsible `<details>` tag
- Write cost to `GITHUB_STEP_SUMMARY` for GHA UI visibility
- Log cost in shadow mode for testing
- Archive `claude-otel.jsonl` as GHA artifact with 90-day retention

## How it works

agentic-ci already captures OTEL cost/token data during each review run and injects it into the verdict dict. This PR connects the last mile — formatting the data and including it in the PR comment.

Each review comment now ends with a collapsible "Review cost" section:

```
Model: claude-opus-4-6
Cost: $0.3935
Tokens: 795 in / 2.1k out
Cache: 80.7k read
Active time: 45s
API calls: 12
```

Since OSAC-2145, each review posts a new comment (no overwrite), so cost history is naturally preserved per run.

## Test plan

- [x] Tested on fork PR: https://github.com/ItzikEzra-rh/enhancement-proposals/pull/15
- [x] Both prd-review and ep-review show cost section
- [x] OTEL artifact uploaded successfully
- [ ] Format v2 (one field per row) tested on: https://github.com/ItzikEzra-rh/enhancement-proposals/pull/16

Jira: https://redhat.atlassian.net/browse/OSAC-2028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer review-cost summary in pull request comments, including an expandable details section.
  * Review runs now save a step summary so cost information is easier to find after completion.
  * Workflow runs now keep a metrics artifact for later inspection.

* **Bug Fixes**
  * Cost reporting is now more readable, with token counts, time spent, and API usage summarized in human-friendly form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->